### PR TITLE
Building number may be in address2 for SG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-- Nil.
+- Singapore, building number may be in address2 [#108](https://github.com/Shopify/worldwide/pull/108)
 
 ---
 

--- a/db/data/regions/SG.yml
+++ b/db/data/regions/SG.yml
@@ -11,6 +11,7 @@ zip_regex: "^\\d{6}$"
 zip_example: '546080'
 phone_number_prefix: 65
 building_number_required: true
+building_number_may_be_in_address2: true
 week_start_day: sunday
 autofill_city_enabled: true
 languages:


### PR DESCRIPTION
### What are you trying to accomplish?
<!--
Link to an issue or provide enough context so that someone new can understand the 'why' behind this change.
-->

* For Addresses, users atypically will enter the building number in Address2. We should account for this in Singapore's YAML file.

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
