### PR TITLE
Patch data related to 830 (Channel Islands)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 - Patch in a name for CQ (Sark). [#84](https://github.com/Shopify/worldwide/pull/84)
+- Patch data related to region 830 (Channel Islands). [#85](https://github.com/Shopify/worldwide/pull/85)
 
 [0.7.0] - 2024-01-31
 

--- a/data/cldr/locales/en/territories.yml
+++ b/data/cldr/locales/en/territories.yml
@@ -32,6 +32,7 @@ en:
     '155': Western Europe
     '202': Sub-Saharan Africa
     '419': Latin America
+    '830': Channel Islands
     AC: Ascension Island
     AD: Andorra
     AE: United Arab Emirates

--- a/data/cldr/locales/fr/territories.yml
+++ b/data/cldr/locales/fr/territories.yml
@@ -32,6 +32,7 @@ fr:
     '155': Europe de l’Ouest
     '202': Afrique subsaharienne
     '419': Amérique latine
+    '830': Îles Anglo-Normandes
     AC: Île de l’Ascension
     AD: Andorre
     AE: Émirats arabes unis

--- a/db/data/world.yml
+++ b/db/data/world.yml
@@ -298,7 +298,7 @@ alternates:
       - TF # French Southern Territories (also filed under 014 Eastern Africa and under FR France)
   '154': # Northern Europe
     '830': # Channel Islands
-      - GY # Guernsey
+      - GG # Guernsey
       - JE # Jersey
       - CQ # Sark
   AU: # Australia

--- a/rake/cldr/patch.rb
+++ b/rake/cldr/patch.rb
@@ -545,6 +545,9 @@ module Worldwide
           ])
 
           patch_territories(:en, [
+            # UN M49 uses 830 for "Channel Islands", but ISO 3166-1 does not, so CLDR is missing this code
+            # https://en.wikipedia.org/wiki/UN_M49#cite_note-7
+            [:"830", nil, "Channel Islands"],
             # CLDR added Sark in version 44.  We need to backport this until we upgrade to that version.
             [:CQ, nil, "Sark"],
             # The U.N. now uses Türkiye for the country formerly recognized as Turkey:
@@ -553,6 +556,9 @@ module Worldwide
           ])
 
           patch_territories(:fr, [
+            # UN M49 uses 830 for "Channel Islands", but ISO 3166-1 does not, so CLDR is missing this code
+            # https://en.wikipedia.org/wiki/UN_M49#cite_note-7
+            [:"830", nil, "Îles Anglo-Normandes"],
             # CLDR added Sark in version 44.  We need to backport this until we upgrade to that version.
             [:CQ, nil, "Sercq"],
           ])


### PR DESCRIPTION
### What are you trying to accomplish?

This change fixes two problems.

First, the country code for Guernsey is GG.
GY is the postcode area for Guernsey, but country code GY is Guyana.

Second, the designation of numeric-three code 830 for the geographic area of the Channel Islands is used by the UN (M49), but not by ISO 3166-1, and not by CLDR.  Thus, we are missing name translations for code 830 and need to patch them in to avoid having a `nil` name value.

### Testing

Before:

```ruby
shopify(dev)> Worldwide.region(code: "830").full_name
=> nil
shopify(dev)> Worldwide.region(code: "830").zones.map(&:iso_code)
=> ["GY", "JE", "CQ"]
```

After:

```ruby
irb(main):002:0> Worldwide.region(code: "830").full_name
=> "Channel Islands"
irb(main):003:0> Worldwide.region(code: "830").zones.map(&:iso_code)
=> ["GG", "JE", "CQ"]
```

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
