### PR TITLE
Allow turning off locale expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-Nil.
+- Allow override to prevent locale expansion during `configure_i18n`. [#90](https://github.com/Shopify/worldwide/pull/90)
 
 ---
 

--- a/lib/worldwide/config.rb
+++ b/lib/worldwide/config.rb
@@ -19,7 +19,7 @@ module Worldwide
     ].freeze
 
     class << self
-      def configure_i18n(i18n_config: nil, additional_components: [])
+      def configure_i18n(i18n_config: nil, additional_components: [], expand_locales: true)
         i18n_config ||= I18n.config
 
         I18n::Backend::Simple.include(
@@ -40,7 +40,9 @@ module Worldwide
         set_unless_explicitly_set(i18n_config, :default_locale, :en)
         set_unless_explicitly_set(i18n_config, :exception_handler, exception_handler)
 
-        i18n_config.available_locales = expanded_locales_from_configuration(i18n_config)
+        if expand_locales
+          i18n_config.available_locales = expanded_locales_from_configuration(i18n_config)
+        end
 
         add_cldr_data(i18n_config, additional_components: additional_components)
         add_other_data(i18n_config)

--- a/test/worldwide/config_test.rb
+++ b/test/worldwide/config_test.rb
@@ -61,6 +61,15 @@ module Worldwide
       end
     end
 
+    test "#configure_i18n does not expand locales when expand_locales: false is passed" do
+      config = Worldwide::RubyI18nConfig.new
+      config.available_locales = [:en, :fr]
+
+      Worldwide::Config.configure_i18n(i18n_config: config, expand_locales: false)
+
+      assert_equal [:en, :fr], config.available_locales
+    end
+
     test "#configure consults parent_locales.yml when determining derivatives of locales" do
       config = Worldwide::RubyI18nConfig.new
       config.available_locales = [:"en-001"]


### PR DESCRIPTION
### What are you trying to accomplish?

By default, Worldwide::Config.configure_i18n will expand a locale (e.g. `:fr`) to include support for its derivative locales (e.g. `:'fr-CA'`).  Some calllers may not want this, because it will expand the RAM footprint significantly by adding locales that they may not care about, e.g. `:'en-US-POSIX'` if `:en` is given.  

### What approach did you choose and why?
This change adds an optional flag that can be used to deactivate locale expansion.

### The impact of these changes
None, unless the optional parameter `expand_locales: false` is passed to `Worldwide::Config.configure_i18n`.

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
