### PR TITLE
Require bundler/setup in rakefile to load gems from github repo backed dependency

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "bundler/setup"
 require "bundler/gem_tasks"
 require "rake/testtask"
 


### PR DESCRIPTION

### What are you trying to accomplish?

Running rake console is producing the following error:
```
rake aborted!
LoadError: cannot load such file -- cldr/download
```

### What approach did you choose and why?

cldr/download is a dependency from ruby-cldr which is a github dependency
Git repository gems will only be available after [running bundler/setup](https://bundler.io/guides/git.html)

### What should reviewers focus on?
<!--
Outline anything you'd like reviewers to pay extra attention to. List open questions for discussion.
-->

...

### The impact of these changes
<!--
Are there any specific impacts from this change that you'd like to call out?
-->

...

### Testing

Ensure that rake console works.

### Checklist

* [ ] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
