### PR TITLE
Add name alternates for KR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Add support for `Region#associated_continent` to return the containing continent of the region [#43](https://github.com/Shopify/worldwide/pull/43)
 - Add more postal code prefixes for KR [#44](https://github.com/Shopify/worldwide/pull/44)
+- Add name alternates for the zones of South Korea [#45](https://github.com/Shopify/worldwide/pull/45)
 
 ---
 

--- a/db/data/regions/KR.yml
+++ b/db/data/regions/KR.yml
@@ -26,6 +26,8 @@ languages:
   - ko
 zones:
 - name: Busan
+  name_alternates:
+  - 부산광역시
   code: KR-26
   iso_code: KR-26
   tax: 0.0
@@ -36,6 +38,8 @@ zones:
   - '48'
   - '49'
 - name: Chungbuk
+  name_alternates:
+  - 충청북도
   code: KR-43
   iso_code: KR-43
   tax: 0.0
@@ -45,6 +49,8 @@ zones:
   - '28'
   - '29'
 - name: Chungnam
+  name_alternates:
+  - 충청남도
   code: KR-44
   iso_code: KR-44
   tax: 0.0
@@ -54,6 +60,8 @@ zones:
   - '32'
   - '33'
 - name: Daegu
+  name_alternates:
+  - 대구광역시
   code: KR-27
   iso_code: KR-27
   tax: 0.0
@@ -63,6 +71,8 @@ zones:
   - '42'
   - '43'
 - name: Daejeon
+  name_alternates:
+  - 대전광역시
   code: KR-30
   iso_code: KR-30
   tax: 0.0
@@ -71,6 +81,8 @@ zones:
   - '34'
   - '35'
 - name: Gangwon
+  name_alternates:
+  - 강원도
   code: KR-42
   iso_code: KR-42
   tax: 0.0
@@ -80,6 +92,8 @@ zones:
   - '25'
   - '26'
 - name: Gwangju
+  name_alternates:
+  - 광주광역시
   code: KR-29
   iso_code: KR-29
   tax: 0.0
@@ -88,6 +102,8 @@ zones:
   - '61'
   - '62'
 - name: Gyeongbuk
+  name_alternates:
+  - 경상북도
   code: KR-47
   iso_code: KR-47
   tax: 0.0
@@ -99,6 +115,8 @@ zones:
   - '39'
   - '40'
 - name: Gyeonggi
+  name_alternates:
+  - 경기도
   code: KR-41
   iso_code: KR-41
   tax: 0.0
@@ -114,6 +132,8 @@ zones:
   - '17'
   - '18'
 - name: Gyeongnam
+  name_alternates:
+  - 경상남도
   code: KR-48
   iso_code: KR-48
   tax: 0.0
@@ -124,6 +144,8 @@ zones:
   - '52'
   - '53'
 - name: Incheon
+  name_alternates:
+  - 인천광역시
   code: KR-28
   iso_code: KR-28
   tax: 0.0
@@ -133,6 +155,8 @@ zones:
   - '22'
   - '23'
 - name: Jeju
+  name_alternates:
+  - 제주특별자치도
   code: KR-49
   iso_code: KR-49
   tax: 0.0
@@ -140,6 +164,8 @@ zones:
   zip_prefixes:
   - '63'
 - name: Jeonbuk
+  name_alternates:
+  - 전라북도
   code: KR-45
   iso_code: KR-45
   tax: 0.0
@@ -149,6 +175,8 @@ zones:
   - '55'
   - '56'
 - name: Jeonnam
+  name_alternates:
+  - 전라남도
   code: KR-46
   iso_code: KR-46
   tax: 0.0
@@ -158,6 +186,8 @@ zones:
   - '58'
   - '59'
 - name: Sejong
+  name_alternates:
+  - 세종특별자치시
   code: KR-50
   iso_code: KR-50
   tax: 0.0
@@ -165,6 +195,9 @@ zones:
   zip_prefixes:
   - '30'
 - name: Seoul
+  name_alternates:
+  - 서울특별시
+  - 서울
   code: KR-11
   iso_code: KR-11
   tax: 0.0
@@ -179,6 +212,8 @@ zones:
   - '07'
   - '08'
 - name: Ulsan
+  name_alternates:
+  - 울산광역시
   code: KR-31
   iso_code: KR-31
   tax: 0.0


### PR DESCRIPTION
### What are you trying to accomplish?
Add name alternates for the zones of South Korea; these name alternates correspond to the Hangul (Korean alphabet) representation of the zones.  

### What approach did you choose and why?
Referenced a handful of sources, including the open source data set provided by OpenAddresses.
The full list can be found on wikipedia [here]( https://en.wikipedia.org/wiki/South_Korea#Administrative_divisions). 

### What should reviewers focus on?


### The impact of these changes


### Testing


### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
