### PR TITLE
Add granular postal code prefixes for KR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 - Add support for `Region#associated_continent` to return the containing continent of the region [#43](https://github.com/Shopify/worldwide/pull/43)
+- Add more postal code prefixes for KR [#44](https://github.com/Shopify/worldwide/pull/44)
 
 ---
 
 [0.4.1] - 2023-11-10
+
 - Add support for deprecated timezone Australia/Canberra [#35](https://github.com/Shopify/worldwide/pull/35)
 - Add alternate codes for territories [#39](https://github.com/Shopify/worldwide/pull/39)
 - Allow building numbers on address2 field for Austrian addresses [#40](https://github.com/Shopify/worldwide/pull/40)

--- a/db/data/regions/KR.yml
+++ b/db/data/regions/KR.yml
@@ -104,7 +104,15 @@ zones:
   tax: 0.0
   tax_name: VAT
   zip_prefixes:
-  - '1'
+  - '10'
+  - '11'
+  - '12'
+  - '13'
+  - '14'
+  - '15'
+  - '16'
+  - '17'
+  - '18'
 - name: Gyeongnam
   code: KR-48
   iso_code: KR-48
@@ -162,7 +170,14 @@ zones:
   tax: 0.0
   tax_name: VAT
   zip_prefixes:
-  - '0'
+  - '01'
+  - '02'
+  - '03'
+  - '04'
+  - '05'
+  - '06'
+  - '07'
+  - '08'
 - name: Ulsan
   code: KR-31
   iso_code: KR-31


### PR DESCRIPTION
### What are you trying to accomplish?
Adding more granular postal codes prefixes for South Korea 

Referenced the following sources: 
- [GRCDI](https://www.grcdi.nl/gsb/south%20korea.html#HB8684CE730533E56377EC2A6514B9C27E54EDA79027A5BA5BLocalA20shortA20nameA20formA5DA5D00100400C01401B022025)
- [Parcelforce](https://www.parcelforce.com/sites/default/files/KR%20Postcodes%20Aug19%20v1%20050819.pdf)
- [Wikipedia](https://en.wikipedia.org/wiki/Postal_codes_in_South_Korea)  

### What approach did you choose and why?
Introduced more granular postal code prefixes for 2 KR zones. 

### What should reviewers focus on?
NA

### The impact of these changes
For Seoul, the postal code prefixes '00' and '09' will be considered invalid. 
For Gyeonggi, the postal code prefix '19' will be considered invalid. 

### Testing


### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
