### PR TITLE
Patch some territory names (BQ, NL, TF, TR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-nil.
+- Patch some territory names (BQ, NL, TF, TR) [#77](https://github.com/Shopify/worldwide/pull/77)
 
 ---
 

--- a/data/cldr/locales/da/territories.yml
+++ b/data/cldr/locales/da/territories.yml
@@ -62,7 +62,7 @@ da:
     BM: Bermuda
     BN: Brunei
     BO: Bolivia
-    BQ: De tidligere Nederlandske Antiller
+    BQ: Caribisk Nederlandene
     BR: Brasilien
     BS: Bahamas
     BT: Bhutan
@@ -204,7 +204,7 @@ da:
     NF: Norfolk Island
     NG: Nigeria
     NI: Nicaragua
-    NL: Holland
+    NL: Holland (Nederlandene)
     'NO': Norge
     NP: Nepal
     NR: Nauru
@@ -256,7 +256,7 @@ da:
     TA: Tristan da Cunha
     TC: Turks- og Caicosøerne
     TD: Tchad
-    TF: De Franske Besiddelser i Det Sydlige Indiske Ocean og Antarktis
+    TF: Franske sydlige territorier
     TG: Togo
     TH: Thailand
     TJ: Tadsjikistan

--- a/data/cldr/locales/de/territories.yml
+++ b/data/cldr/locales/de/territories.yml
@@ -256,7 +256,7 @@ de:
     TA: Tristan da Cunha
     TC: Turks- und Caicosinseln
     TD: Tschad
-    TF: Französische Süd- und Antarktisgebiete
+    TF: Französische Südgebiete
     TG: Togo
     TH: Thailand
     TJ: Tadschikistan

--- a/data/cldr/locales/en/territories.yml
+++ b/data/cldr/locales/en/territories.yml
@@ -265,7 +265,7 @@ en:
     TM: Turkmenistan
     TN: Tunisia
     TO: Tonga
-    TR: Turkey
+    TR: Türkiye
     TT: Trinidad & Tobago
     TV: Tuvalu
     TW: Taiwan

--- a/rake/cldr/patch.rb
+++ b/rake/cldr/patch.rb
@@ -530,6 +530,26 @@ module Worldwide
             [:MO, "ম্যাকাও এসএআর চীনা চীনা (ম্যাকাও এসএআর চীনা) চীনা (ঐতিহ্যবাহী, ম্যাকাও এসএআর চীনা) অঞ্চল: ম্যাকাও এসএআর চীন", "ম্যাকাও এসএআর চীনা"],
           ])
 
+          patch_territories(:da, [
+            # "De tidligere Nederlandske Antiller" means "the former Netherlands Antilles", which is country code AN
+            [:BQ, "De tidligere Nederlandske Antiller", "Caribisk Nederlandene"],
+            # (North and South) Holland are two of the many provinces in NL; the whole country is the Netherlands
+            [:NL, "Holland", "Holland (Nederlandene)"],
+            # This name is technically correct, but overly long
+            [:TF, "De Franske Besiddelser i Det Sydlige Indiske Ocean og Antarktis", "Franske sydlige territorier"],
+          ])
+
+          patch_territories(:de, [
+            # This name is correct, but overly long
+            [:TF, "Französische Süd- und Antarktisgebiete", "Französische Südgebiete"],
+          ])
+
+          patch_territories(:en, [
+            # The U.N. now uses Türkiye for the country formerly recognized as Turkey:
+            # https://turkiye.un.org/en/184798-turkeys-name-changed-t%C3%BCrkiye
+            [:TR, "Turkey", "Türkiye"],
+          ])
+
           # CLDR changed the name to Latin characters
           patch_territories(:mr, [
             [:CI, "Côte d’Ivoire", "आयव्हरी कोस्ट"],

--- a/test/worldwide/region_data_consistency_test.rb
+++ b/test/worldwide/region_data_consistency_test.rb
@@ -142,5 +142,11 @@ module Worldwide
         end
       end
     end
+
+    test "TR uses the new English name Türkiye" do
+      I18n.with_locale(:en) do
+        assert_equal "Türkiye", Worldwide.region(code: "TR").full_name
+      end
+    end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Patch some names in the CLDR data that don't seem quite right.

 - BQ (Bonaire, Sint Eustatius and Saba) was formerly part of the Netherlands Antilles (AN), but AN was dissolved in 2010. BQ may be referred to as the Caribbean Netherlands.
 - NL is the country of the Netherlands, which includes (North and South) Holland as two of its many provinces.  We should make sure that the country name reflects the fact that we're referring to the country, not just to a province.
 - TF's names in Danish and German is a bit too long when compared to other country names, so we are shortening it.
 - TR has changed its official English-language name, as recognized by the UN.

### What approach did you choose and why?

These changes are applied in the `cldr:data:patch` rake task, so that they will get re-applied when we upgrade to a newer version of CLDR.

### The impact of these changes

`Worldwide::Region.full_name` will report different values for
 - BQ, NL, and TF in Danish
 - TF in German
 - TR in English

### Testing

```ruby
irb(main):008:0> %w(da de en).each {|locale| I18n.with_locale(locale){puts %w(BQ NL TF TR).map{|cc| [locale, cc, Worldwi
de.region(code: cc).full_name]}.join(",")}}
da,BQ,Caribisk Nederlandene,da,NL,Holland (Nederlandene),da,TF,Franske sydlige territorier,da,TR,Tyrkiet
de,BQ,Karibische Niederlande,de,NL,Niederlande,de,TF,Französische Südgebiete,de,TR,Türkei
en,BQ,Caribbean Netherlands,en,NL,Netherlands,en,TF,French Southern Territories,en,TR,Türkiye
=> ["da", "de", "en"]
```

(Also added a unit test to guard against regression of the `Türkiye` change).

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
