### PR TITLE
Patch name of SZ (eSwatini) in Italian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Patch in a name for CQ (Sark). [#84](https://github.com/Shopify/worldwide/pull/84)
 - Patch data related to region 830 (Channel Islands). [#85](https://github.com/Shopify/worldwide/pull/85)
+- Patch name of SZ (eSwatini) in Italian. [#86](https://github.com/Shopify/worldwide/pull/86)
 
 [0.7.0] - 2024-01-31
 

--- a/data/cldr/locales/it/territories.yml
+++ b/data/cldr/locales/it/territories.yml
@@ -252,7 +252,7 @@ it:
     SV: El Salvador
     SX: Sint Maarten
     SY: Siria
-    SZ: Swaziland
+    SZ: eSwatini
     TA: Tristan da Cunha
     TC: Isole Turks e Caicos
     TD: Ciad

--- a/rake/cldr/patch.rb
+++ b/rake/cldr/patch.rb
@@ -563,6 +563,11 @@ module Worldwide
             [:CQ, nil, "Sercq"],
           ])
 
+          patch_territories(:it, [
+            # Swaziland changed its name to eSwatini in 2018
+            [:SZ, "Swaziland", "eSwatini"],
+          ])
+
           # CLDR changed the name to Latin characters
           patch_territories(:mr, [
             [:CI, "Côte d’Ivoire", "आयव्हरी कोस्ट"],


### PR DESCRIPTION
### What are you trying to accomplish?

Swaziland changed its name to eSwatini in 2018.
http://www.times.co.sz/news/118373-kingdom-of-eswatini-change-now-official.html

### What approach did you choose and why?
Patch using our rake task, so that the change will be re-applied when we upgrade to a newer version of CLDR.

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
