### PR TITLE
Configured Belgium to allow building number in address2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-- Update Singapore GST in preparation for January 1 2024 increase [#68](https://github.com/Shopify/worldwide/pull/68)
-
 ---
+
+[0.6.4] - 2024-01-22
+
+- Allow building number in address2 for BE [#70](https://github.com/Shopify/worldwide/pull/70)
+- Update Singapore GST in preparation for January 1 2024 increase [#68](https://github.com/Shopify/worldwide/pull/68)
 
 [0.6.3] - 2023-12-11
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (0.6.3)
+    worldwide (0.6.4)
       activesupport (~> 7.0)
       i18n (~> 1.12.0)
       phonelib (~> 0.8)

--- a/db/data/regions/BE.yml
+++ b/db/data/regions/BE.yml
@@ -14,6 +14,7 @@ tags:
 - EU-member
 phone_number_prefix: 32
 building_number_required: true
+building_number_may_be_in_address2: true
 week_start_day: monday
 languages:
   - de

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "0.6.3"
+  VERSION = "0.6.4"
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Found roughly 20% of addresses in checkout for Belgium have building numbers added in `address2`. This PR changes the config to allow/expect building number, unit number data in address2

### What approach did you choose and why?

- Updated the config for BE

### What should reviewers focus on?
Official recommendations for writing addresses for BE states that building number is recommended in address line 1 itself. However we see several instances wherein it is entered in address2. Will this have an impact in checkout or any other systems in any way ?

### The impact of these changes
Should not have an impact on other existing systems 

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
