### PR TITLE
Return early if country_code is nil `Zip.normalize`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-- Nil.
+- Return early if country_code is nil Zip::Normalize [#110](https://github.com/Shopify/worldwide/pull/110)
 
 ---
 

--- a/lib/worldwide/zip.rb
+++ b/lib/worldwide/zip.rb
@@ -85,6 +85,8 @@ module Worldwide
     def normalize(country_code:, zip:, allow_autofill: true, strip_extraneous_characters: false)
       input = zip # preserve the original zip, in case we need to fall back to it
 
+      return input if country_code.nil?
+
       country = Worldwide.region(code: country_code)
       return zip if country.nil? || NORMALIZATION_DISABLED_COUNTRIES.include?(country.iso_code)
 


### PR DESCRIPTION
### What are you trying to accomplish?
<!--
Link to an issue or provide enough context so that someone new can understand the 'why' behind this change.
-->

* Preserving prior behaviour - Region does not allow for nil country code so we should return early before an exception is thrown.

### What approach did you choose and why?
<!--
There are many ways to solve a problem. How did you approach this problem and why?
-->

* Return if country_code is nil

### What should reviewers focus on?
<!--
Outline anything you'd like reviewers to pay extra attention to. List open questions for discussion.
-->

??

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
