### PR TITLE
Ensure `Region#has_zip?` returns a boolean for all regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 - Add Region#group and Region#group_name [#15](https://github.com/Shopify/worldwide/pull/15)
-
+- Ensure Region#has_zip? returns a boolean for all regions [#17](https://github.com/Shopify/worldwide/pull/17)
 ---
 
 [0.1.1] - 2023-10-27

--- a/lib/worldwide/region.rb
+++ b/lib/worldwide/region.rb
@@ -301,7 +301,7 @@ module Worldwide
 
     # Does this region have postal codes?
     def has_zip?
-      format["show"]&.include?("{zip}")
+      !!format["show"]&.include?("{zip}")
     end
 
     # Is this Region considered a "province" (political subdivision of a "country")?

--- a/test/worldwide/region_test.rb
+++ b/test/worldwide/region_test.rb
@@ -11,6 +11,7 @@ module Worldwide
       assert_equal false, region.continent?
       assert_equal false, region.country?
       assert_equal false, region.deprecated?
+      assert_equal false, region.has_zip?
       assert_equal "ZZ", region.iso_code
       assert_nil region.legacy_code
       assert_nil region.legacy_name


### PR DESCRIPTION
### What are you trying to accomplish?
```ruby
irb(main):001:0> Worldwide.region(code: "US").has_zip?
=> true
irb(main):002:0> Worldwide.region(code: "AW").has_zip?
=> false
irb(main):003:0> Worldwide.region(code: "ZZ").has_zip?
=> nil
```
The predicate `has_zip?` should not respond with `nil` on any region.

### What approach did you choose and why?
Double-negate the statement that returns `nil` for regions having no `show` format.

### Testing
```ruby
irb(main):001:0> Worldwide.region(code: "US").has_zip?
=> true
irb(main):002:0> Worldwide.region(code: "AW").has_zip?
=> false
irb(main):003:0> Worldwide.region(code: "ZZ").has_zip?
=> false
```

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
