### PR TITLE
Release 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- nil
+
+---
+
+[0.6.1] - 2023-12-11
+
 - Allow building number in address2 for DK [#53](https://github.com/Shopify/worldwide/pull/53)
 - Avoid .present? and .blank? so we don't require Rails [#57](https://github.com/Shopify/worldwide/pull/57)
 - (bugfix) Zone lookup by name [#58](https://github.com/Shopify/worldwid/pull/58)
-
----
 
 [0.6.0] - 2023-12-08
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (0.6.0)
+    worldwide (0.6.1)
       activesupport (~> 7.0)
       i18n (~> 1.12.0)
       phonelib (~> 0.8)

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "0.6.0"
+  VERSION = "0.6.1"
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Release 0.6.1 with these fixes and minor changes

- Allow building number in address2 for DK [#53](https://github.com/Shopify/worldwide/pull/53)
- Avoid .present? and .blank? so we don't require Rails [#57](https://github.com/Shopify/worldwide/pull/57)
- (bugfix) Zone lookup by name [#58](https://github.com/Shopify/worldwid/pull/58)

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
