### PR TITLE
added autofill_city_enabled property to region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-Nil.
+- Add region.autofill_city_enabled [#31](https://github.com/Shopify/worldwide/pull/31)
 
 ---
 

--- a/lib/worldwide/region.rb
+++ b/lib/worldwide/region.rb
@@ -42,6 +42,10 @@ module Worldwide
     # Otherwise, nil.
     attr_reader :alpha_three
 
+    # Some countries have only a single city (i.e Singapore, Vatican City), so the city value can be autofilled.
+    # Where this is the case, this will be true.
+    attr_accessor :autofill_city_enabled
+
     # In some countries, every address must have a building number.
     # In others (e.g., GB), some addresses rely on just a building name, not a number.
     # If we require a building number in an address, then this will be true.
@@ -222,6 +226,7 @@ module Worldwide
       @tax_rate = tax_rate
       @use_zone_code_as_short_name = use_zone_code_as_short_name
 
+      @autofill_city_enabled = false
       @building_number_required = false
       @building_number_may_be_in_address2 = false
       @currency = nil

--- a/lib/worldwide/regions_loader.rb
+++ b/lib/worldwide/regions_loader.rb
@@ -58,6 +58,7 @@ module Worldwide
     end
 
     def apply_territory_attributes(region, spec)
+      region.autofill_city_enabled = spec["autofill_city_enabled"] || false
       region.building_number_required = spec["building_number_required"] || true
       region.building_number_may_be_in_address2 = spec["building_number_may_be_in_address2"] || false
       currency_code = spec["currency"]


### PR DESCRIPTION
### What are you trying to accomplish?

Add a property to show whether a region has `autofill_city_enabled`.

### What approach did you choose and why?

Added this to `Region` and set default to `false`. The regions that are concerned with this already had the correct field in their respective `.yml` files. 

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
