### PR TITLE
Default building number required to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-- nil
+- Fix for building_number_required to default to false [#48]
 
 ---
 

--- a/lib/worldwide/regions_loader.rb
+++ b/lib/worldwide/regions_loader.rb
@@ -89,7 +89,7 @@ module Worldwide
     end
 
     def apply_territory_attributes(region, spec)
-      region.building_number_required = spec["building_number_required"] || true
+      region.building_number_required = spec["building_number_required"] || false
       region.building_number_may_be_in_address2 = spec["building_number_may_be_in_address2"] || false
       currency_code = spec["currency"]
       region.code_alternates = spec["code_alternates"] || []

--- a/test/worldwide/region_test.rb
+++ b/test/worldwide/region_test.rb
@@ -308,5 +308,17 @@ module Worldwide
         assert_equal expected_alternates, Worldwide.region(code: region_code).zone(code: zone_code).name_alternates
       end
     end
+
+    test "building_number_requrired returns values as expected" do
+      [
+        [:ca, true],
+        [:in, false],
+        [:pk, false],
+        [:de, true],
+        [:us, true],
+      ].each do |region_code, expected_value|
+        assert_equal expected_value, Worldwide.region(code: region_code).building_number_required
+      end
+    end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

There is a bug in our building_number_required logic where the default to `false` is inconsistent in one place in the code. This is resulting in certain regions claiming to require building number when they do not.

### What approach did you choose and why?

Fix the offending code to default `building_number_required` to false when unset.

### What should reviewers focus on?
<!--
Outline anything you'd like reviewers to pay extra attention to. List open questions for discussion.
-->

...

### The impact of these changes

`IN` and `PK` among others should no longer require building number.

### Testing

Unit tests have been added.

<img width="506" alt="image" src="https://github.com/Shopify/worldwide/assets/107632104/d53dd7f6-3c84-4257-87e0-99e38ff63cff">


### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
