### PR TITLE
Add code alternates for US, PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 - Add code alternates for Japan [#23](https://github.com/Shopify/worldwide/pull/23)
+- Add code alternates for Puerto Rico [#24](https://github.com/Shopify/worldwide/pull/24)
 
 ---
 

--- a/db/data/regions/US.yml
+++ b/db/data/regions/US.yml
@@ -1357,6 +1357,9 @@ zones:
   example_city_zip: '00717'
   tax_name: State Tax
   code: PR
+  code_alternates:
+  - US-PR
+  - USPR
   iso_code: PR
   zip_prefixes:
   - '006'


### PR DESCRIPTION
### What are you trying to accomplish?
<!--
Link to an issue or provide enough context so that someone new can understand the 'why' behind this change.
-->

* https://github.com/Shopify/worldwide/issues/21

### What approach did you choose and why?
<!--
There are many ways to solve a problem. How did you approach this problem and why?
-->

* Add code alternates

### The impact of these changes
<!--
Are there any specific impacts from this change that you'd like to call out?
-->
* Before
```ruby
(byebug) Worldwide.region(code: 'us').zone(code: 'uspr').legacy_name
"Unknown"
(byebug) Worldwide.region(code: 'us').zone(code: 'us-pr').legacy_name
"Unknown"
```
* After
```ruby
(byebug) Worldwide.region(code: 'us').zone(code: 'uspr').legacy_name
"Puerto Rico"
(byebug) Worldwide.region(code: 'us').zone(code: 'us-pr').legacy_name
"Puerto Rico"
```

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
