### PR TITLE
Allow push host to rubygems.org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Nil.
 
 ---
 
+- Fix issue with deploy to rubygems.org failing
+
 [0.1.0] - 2023-10-27
 
 - Initial release of Worldwide

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,22 +14,32 @@ PATH
   remote: .
   specs:
     worldwide (0.1.0)
-      activesupport (>= 5.0)
-      i18n (>= 1.12)
-      phonelib
+      activesupport (~> 7.0)
+      i18n (~> 1.12.0)
+      phonelib (~> 0.8)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.4.3)
+    activesupport (7.1.1)
+      base64
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
+      mutex_m
       tzinfo (~> 2.0)
     ansi (1.5.0)
     ast (2.4.2)
+    base64 (0.1.1)
+    bigdecimal (3.1.4)
     builder (3.2.4)
     concurrent-ruby (1.2.2)
+    connection_pool (2.4.1)
+    drb (2.1.1)
+      ruby2_keywords
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     json (2.6.3)
@@ -44,6 +54,7 @@ GEM
       ruby-progressbar
     mocha (2.0.2)
       ruby2_keywords (>= 0.0.5)
+    mutex_m (0.1.2)
     nokogiri (1.14.3-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.14.3-x86_64-linux)

--- a/test/worldwide/regions_test.rb
+++ b/test/worldwide/regions_test.rb
@@ -37,7 +37,12 @@ module Worldwide
 
         assert_equal name, region.legacy_name
         assert_equal zones_count, region.zones.count
-        assert_equal zone_name, region.zones.first&.legacy_name
+
+        if zone_name.present?
+          assert_equal zone_name, region.zones.first&.legacy_name
+        else
+          assert_nil region.zones.first&.legacy_name
+        end
       end
     end
 

--- a/test/worldwide/shipit.rubygems.yml
+++ b/test/worldwide/shipit.rubygems.yml
@@ -1,0 +1,1 @@
+# default config

--- a/worldwide.gemspec
+++ b/worldwide.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 3.0.0"
 
-  spec.add_dependency("activesupport", ">= 5.0")
-  spec.add_dependency("i18n", ">= 1.12")
-  spec.add_dependency("phonelib")
+  spec.add_dependency("activesupport", "~> 7.0")
+  spec.add_dependency("i18n", "~> 1.12.0")
+  spec.add_dependency("phonelib", "~> 0.8")
 end

--- a/worldwide.gemspec
+++ b/worldwide.gemspec
@@ -7,14 +7,16 @@ require "worldwide/version"
 Gem::Specification.new do |spec|
   spec.name          = "worldwide"
   spec.version       = Worldwide::VERSION
-  spec.authors       = ["Christian Jaekl", "Michael Overmeyer"]
-  spec.email         = ["christian.jaekl@shopify.com"]
+  spec.author        = "Shopify"
+  spec.email         = "developers@shopify.com"
 
   spec.summary       = "Internationalization and localization APIs"
   spec.description   = "APIs to support i18n and l10n of Ruby code"
   spec.homepage      = "https://github.com/Shopify/worldwide"
 
-  spec.files         = %x(git ls-files -z).split("\x0").reject do |f|
+  spec.metadata["allowed_push_host"] = "https://rubygems.org/"
+
+  spec.files = %x(git ls-files -z).split("\x0").reject do |f|
     f.match(%r{^(rake|test|spec|features)/})
   end
   spec.bindir        = "exe"


### PR DESCRIPTION
### What are you trying to accomplish?

Fix issue with deploy to rubygems.org failing

```
Can't release the gem: spec.metadata['allowed_push_host'] must be defined.
```

### What approach did you choose and why?
<!--
There are many ways to solve a problem. How did you approach this problem and why?
-->

...

### What should reviewers focus on?
<!--
Outline anything you'd like reviewers to pay extra attention to. List open questions for discussion.
-->

...

### The impact of these changes
<!--
Are there any specific impacts from this change that you'd like to call out?
-->

...

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

...

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
