### PR TITLE
bump to v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+Nil.
+
+---
+
+[0.8.0] - 2024-02-02
+
 - Add translations for address fields with mathematical symbols errors. [#92](https://github.com/Shopify/worldwide/pull/92)
 - Enable lookup of Region by alternate name. [#93](https://github.com/Shopify/worldwide/93)
 - Allow lookup of EU region using alternate code QUU. [#94](http://github.com/Shopify/worldwide/pull/94)
-
----
 
 [0.7.1] - 2024-02-01
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (0.7.1)
+    worldwide (0.8.0)
       activesupport (~> 7.0)
       i18n
       phonelib (~> 0.8)

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "0.7.1"
+  VERSION = "0.8.0"
 end


### PR DESCRIPTION
### What are you trying to accomplish?
Release a new version of the gem.

Changes since 0.7.1:
- Add translations for address fields with mathematical symbols errors. [#92](https://github.com/Shopify/worldwide/pull/92)
- Enable lookup of Region by alternate name. [#93](https://github.com/Shopify/worldwide/93)
- Allow lookup of EU region using alternate code QUU. [#94](http://github.com/Shopify/worldwide/pull/94)

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
