### PR TITLE
Expose alternate names of regions and zones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-Nil.
+- Add region name alternates [#32](https://github.com/Shopify/worldwide/pull/32)
 
 ---
 

--- a/db/data/regions/US.yml
+++ b/db/data/regions/US.yml
@@ -7,6 +7,8 @@ unit_system: imperial
 tax_name: Federal Tax
 group: North American Countries
 group_name: North America
+name_alternates:
+- United States of America
 zip_label: Zip code
 zip_regex: "(?-mix:\\A\\d{5}(-\\d{4})?\\z)|(?i-mx:\\AFPO\\s*A[A-Z]\\s*\\d{5}-\\d{4}\\z)"
 zip_example: '90210'

--- a/lib/worldwide/region.rb
+++ b/lib/worldwide/region.rb
@@ -110,6 +110,10 @@ module Worldwide
     # This name is the name that was traditionally returned by "country_db".
     attr_reader :legacy_name
 
+    # Other names that may be used to refer to this region.
+    # E.g., "Czech Republic" is also known as "Czechia".
+    attr_accessor :name_alternates
+
     # iso_code values of regions (subdivisions) within the same country that border this region.
     # E.g., for CA-ON, the neighbouring zones are CA-MB, CA-NU and CA-QC.
     attr_accessor :neighbours

--- a/lib/worldwide/regions_loader.rb
+++ b/lib/worldwide/regions_loader.rb
@@ -82,10 +82,12 @@ module Worldwide
       region.zip_requirement = spec["zip_requirement"]
       region.zip_regex = spec["zip_regex"]
       region.zips_crossing_provinces = spec["zips_crossing_provinces"]
+      region.name_alternates = spec["name_alternates"] || []
     end
 
     def apply_zone_attributes(region, zone)
       region.code_alternates = zone["code_alternates"] || []
+      region.name_alternates = zone["name_alternates"] || []
       region.example_city = zone["example_city"]
       region.neighbours = zone["neighboring_zones"]
       region.zip_prefixes = zone["zip_prefixes"] || []

--- a/test/worldwide/region_test.rb
+++ b/test/worldwide/region_test.rb
@@ -249,5 +249,26 @@ module Worldwide
         assert_equal expected_country, Worldwide.region(code: region_code).associated_country.iso_code
       end
     end
+
+    test "name alternates are returned as expected" do
+      {
+        cz: ["Czechia"],
+        sz: ["Swaziland"],
+        us: ["United States of America"],
+        ca: [],
+      }.each do |region_code, expected_alternates|
+        assert_equal expected_alternates, Worldwide.region(code: region_code).name_alternates
+      end
+    end
+
+    test "name alternates are returned as expected on zones" do
+      [
+        [:th, "TH-10", ["Krung Thep Maha Nakhon"]],
+        [:jp, "JP-01", ["Hokkaido Prefecture", "北海道"]],
+        [:ca, "ON", []],
+      ].each do |region_code, zone_code, expected_alternates|
+        assert_equal expected_alternates, Worldwide.region(code: region_code).zone(code: zone_code).name_alternates
+      end
+    end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Expose the alternate names data we have under a new method `alternate_names`

### What approach did you choose and why?

- Add an attr_accessor on region and modify regions loader to set the data accordingly

### What should reviewers focus on?
<!--
Outline anything you'd like reviewers to pay extra attention to. List open questions for discussion.
-->

...

### The impact of these changes
<!--
Are there any specific impacts from this change that you'd like to call out?
-->

...

### Testing

Verify unit test coverage.

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
