### PR TITLE
Add associated_continent attribute to region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-Nil.
+- Add support for `Region#associated_continent` to return the containing continent of the region [#43](https://github.com/Shopify/worldwide/pull/43)
 
 ---
 

--- a/lib/worldwide/region.rb
+++ b/lib/worldwide/region.rb
@@ -272,6 +272,17 @@ module Worldwide
       parent_country
     end
 
+    def associated_continent
+      return self if continent?
+
+      parents.each do |parent|
+        candidate = parent.associated_continent
+        return candidate unless candidate.nil?
+      end
+
+      nil
+    end
+
     # The value with which to autofill the zip, if this region has zip autofill active;
     # otherwise, nil.
     def autofill_zip

--- a/test/worldwide/region_test.rb
+++ b/test/worldwide/region_test.rb
@@ -263,6 +263,31 @@ module Worldwide
       end
     end
 
+    test "associated_continent returns the expected continent" do
+      [
+        # Canada
+        [:ca, "North America"],
+        # Ontario is a province of Canada, which is in North America
+        ["CA-ON", "North America"],
+        # Tokyo is a province of Japan, which is in Asia
+        ["JP-13", "Asia"],
+        # North America itself
+        ["003", "North America"],
+        # Puerto Rico is a territory of the US, which is in North America too
+        ["US-PR", "North America"],
+        # Bermuda is a territory of the UK, which is in Europe, but it lies in North America
+        ["GB-BM", "North America"],
+        # French Polynesia is a territory of France, which is in Europe, but it lies in Oceania
+        ["FR-PF", "Oceania"],
+      ].each do |region_code, expected_continent|
+        assert_equal expected_continent, Worldwide.region(code: region_code).associated_continent.full_name
+      end
+    end
+
+    test "associated_continent for world region returns nil" do
+      assert_nil Worldwide.region(code: "001").associated_continent
+    end
+
     test "name alternates are returned as expected" do
       {
         cz: ["Czechia"],


### PR DESCRIPTION
### What are you trying to accomplish?
Adds an associated_continent attribute to the region class that references the containing continent of the region.


### What approach did you choose and why?
Recursively looks at the parent regions until it finds one that is a continent. This means regions with more than one parent like Puerto Rico will take their first parent into consideration, both of which have a parent continent of "North America". French Polynesia is in Oceania, but one of it's parents is France, which lies in Europe. 


### What should reviewers focus on?
<!--
Outline anything you'd like reviewers to pay extra attention to. List open questions for discussion.
-->
Are there any outliers in the above logic that we might hit with this method, or will the first parent pulled out of the set always be the continent where the region actually physically sits?

### The impact of these changes
<!--
Are there any specific impacts from this change that you'd like to call out?
-->

This is a new field, so should be no impact.

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
