### PR TITLE
Patch a name for CQ (Sark)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-- Nil.
+- Patch in a name for CQ (Sark). [#84](https://github.com/Shopify/worldwide/pull/84)
 
 [0.7.0] - 2024-01-31
 

--- a/data/cldr/locales/en/territories.yml
+++ b/data/cldr/locales/en/territories.yml
@@ -83,6 +83,7 @@ en:
     CN: China
     CO: Colombia
     CP: Clipperton Island
+    CQ: Sark
     CR: Costa Rica
     CU: Cuba
     CV: Cape Verde

--- a/data/cldr/locales/fr/territories.yml
+++ b/data/cldr/locales/fr/territories.yml
@@ -83,6 +83,7 @@ fr:
     CN: Chine
     CO: Colombie
     CP: Île Clipperton
+    CQ: Sercq
     CR: Costa Rica
     CU: Cuba
     CV: Cap-Vert

--- a/rake/cldr/patch.rb
+++ b/rake/cldr/patch.rb
@@ -545,9 +545,16 @@ module Worldwide
           ])
 
           patch_territories(:en, [
+            # CLDR added Sark in version 44.  We need to backport this until we upgrade to that version.
+            [:CQ, nil, "Sark"],
             # The U.N. now uses Türkiye for the country formerly recognized as Turkey:
             # https://turkiye.un.org/en/184798-turkeys-name-changed-t%C3%BCrkiye
             [:TR, "Turkey", "Türkiye"],
+          ])
+
+          patch_territories(:fr, [
+            # CLDR added Sark in version 44.  We need to backport this until we upgrade to that version.
+            [:CQ, nil, "Sercq"],
           ])
 
           # CLDR changed the name to Latin characters

--- a/test/worldwide/region_data_consistency_test.rb
+++ b/test/worldwide/region_data_consistency_test.rb
@@ -143,6 +143,15 @@ module Worldwide
       end
     end
 
+    test "CQ has a name" do
+      I18n.with_locale(:en) do
+        assert_equal "Sark", Worldwide.region(code: "CQ").full_name
+      end
+      I18n.with_locale(:fr) do
+        assert_equal "Sercq", Worldwide.region(code: "CQ").full_name
+      end
+    end
+
     test "TR uses the new English name Türkiye" do
       I18n.with_locale(:en) do
         assert_equal "Türkiye", Worldwide.region(code: "TR").full_name


### PR DESCRIPTION
### What are you trying to accomplish?

Unicode CLDR added support for CQ (Sark) in v44.
We're currently based on Unicode CLDR v41.
In the long run, we need to upgrade to a more recent CLDR, but that's going to take some time.

In the interim, patch a value for CQ so that it has a name.

Before:

```ruby
shopify(dev)> Worldwide.region(code: "CQ").full_name
=> nil
```

After:

```ruby
irb(main):001:0> Worldwide.region(code: "CQ").full_name
=> "Sark"
```

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
