### PR TITLE
bump to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,12 +27,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- nil
+
+---
+
+[0.5.0] - 2023-11-20
+
 - Add support for `Region#associated_continent` to return the containing continent of the region [#43](https://github.com/Shopify/worldwide/pull/43)
 - Add more postal code prefixes for KR [#44](https://github.com/Shopify/worldwide/pull/44)
 - Add name alternates for the zones of South Korea [#45](https://github.com/Shopify/worldwide/pull/45)
 - Add support for Hangul and Arabic script detection, update Latn regexp [#46](https://github.com/Shopify/worldwide/pull/46)
-
----
 
 [0.4.1] - 2023-11-10
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (0.4.1)
+    worldwide (0.5.0)
       activesupport (~> 7.0)
       i18n (~> 1.12.0)
       phonelib (~> 0.8)

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "0.4.1"
+  VERSION = "0.5.0"
 end


### PR DESCRIPTION
### What are you trying to accomplish?
Release a new version of Worldwide 

### What approach did you choose and why?
- Updated the changelog and version.rb
-  ran `bundle install` to `update the Gemfile.lock`*

*Had to install a new version of ruby locally, followed this [stack overflow thread ](https://stackoverflow.com/questions/51126403/you-dont-have-write-permissions-for-the-library-ruby-gems-2-3-0-directory-ma) to:
1. Install a separate version of Ruby that does not interfere with the one that came with your Mac.
2. Update your PATH such that the location of the new Ruby version is first in the PATH.


### What should reviewers focus on?


### The impact of these changes
New features available :) 

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

...

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
