### PR TITLE
Remove name translations from `translations.yml`

### DIFF
--- a/translation.yml
+++ b/translation.yml
@@ -7,5 +7,4 @@ components:
     paths:
       - db/data/regions/*/{{language}}.yml
       - data/other/hand_translated/{{language}}.yml
-      - data/other/names/{{language}}.yml
       - data/other/timezones/{{language}}.yml


### PR DESCRIPTION
### What are you trying to accomplish?
<!--
Link to an issue or provide enough context so that someone new can understand the 'why' behind this change.
-->

* Name translations require editing of interpolation values that translators may not have context on. These should be done manually - and so we're removing this path from `translation.yml`

### Checklist

* [ ] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
