### PR TITLE
Bump to version 0.6.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-- Prefer "SAR" over "SAR China" in Chinese-language names for regions `HK` and `MO`. [#79](https://github.com/Shopify/worldwide/pull/79).
-- Add Worldwide::Field.valid_key? method. [#80](https://github.com/Shopify/worldwide/pull/80)
+nil.
 
 ---
+
+[0.6.8] - 2024-01-31
+
+- Prefer "SAR" over "SAR China" in Chinese-language names for regions `HK` and `MO`. [#79](https://github.com/Shopify/worldwide/pull/79).
+- Add Worldwide::Field.valid_key? method. [#80](https://github.com/Shopify/worldwide/pull/80)
 
 [0.6.7] - 2024-01-30
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (0.6.7)
+    worldwide (0.6.8)
       activesupport (~> 7.0)
       i18n
       phonelib (~> 0.8)

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "0.6.7"
+  VERSION = "0.6.8"
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Changes:
- Prefer "SAR" over "SAR China" in Chinese-language names for regions `HK` and `MO`. [#79](https://github.com/Shopify/worldwide/pull/79).
- Add Worldwide::Field.valid_key? method. [#80](https://github.com/Shopify/worldwide/pull/80)

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
