### PR TITLE
Allow building numbers on address2 field for Polish addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- Allow building numbers on address2 field for Polish addresses [#71](https://github.com/Shopify/worldwide/pull/71)
+
 ---
 
 [0.6.4] - 2024-01-22

--- a/db/data/regions/PL.yml
+++ b/db/data/regions/PL.yml
@@ -17,6 +17,7 @@ group: European Countries
 group_name: Europe
 phone_number_prefix: 48
 building_number_required: true
+building_number_may_be_in_address2: true
 week_start_day: monday
 format:
   address1: "{street} {building_num}"


### PR DESCRIPTION
### What are you trying to accomplish?
After sampling 200 Polish addresses at checkout, I counted 54 cases where the street name is on address1 and the building number (or building + unit) is on address2. Most of these addresses were otherwise valid.

Our internal address validation system similarly shows that 40% of all addresses shipping to Poland lacked a number on address line 1.

I think we should recognize this addressing pattern as valid for Poland, and set `building_number_may_be_in_address2` to `true` in the region definition.

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
