### PR TITLE
Lookup by CLDR code for a Region

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,17 @@ $ Worldwide.region(code: "076")
 $ Worldwide.region(name: "Brazil")
 => Worldwide::Region <code: 'BR', name: 'Brazil', ... >
 
+# Get Worldwide::Region object based on an internal code used by Unicode CLDR
+# Note that you can't pass such a code directly as a `code:` argument, because the result
+# would be ambiguous:  `are` might be `ARE` (three-letter code for the United Arab Emirates)
+# or `AR-E` (province of Entre Ríos in Argentina).
+$ Worldwide.region(cldr: "caon")
+=> Worldwide::Region <iso_code: 'CA-ON', full_name: 'Ontario', ...>
+$ Worldwide.region(code: "are")
+=> Worldwide::Region <iso_code: 'AE', full_name: "United Arab Emirates', ...>
+$ Worldwide.region(cldr: "are")
+=> Worldwide::Region <iso_code: 'AR-E', full_name: 'Entre Ríos', ...>
+
 # Get array of Region objects for country code passed in (with attributes in the current locale)
 $ Worldwide.region(code: "CA").zones
 => [ Worldwide::Region <code: 'caab', name: 'Alberta', ... >, Worldwide::Region <code: 'cabc', name: 'British Columbia', ... >]

--- a/lib/worldwide.rb
+++ b/lib/worldwide.rb
@@ -84,6 +84,10 @@ module Worldwide
       Punctuation
     end
 
+    def region_by_cldr_code(**kwargs)
+      Regions.region_by_cldr_code(**kwargs)
+    end
+
     def region(**kwargs)
       Regions.region(**kwargs)
     end

--- a/lib/worldwide/region.rb
+++ b/lib/worldwide/region.rb
@@ -19,6 +19,7 @@ module Worldwide
       :example_city,
       :flag,
       :format,
+      :cldr_code,
       :iso_code,
       :languages,
       :neighbours,
@@ -68,6 +69,9 @@ module Worldwide
     # show them as part of a formatted address.  If the province is missing, we will auto-infer it
     # based on the zip (note that this auto-inference may be wrong for some addresses near a border).
     attr_accessor :hide_provinces_from_addresses
+
+    # The CLDR code for this region.
+    attr_reader :cldr_code
 
     # The ISO-3166-2 code for this region (e.g. "CA", "CA-ON")
     # or, if there is no alpha-2 code defined for this region, a numeric code (e.g. "001").
@@ -172,6 +176,7 @@ module Worldwide
       continent: false,
       country: false,
       deprecated: false,
+      cldr_code: nil,
       iso_code: nil,
       legacy_code: nil,
       legacy_name: nil,
@@ -190,6 +195,7 @@ module Worldwide
       @continent = continent
       @country = country
       @deprecated = deprecated
+      @cldr_code = cldr_code
       @iso_code = iso_code&.to_s&.upcase
       @legacy_code = legacy_code
       @legacy_name = legacy_name
@@ -365,18 +371,6 @@ module Worldwide
     end
 
     private
-
-    # When looking up names in the CLDR data files, we need to use CLDR's naming convention.
-    # ISO code CA is CLDR code ca
-    # ISO code CA-ON is CLDR code caon
-    def cldr_code
-      result = (iso_code || numeric_three).to_s
-      if 2 == result.length
-        result.upcase
-      else
-        result.downcase.delete("-")
-      end
-    end
 
     def cross_border_zip_includes_province?(zip:, province_code:)
       return false unless country?

--- a/test/worldwide/region_test.rb
+++ b/test/worldwide/region_test.rb
@@ -173,6 +173,7 @@ module Worldwide
     test "when CLDR has no name available, full_name falls back to legacy_name" do
       dummy = Worldwide::Region.new(
         legacy_name: "Legacy name",
+        cldr_code: "x@",
         iso_code: "X@", # does not exist
       )
 

--- a/test/worldwide/regions_test.rb
+++ b/test/worldwide/regions_test.rb
@@ -15,11 +15,6 @@ module Worldwide
     end
 
     test "Can look up a province by iso_code" do
-      # Note that lookup of a province (subdivision) without the hyphen is not allowed,
-      # because this would be potentially ambiguous.  For example:
-      # `ARE` is the alpha-3 code for the United Arab Emirates, but
-      # `AR-E` is the code for Entre Rios, Argentina.
-
       ["CA-ON", :"CA-ON", "ca-on", :"ca-on"].each do |code|
         ontario = Worldwide.region(code: code)
         context = "Constructed using code #{code.inspect}"
@@ -28,6 +23,40 @@ module Worldwide
         assert_equal "Ontario", ontario.legacy_name, context
         assert_equal "Ontario", ontario.full_name(locale: "en-US"), context
         assert_equal "オンタリオ州", ontario.full_name(locale: "ja"), context
+      end
+    end
+
+    test "Can look up a region by cldr_code" do
+      [
+        ["ca", 13, "Canada", "Alberta"],
+        [:ca, 13, "Canada", "Alberta"],
+        ["are", 0, "Entre Ríos", nil],
+        [:are, 0, "Entre Ríos", nil],
+      ].each do |code, zones_count, name, zone_name|
+        region = Worldwide.region(cldr: code)
+
+        assert_equal name, region.legacy_name
+        assert_equal zones_count, region.zones.count
+        assert_equal zone_name, region.zones.first&.legacy_name
+      end
+    end
+
+    test "Can look up a province by cldr_code" do
+      [
+        ["caon", "Ontario", "オンタリオ州"],
+        [:caon, "Ontario", "オンタリオ州"],
+        ["jp14", "Kanagawa", "神奈川県"],
+        [:jp14, "Kanagawa", "神奈川県"],
+        ["are", "Entre Ríos", "エントレ・リオス州"],
+        [:are, "Entre Ríos", "エントレ・リオス州"],
+      ].each do |code, name, japanese_name|
+        region = Worldwide.region(cldr: code)
+        context = "Constructed using code #{code.inspect}"
+
+        assert_not_nil region, context
+        assert_equal name, region.legacy_name, context
+        assert_equal name, region.full_name(locale: "en-US"), context
+        assert_equal japanese_name, region.full_name(locale: "ja"), context
       end
     end
 


### PR DESCRIPTION
### What are you trying to accomplish?
<!--
Link to an issue or provide enough context so that someone new can understand the 'why' behind this change.
-->

* Setup an interface for Region lookups by CLDR code.

### What approach did you choose and why?
<!--
There are many ways to solve a problem. How did you approach this problem and why?
-->

* Add a separate, explicit method for CLDR lookups to avoid ambiguity.
  * `ARE` is the alpha-3 code for the United Arab Emirates, but
  * `AR-E` is the code for Entre Rios, Argentina.

### Checklist

* [ ] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
