### PR TITLE
Add XK and AN to continental grouping

### DIFF
--- a/db/data/world.yml
+++ b/db/data/world.yml
@@ -78,6 +78,7 @@
       '029': # Caribbean
         - AI # Anguilla
         - AG # Antigua and Barbuda
+        - AN # Netherlands Antilles
         - AW # Aruba
         - BS # Bahamas
         - BB # Barbados
@@ -240,6 +241,7 @@
       - RS # Serbia
       - SI # Slovenia
       - ES # Spain
+      - XK # Kosovo
     '155': # Western Europe
       - AT # Austria
       - BE # Belgium


### PR DESCRIPTION
### What are you trying to accomplish?
Add continent grouping to Kosovo (XK) and Netherlands Antilles (AN)

The `associated_continent` attribute currently returns nil for these. When we translate these regions' continent names in atlas, we fall back to the EN group name. This gives a mixed language experience, even though we have translations for these continents.


### What approach did you choose and why?
I updated the `world.yml` to reflect the geographic positions of these countries, putting AN into the Caribbean, and XK into Southern Europe. This file is meant to reflect the M49 data, but as AN is a deprecated country code, it doesn't appear in the data, and XK is not fully recognised by all of the UN, so I assume that's why it's not there either.


### What should reviewers focus on?
Should this be done another way to avoid overwriting the M49 data?

### The impact of these changes
<!--
Are there any specific impacts from this change that you'd like to call out?
-->

...

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

...

### Checklist

* [ ] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
