### PR TITLE
added building-number-may-be-in-address2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add code alternates for Japan [#23](https://github.com/Shopify/worldwide/pull/23)
 - Add code alternates for Puerto Rico [#24](https://github.com/Shopify/worldwide/pull/24)
 - Record multiple parents per region [#27](https://github.com/Shopify/worldwide/pull/27)
+- Add region.building_number_may_be_in_address2 [#28](https://github.com/Shopify/worldwide/pull/28)
 - Lookup by parent-child ISO and CLDR codes for dual-status territories
   [#29](https://github.com/Shopify/worldwide/pull/29)
 

--- a/db/data/regions/IT.yml
+++ b/db/data/regions/IT.yml
@@ -14,6 +14,7 @@ zip_regex: "^(IT?-?)?\\d{5}$"
 zip_example: '00144'
 phone_number_prefix: 39
 building_number_required: true
+building_number_may_be_in_address2: true
 week_start_day: monday
 languages:
   - it

--- a/lib/worldwide/region.rb
+++ b/lib/worldwide/region.rb
@@ -47,6 +47,10 @@ module Worldwide
     # If we require a building number in an address, then this will be true.
     attr_accessor :building_number_required
 
+    # In some countries, an address may have the building number in address2.
+    # If we are allowed to have a building number in address2, then this will be true.
+    attr_accessor :building_number_may_be_in_address2
+
     # Alternate codes which may be used to designate this region
     attr_accessor :code_alternates
 
@@ -219,6 +223,7 @@ module Worldwide
       @use_zone_code_as_short_name = use_zone_code_as_short_name
 
       @building_number_required = false
+      @building_number_may_be_in_address2 = false
       @currency = nil
       @flag = nil
       @format = {}

--- a/lib/worldwide/regions_loader.rb
+++ b/lib/worldwide/regions_loader.rb
@@ -59,6 +59,7 @@ module Worldwide
 
     def apply_territory_attributes(region, spec)
       region.building_number_required = spec["building_number_required"] || true
+      region.building_number_may_be_in_address2 = spec["building_number_may_be_in_address2"] || false
       currency_code = spec["currency"]
       region.currency = Worldwide.currency(code: currency_code) unless currency_code.nil?
       region.flag = spec["emoji"]


### PR DESCRIPTION
### What are you trying to accomplish?

In the `BuildingNumberInAddress1` and `BuildingNumberInAddress1OrAddress2` validators in Atlas, we check if the building number is allowed to be in address2. The functionality for that is not entirely in Worldwide. 

Specifically this line in Atlas: https://github.com/Shopify/atlas/blob/4c34ca370b0e63e10f9e6c036bb06a6eaf4726a6/app/models/address_validation/validators/street_address.rb#L63

We still use `CountryDb` there. 

### What approach did you choose and why?

I just added the property as an attribute to region. 

The `.yml` files for the countries that this concerns were already updated; except for `IT.yml` which I updated.

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
