### PR TITLE
Bump to v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+Nil.
+
+---
+
+[0.7.1] - 2024-02-01
+
 - Patch in a name for CQ (Sark). [#84](https://github.com/Shopify/worldwide/pull/84)
 - Patch data related to region 830 (Channel Islands). [#85](https://github.com/Shopify/worldwide/pull/85)
 - Patch name of SZ (eSwatini) in Italian. [#86](https://github.com/Shopify/worldwide/pull/86)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (0.7.0)
+    worldwide (0.7.1)
       activesupport (~> 7.0)
       i18n
       phonelib (~> 0.8)

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "0.7.0"
+  VERSION = "0.7.1"
 end


### PR DESCRIPTION
### What are you trying to accomplish?
Release a new version of the gem.

Changes since 0.7.0:
- Patch in a name for CQ (Sark). [#84](https://github.com/Shopify/worldwide/pull/84)
- Patch data related to region 830 (Channel Islands). [#85](https://github.com/Shopify/worldwide/pull/85)
- Patch name of SZ (eSwatini) in Italian. [#86](https://github.com/Shopify/worldwide/pull/86)
- Patch names of HK and MO in zh-TW and zh-Hant. [#87](https://github.com/Shopify/worldwide/pull/87)
- Patch name of GB (United Kingdom) in Suomi. [#88](https://github.com/Shopify/worldwide/pull/88)

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
