### PR TITLE
Release version 0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- Nil.
+
+---
+
+[0.10.2] - 2024-03-12
+
 - Add translations for address line 1, 2 concern messages [#115](https://github.com/Shopify/worldwide/pull/115), [#116](https://github.com/Shopify/worldwide/pull/116)
 - Make new concern messages more generic for address line 1, 2 [#114](https://github.com/Shopify/worldwide/pull/114)
 - Add localized concern messages when field is unknown for address [#109](https://github.com/Shopify/worldwide/pull/109)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (0.10.1)
+    worldwide (0.10.2)
       activesupport (~> 7.0)
       i18n
       phonelib (~> 0.8)

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "0.10.1"
+  VERSION = "0.10.2"
 end


### PR DESCRIPTION
### What are you trying to accomplish?
Release new version with the following changes: 
- Add translations for address line 1, 2 concern messages [#115](https://github.com/Shopify/worldwide/pull/115), [#116](https://github.com/Shopify/worldwide/pull/116)
- Make new concern messages more generic for address line 1, 2 [#114](https://github.com/Shopify/worldwide/pull/114)
- Add localized concern messages when field is unknown for address [#109](https://github.com/Shopify/worldwide/pull/109)

### What approach did you choose and why?

```
Manually adjust version in version.rb
Bundle lock
Manually update changelog
```


### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
