### PR TITLE
Release 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,12 +27,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-- Add zone name alternates for Italy [#42](https://github.com/Shopify/worldwide/pull/35)
+Nil.
+
+---
+
+[0.4.1] - 2023-11-10
 - Add support for deprecated timezone Australia/Canberra [#35](https://github.com/Shopify/worldwide/pull/35)
 - Add alternate codes for territories [#39](https://github.com/Shopify/worldwide/pull/39)
 - Allow building numbers on address2 field for Austrian addresses [#40](https://github.com/Shopify/worldwide/pull/40)
-
----
+- Add zone name alternates for Italy [#42](https://github.com/Shopify/worldwide/pull/35)
 
 [0.4.0] - 2023-11-08
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (0.4.0)
+    worldwide (0.4.1)
       activesupport (~> 7.0)
       i18n (~> 1.12.0)
       phonelib (~> 0.8)

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end


### PR DESCRIPTION
### What are you trying to accomplish?
<!--
Link to an issue or provide enough context so that someone new can understand the 'why' behind this change.
-->

Release 0.4.1
* Add support for deprecated timezone Australia/Canberra [#35](https://github.com/Shopify/worldwide/pull/35)
*  Add alternate codes for territories [#39](https://github.com/Shopify/worldwide/pull/39)
* Allow building numbers on address2 field for Austrian addresses [#40](https://github.com/Shopify/worldwide/pull/40)
* Add zone name alternates for Italy [#42](https://github.com/Shopify/worldwide/pull/35)

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
