### PR TITLE
Improve performance by using hash table for by-code region lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Add region name alternates [#32](https://github.com/Shopify/worldwide/pull/32)
 - Cache `Region#parent_name` [#33](https://github.com/Shopify/worldwide/pull/33)
+- Use hash tables to look up regions by code [#36](https://github.com/Shopify/worldwide/pull/36)
 
 ---
 

--- a/lib/worldwide/regions.rb
+++ b/lib/worldwide/regions.rb
@@ -16,7 +16,7 @@ module Worldwide
     end
 
     def initialize
-      @regions = RegionsLoader.new.load_regions
+      @regions, @regions_by_cldr_code, @regions_by_iso_code = RegionsLoader.new.load_regions
     end
 
     def all
@@ -29,17 +29,9 @@ module Worldwide
       end
 
       result = if cldr
-        search_code = cldr.to_s.upcase
-
-        @regions.find do |r|
-          r.send(:answers_to_cldr_code, search_code)
-        end
+        @regions_by_cldr_code[cldr.to_s.upcase]
       elsif code
-        search_code = code.to_s.upcase
-
-        @regions.find do |r|
-          r.send(:answers_to_iso_code, search_code) || r.alpha_three == search_code || r.numeric_three == search_code
-        end
+        @regions_by_iso_code[code.to_s.upcase]
       else # search by name
         search_name = name.upcase
 


### PR DESCRIPTION
### What are you trying to accomplish?

Calls to `Worldwide.region(code: x)` and `Worldwide.region(cldr: x)` had been doing linear searches of all known regions.  Recent experience shows that this has become a problem.  Let's use hash table lookups to speed things up.

### What approach did you choose and why?

Note that we're still doing linear searches when looking up by name. Looking up by name is strongly discouraged in any case. Also, the hash table would be significantly larger, because we'd need to cache all translated versions of each name.  At least for now, I'm going to leave that bit of code as it is.

### The impact of these changes

Before:
```ruby
cejaekl@cjm1 worldwide % bin/console
irb(main):001:0> require 'benchmark'
=> true
irb(main):002:0> puts Benchmark.measure{1000.times{Worldwide.region(code: "US-PR")}}
  0.588466   0.010987   0.599453 (  0.616751)
```

After:
```ruby
cejaekl@cjm1 worldwide % bin/console
irb(main):001:0> require 'benchmark'
=> true
irb(main):002:0> puts Benchmark.measure{1000.times{Worldwide.region(code: "US-PR")}}
  0.127260   0.009308   0.136568 (  0.141930)
```

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
