### PR TITLE
Region loader updates parent for alternates in world.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add Region#group and Region#group_name [#15](https://github.com/Shopify/worldwide/pull/15)
 - Ensure Region#has_zip? returns a boolean for all regions [#17](https://github.com/Shopify/worldwide/pull/17)
 - Zip normalization bugfix when parent isocode is not set [#6](https://github.com/Shopify/worldwide/pull/6)
+- Update region parent when alternates are defined [#18](https://github.com/Shopify/worldwide/pull/18)
 
 ---
 

--- a/lib/worldwide/regions_loader.rb
+++ b/lib/worldwide/regions_loader.rb
@@ -46,6 +46,9 @@ module Worldwide
         @regions << current_region
       end
 
+      if parent.present? && current_region.parent != parent
+        current_region.parent = parent
+      end
       parent&.add_zone(current_region)
       return current_region if children.nil?
 

--- a/test/worldwide/region_validation_test.rb
+++ b/test/worldwide/region_validation_test.rb
@@ -75,7 +75,7 @@ module Worldwide
         [:US, :MA, "2128"],
         [:US, :NY, "100018"],
         [:US, :CA, "902210"],
-        [:US, :PR, "000901"],
+        [:US, :PR, "006000"],
       ].each do |country_code, province_code, zip|
         assert_equal false, Worldwide.region(code: country_code).valid_zip?(zip)
         assert_equal false, Worldwide.region(code: country_code).zone(code: province_code).valid_zip?(zip)

--- a/test/worldwide/regions_test.rb
+++ b/test/worldwide/regions_test.rb
@@ -104,6 +104,14 @@ module Worldwide
       end
     end
 
+    test "Region uses parent from alternates" do
+      pr = Worldwide.region(code: "PR")
+
+      assert_equal "Puerto Rico", pr.legacy_name
+      assert_equal "PR", pr.legacy_code
+      assert_equal "US", pr.parent.iso_code
+    end
+
     test "Look up with both code and name raises" do
       assert_raises ArgumentError do
         Worldwide.region(code: "CA", name: "Canada")


### PR DESCRIPTION
### What are you trying to accomplish?

Based on feedback in https://github.com/Shopify/worldwide/pull/6, we should update PR to have the US be its parent when the hierarchy is built.

### What approach did you choose and why?

I added a conditional to override the parent of the region when it is defined multiple times in the world.yml hierarchy. This will give preference to the alternates instead of where the region is first defined.

### What should reviewers focus on?

Is this an adequate stop gap or do we need to support multiple parents instead?

### The impact of these changes

This change should fix a bug with Puerto Rico zip validation and have territories behave closer to how we are expecting.

### Testing

Focus testing around territories and other places where alternates are defined to ensure the regions are still behaving as expected.

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
