### PR TITLE
Patch name of GB in Suomi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Patch data related to region 830 (Channel Islands). [#85](https://github.com/Shopify/worldwide/pull/85)
 - Patch name of SZ (eSwatini) in Italian. [#86](https://github.com/Shopify/worldwide/pull/86)
 - Patch names of HK and MO in zh-TW and zh-Hant. [#87](https://github.com/Shopify/worldwide/pull/87)
+- Patch name of GB (United Kingdom) in Suomi. [#88](https://github.com/Shopify/worldwide/pull/88)
 
 [0.7.0] - 2024-01-31
 

--- a/data/cldr/locales/fi/territories.yml
+++ b/data/cldr/locales/fi/territories.yml
@@ -114,7 +114,7 @@ fi:
     FO: Färsaaret
     FR: Ranska
     GA: Gabon
-    GB: Iso-Britannia
+    GB: Yhdistynyt kuningaskunta
     GD: Grenada
     GE: Georgia
     GF: Ranskan Guayana

--- a/rake/cldr/patch.rb
+++ b/rake/cldr/patch.rb
@@ -555,6 +555,12 @@ module Worldwide
             [:TR, "Turkey", "Türkiye"],
           ])
 
+          patch_territories(:fi, [
+            # GB is the ISO code for the United Kingdom of Great Britain _and_ Northern Ireland
+            # (Northern Ireland is part of the United Kingdom, but not part of Great Britain).
+            [:GB, "Iso-Britannia", "Yhdistynyt kuningaskunta"],
+          ])
+
           patch_territories(:fr, [
             # UN M49 uses 830 for "Channel Islands", but ISO 3166-1 does not, so CLDR is missing this code
             # https://en.wikipedia.org/wiki/UN_M49#cite_note-7


### PR DESCRIPTION
### What are you trying to accomplish?

The ISO country code GB refers to the United Kingdom of Great Britain and Northern Ireland.  (Northern Ireland is part of the United Kingdom, but not part of Great Britain).  Thus, "Iso-Britania" ("Great Britain") is not a good translated name for GB; "Yhdistynyt kuningaskunta" ("United Kingdom") is better.

### What approach did you choose and why?
Patch in our rake task, so that it'll get re-applied upon CLDR version upgrade.

### Testing

Before:
```ruby
irb(main):003:0> I18n.with_locale(:fi){Worldwide.region(code: :GB).full_name}
=> "Iso-Britannia"
```

After:

```ruby
irb(main):004:0> I18n.with_locale(:fi){Worldwide.region(code: :GB).full_name}
=> "Yhdistynyt kuningaskunta"
```

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
