### PR TITLE
Add Hangul and Arabic to scripts module, update latin to use unicode script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add support for `Region#associated_continent` to return the containing continent of the region [#43](https://github.com/Shopify/worldwide/pull/43)
 - Add more postal code prefixes for KR [#44](https://github.com/Shopify/worldwide/pull/44)
 - Add name alternates for the zones of South Korea [#45](https://github.com/Shopify/worldwide/pull/45)
+- Add support for Hangul and Arabic script detection, update Latn regexp [#46](https://github.com/Shopify/worldwide/pull/46)
 
 ---
 

--- a/lib/worldwide/scripts.rb
+++ b/lib/worldwide/scripts.rb
@@ -10,10 +10,12 @@ module Worldwide
         discovered_scripts = []
 
         script_regexes = {
-          "Latn": "[A-Za-z\uFF21-\uFF3A\uFF41-\uFF5A]",
+          "Arabic": "\\p{Arabic}",
+          "Latn": "\\p{Latin}",
           "Han": "\\p{Han}",
-          "Katakana": "\\p{Katakana}",
+          "Hangul": "\\p{Hangul}",
           "Hiragana": "\\p{Hiragana}",
+          "Katakana": "\\p{Katakana}",
         }
 
         script_regexes.each do |script, regex|

--- a/test/worldwide/scripts_test.rb
+++ b/test/worldwide/scripts_test.rb
@@ -7,12 +7,15 @@ module Worldwide
     test "identify returns expected script values for several text inputs" do
       {
         "The quick brown fox jumps": [:Latn],
+        "Ｔｈｅ ｑｕｉｃｋ ｂｒｏｗｎ ｆｏｘ ｊｕｍｐｓ ｆｕｌｌ ｗｉｄｔｈ": [:Latn],
         "日本": [:Han],
         "にほん": [:Hiragana],
         "ニホン": [:Katakana],
         "素早い茶色のキツネが怠け者の犬を飛び越えます。": [:Han, :Hiragana, :Katakana],
         "車": [:Han],
         "车": [:Han],
+        "부산광역시": [:Hangul],
+        "بوسان": [:Arabic],
       }.each do |text, expected|
         actual = Worldwide::Scripts.identify(text: text)
 


### PR DESCRIPTION
### What are you trying to accomplish?
Add the scripts Hangul and Arabic to the scripts module. The module is used to identify the input script. 

### What approach did you choose and why?
Added the unicode scripts for each language, supported by Ruby. 
https://www.regular-expressions.info/unicode.html

### What should reviewers focus on?
NA

### The impact of these changes
Before:
```
irb(main):001:0> Worldwide::Scripts.identify(text: "부산광역시")
=> []
irb(main):002:0> Worldwide::Scripts.identify(text: "بوسان")
=> []
```
After:
```
irb(main):001:0> Worldwide::Scripts.identify(text: "부산광역시")
=> [:Hangul]
irb(main):002:0> Worldwide::Scripts.identify(text: "بوسان")
=> [:Arabic]
```

No change expected for Latin character set. Behaviour should be preserved. 

### Testing


### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
