### PR TITLE
bump to v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-- Add Thai to the list of scripts identified by `Worldwide::Scripts.identify`. [#96](https://github.com/Shopify/worldwide/pull/96)
-- Add translations for address fields with invalid province errors. [#97](https://github.com/Shopify/worldwide/pull/97)
+Nil.
 
 ---
+
+[0.9.0] - 2024-02-05
+
+- Add Thai to the list of scripts identified by `Worldwide::Scripts.identify`. [#96](https://github.com/Shopify/worldwide/pull/96)
+- Add translations for address fields with invalid province errors. [#97](https://github.com/Shopify/worldwide/pull/97)
 
 [0.8.0] - 2024-02-02
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (0.8.0)
+    worldwide (0.9.0)
       activesupport (~> 7.0)
       i18n
       phonelib (~> 0.8)
@@ -62,7 +62,7 @@ GEM
     parallel (1.22.1)
     parser (3.2.0.0)
       ast (~> 2.4.1)
-    phonelib (0.8.3)
+    phonelib (0.8.7)
     prettier_print (1.2.0)
     psych (5.1.0)
       stringio

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "0.8.0"
+  VERSION = "0.9.0"
 end


### PR DESCRIPTION
### What are you trying to accomplish?
Release a new version of the gem.

Changes since 0.8.0:
- Add Thai to the list of scripts identified by `Worldwide::Scripts.identify`. [#96](https://github.com/Shopify/worldwide/pull/96)
- Add translations for address fields with invalid province errors. [#97](https://github.com/Shopify/worldwide/pull/97)

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
