### PR TITLE
Cache `Region#parent_country` call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 - Add region name alternates [#32](https://github.com/Shopify/worldwide/pull/32)
+- Cache `Region#parent_name` [#33](https://github.com/Shopify/worldwide/pull/33)
 
 ---
 

--- a/lib/worldwide/region.rb
+++ b/lib/worldwide/region.rb
@@ -442,7 +442,7 @@ module Worldwide
     end
 
     def parent_country
-      parents.find(&:country?)
+      @parent_country ||= parents.find(&:country?)
     end
 
     # Checks whether the given value is acceptable according to the regular expression defined for the country.


### PR DESCRIPTION
### What are you trying to accomplish?
<!--
Link to an issue or provide enough context so that someone new can understand the 'why' behind this change.
-->

* Following https://github.com/Shopify/worldwide/pull/30, we call `Region#parent_country` without caching the result which is inefficient

### What approach did you choose and why?
<!--
There are many ways to solve a problem. How did you approach this problem and why?
-->

* Cache the result of `Region#parent_country`

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
