### PR TITLE
Add `Region#city_required?`

### DIFF
--- a/lib/worldwide/region.rb
+++ b/lib/worldwide/region.rb
@@ -243,6 +243,11 @@ module Worldwide
       zip_example if @zip_autofill_enabled
     end
 
+    # Does this region require cities to be specified?
+    def city_required?
+      field(key: :city).autofill(locale: :en).nil?
+    end
+
     # Is this Region a continent?
     def continent?
       @continent

--- a/test/worldwide/region_test.rb
+++ b/test/worldwide/region_test.rb
@@ -206,5 +206,18 @@ module Worldwide
         assert_nil Worldwide.region(code: country_code).autofill_zip
       end
     end
+
+    test "city_required? returns values as expected" do
+      city_not_required_countries = [:gi, :gs, :pn, :sg, :ta, :va]
+      city_required_countries = [:ca, :us, :gb]
+
+      city_not_required_countries.each do |country_code|
+        refute_predicate Worldwide.region(code: country_code), :city_required?
+      end
+
+      city_required_countries.each do |country_code|
+        assert_predicate Worldwide.region(code: country_code), :city_required?
+      end
+    end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?
<!--
Link to an issue or provide enough context so that someone new can understand the 'why' behind this change.
-->

* Implement a method to determine if the city field is required for a region.
* Added a changelog.

### What approach did you choose and why?
<!--
There are many ways to solve a problem. How did you approach this problem and why?
-->

* Interface with `Field` class's autofill logic. If `autofill` is nil, the city is required.
  * Ensures parity between methods as we autofill the city field for regions not requiring it.

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
