### PR TITLE
Check for presence of parent isocode during zip normalization in region.valid_zip?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Add Region#group and Region#group_name [#15](https://github.com/Shopify/worldwide/pull/15)
 - Ensure Region#has_zip? returns a boolean for all regions [#17](https://github.com/Shopify/worldwide/pull/17)
+- Zip normalization bugfix when parent isocode is not set [#6](https://github.com/Shopify/worldwide/pull/6)
+
 ---
 
 [0.1.1] - 2023-10-27

--- a/lib/worldwide/region.rb
+++ b/lib/worldwide/region.rb
@@ -371,7 +371,7 @@ module Worldwide
     # is the given postal code value valid for this region?
     def valid_zip?(zip)
       normalized = Zip.normalize(
-        country_code: province? ? parent.iso_code : iso_code,
+        country_code: province? && parent.iso_code ? parent.iso_code : iso_code,
         zip: zip,
       )
       valid_normalized_zip?(normalized)

--- a/test/worldwide/region_validation_test.rb
+++ b/test/worldwide/region_validation_test.rb
@@ -58,6 +58,7 @@ module Worldwide
         [:US, :MA, "02128"],
         [:US, :NY, "10018"],
         [:US, :CA, "90210"],
+        [:US, :PR, "00901"],
       ].each do |country_code, province_code, zip|
         assert_equal true, Worldwide.region(code: country_code).valid_zip?(zip)
         assert_equal true, Worldwide.region(code: country_code).zone(code: province_code).valid_zip?(zip)
@@ -74,6 +75,7 @@ module Worldwide
         [:US, :MA, "2128"],
         [:US, :NY, "100018"],
         [:US, :CA, "902210"],
+        [:US, :PR, "000901"],
       ].each do |country_code, province_code, zip|
         assert_equal false, Worldwide.region(code: country_code).valid_zip?(zip)
         assert_equal false, Worldwide.region(code: country_code).zone(code: province_code).valid_zip?(zip)
@@ -93,6 +95,7 @@ module Worldwide
         [:US, :NH, "02128"],
         [:US, :MA, "10018"],
         [:US, :OR, "90210"],
+        [:US, :PR, "00899"],
       ].each do |country_code, province_code, zip|
         assert_equal true, Worldwide.region(code: country_code).valid_zip?(zip)
         assert_equal false, Worldwide.region(code: country_code).zone(code: province_code).valid_zip?(zip)


### PR DESCRIPTION

### What are you trying to accomplish?

Fix an issue identified when checking valid_zip? on region `PR`. Since `PR` is a province but its parent `Caribbean` does not have an isocode, zip normalization throws an argument error.

### What approach did you choose and why?

I went with the simplest approach to safety check if the parent has an isocode before sending to `Zip.normalize`.
I added test cases to replicate the issue with `PR` in the `region_validation_test`.

### Testing

Verify that US territories such as `PR` now work with `valid_zip?`

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
