### PR TITLE
Record multiple parents per region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Add code alternates for Japan [#23](https://github.com/Shopify/worldwide/pull/23)
 - Add code alternates for Puerto Rico [#24](https://github.com/Shopify/worldwide/pull/24)
+- Record multiple parents per region [#27](https://github.com/Shopify/worldwide/pull/27)
 
 ---
 

--- a/lib/worldwide/regions_loader.rb
+++ b/lib/worldwide/regions_loader.rb
@@ -46,9 +46,7 @@ module Worldwide
         @regions << current_region
       end
 
-      if parent.present? && current_region.parent != parent
-        current_region.parent = parent
-      end
+      current_region.parents << parent if Util.present?(parent)
       parent&.add_zone(current_region)
       return current_region if children.nil?
 

--- a/test/worldwide/region_test.rb
+++ b/test/worldwide/region_test.rb
@@ -76,7 +76,7 @@ module Worldwide
 
       region.add_zone(zone)
 
-      assert_equal region, zone.parent
+      assert_includes zone.parents, region
       assert_equal [zone], region.zones
       assert_equal zone, region.zone(code: "XB")
     end
@@ -219,6 +219,19 @@ module Worldwide
 
       city_required_countries.each do |country_code|
         assert_predicate Worldwide.region(code: country_code), :city_required?
+      end
+    end
+
+    test "associated_country returns the expected country" do
+      {
+        ca: "CA",
+        gb: "GB",
+        ic: "ES",
+        pr: "US",
+        sh: "SH",
+        us: "US",
+      }.each do |region_code, expected_country|
+        assert_equal expected_country, Worldwide.region(code: region_code).associated_country.iso_code
       end
     end
   end

--- a/test/worldwide/regions_test.rb
+++ b/test/worldwide/regions_test.rb
@@ -109,7 +109,7 @@ module Worldwide
 
       assert_equal "Puerto Rico", pr.legacy_name
       assert_equal "PR", pr.legacy_code
-      assert_equal "US", pr.parent.iso_code
+      assert_equal "US", pr.associated_country.iso_code
     end
 
     test "Look up with both code and name raises" do
@@ -135,6 +135,21 @@ module Worldwide
     test "Looking up a region that does not exist returns the unknown region ZZ" do
       assert_equal "ZZ", Worldwide.region(code: "bogus-does-not-exist").iso_code
       assert_equal "ZZ", Worldwide.region(code: "CA").zone(code: "bogus-does-not-exist").iso_code
+    end
+
+    test "Multi-parent regions have all expected parents recorded" do
+      {
+        bq: ["029", "NL"],
+        ca: ["021"],
+        gb: ["154"],
+        hk: ["030", "CN"],
+        pr: ["029", "US"],
+        sh: ["011", "GB"],
+      }.each do |region_code, expected_parents|
+        expected_parents.each do |parent_code|
+          assert_includes Worldwide.region(code: region_code).parents, Worldwide.region(code: parent_code)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

The world hierarchy is complex, and a given region may have more than one "parent" region. For example, Puerto Rico is associated both with US (United Stats) and with 029 (Caribbean).

### What approach did you choose and why?

Replace `Region.parent` with `Region.parents`, which is a set of `Region` objects that can be considered a "parent" (associated region).

### What should reviewers focus on?

This is removing a piece of public API (`Region.parent`).  In some sense, this is a good thing, because the API was "broken" (e.g. it would return `029` for `PR`, when folks might have been expecting `US`).  We could provide a `parent` method that returns a single value out of the set for backward compatibility, but that's perpetuating a broken concept.  What are peoples' thoughts about this?

### The impact of these changes

`Region.parent` is removed.
`Region.parents` is added.

### Checklist

* [ ] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
