### PR TITLE
support field lookup when there is no country code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-nil.
+- Support address field lookup when there is no country code. [#82](https://github.com/Shopify/worldwide/pull/82)
 
 ---
 

--- a/lib/worldwide/field.rb
+++ b/lib/worldwide/field.rb
@@ -26,8 +26,8 @@ module Worldwide
       end
     end
 
-    def initialize(country_code:, field_key:)
-      @country_code = country_code.upcase.to_sym
+    def initialize(country_code: nil, field_key:)
+      @country_code = country_code&.upcase&.to_sym
       @field_key = field_key.downcase.to_sym
     end
 
@@ -65,8 +65,12 @@ module Worldwide
 
     def lookup(key_suffix, locale:, options: {})
       I18n.with_locale(locale) do
-        I18n.t("#{base_key(@country_code)}.#{key_suffix}", default: nil, **options) ||
+        if @country_code.nil?
           default_lookup(key_suffix, options: options)
+        else
+          I18n.t("#{base_key(@country_code)}.#{key_suffix}", default: nil, **options) ||
+            default_lookup(key_suffix, options: options)
+        end
       end
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

This PR adds functionality that supports looking up address fields when there is no country_code

...

### Testing

<img width="704" alt="Screenshot 2024-01-31 at 1 25 29 PM" src="https://github.com/Shopify/worldwide/assets/8383726/b1bd6422-8fbe-4a80-a8fa-6d4b5aa66e58">

...

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
