### PR TITLE
Fix broken CLDR rake tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 - Add regional language for zip_unknown_for_address, province_unknown_for_address. Remove error message for zip_unknown_for_street_and_city [#121](https://github.com/Shopify/worldwide/pull/121)
+- Fix broken CLDR `import`/`patch`/`generate` rake tasks [#119](https://github.com/Shopify/worldwide/pull/119)
 
 ---
 

--- a/lib/worldwide/locale.rb
+++ b/lib/worldwide/locale.rb
@@ -155,7 +155,7 @@ module Worldwide
       return if parts.size <= 1
 
       region_code = parts.last
-      return if region_code.blank?
+      return if Util.blank?(region_code)
 
       region = Worldwide::Cldr.t(region_code, scope: :territories, default: nil)
       region = region.nil? ? region_code : Worldwide::Cldr::ContextTransforms.transform(region, :territory, :start_of_sentence)

--- a/lib/worldwide/numbers.rb
+++ b/lib/worldwide/numbers.rb
@@ -92,10 +92,10 @@ module Worldwide
 
       result = number.reverse.scan(/.{1,4}/).zip(JAPAN_MYRIAD_UNITS).map do |segment, unit|
         segment.gsub!(/0*$/, "")
-        segment.blank? ? "" : (unit + segment)
+        Util.blank?(segment) ? "" : (unit + segment)
       end.join.reverse
 
-      result = "0" if result.blank?
+      result = "0" if Util.blank?(result)
       result = "#{result}#{decimal_marker}#{decimal}" if decimal
 
       result

--- a/rake/cldr/locale_generator.rb
+++ b/rake/cldr/locale_generator.rb
@@ -19,20 +19,18 @@ module Worldwide
         initialize_i18n
 
         generate_plural_keys_lookup
+        sort_cldr_files
 
-        initialize_i18n # We need to re-initialize i18n to load the new data for the next step
+        initialize_i18n
 
         # CLDR is missing pluralization keys in some cases
         # We fill in the holes by copying from the existing values
         # based on the premise that having poor grammar is better than falling back
         # to a different language.
         expand_cldr_to_cover_missing_plurals
-
-        # Sort the expanded files.
-        # Ideally, plural key expansion would be done in rake/cldr/patch.rb
-        # However, it depends on `generate_plural_keys_lookup` being run, which belongs in this file
-        # So instead, we just sort the files again.
         sort_cldr_files
+
+        initialize_i18n
 
         Worldwide::Locales.map(&:to_s).each do |locale|
           puts "Generating date/time formats for locale '#{locale}'..."
@@ -44,7 +42,7 @@ module Worldwide
         # Expand the keys to cover all the keys needed for the language.
         expand_output_to_cover_missing_plurals
 
-        initialize_i18n # We need to re-initialize i18n to load the new data for the next step
+        initialize_i18n
 
         generate_format_documentation
       end

--- a/rake/cldr/patch.rb
+++ b/rake/cldr/patch.rb
@@ -588,10 +588,6 @@ module Worldwide
             [:HK, "中國香港特別行政區", "香港特別行政區"],
             [:MO, "中國澳門特別行政區", "澳門特別行政區"],
           ])
-          patch_territories(:"zh-TW", [
-            [:HK, "中國香港特別行政區", "香港特別行政區"],
-            [:MO, "中國澳門特別行政區", "澳門特別行政區"],
-          ])
 
           # Should use capitalized letters for territories in UI list context, by default.
           # https://github.com/Shopify/shopify-i18n/issues/1551

--- a/rake/cldr/patch.rb
+++ b/rake/cldr/patch.rb
@@ -690,7 +690,7 @@ module Worldwide
 
         def sort_cldr_files
           puts("🔀 Sorting the keys in the patched files")
-          files_changed = Dir.glob(File.join(["data", "cldr", "**", "*.yml"])).sum do |filepath|
+          Dir.glob(File.join(["data", "cldr", "**", "*.yml"])).sum do |filepath|
             next 0 if filepath.start_with?("data/cldr/transforms")
             next 0 if filepath.start_with?("data/cldr/metazones.yml")
 
@@ -702,7 +702,6 @@ module Worldwide
             file_changed = SortYaml.sort_file(filepath, output_filename: filepath)
             file_changed ? 1 : 0
           end
-          raise NotNeededError, "Sorting the CLDR files made no changes." if files_changed == 0
         end
 
         # How one refers to Macau and Hong Kong is contentious

--- a/rake/cldr/patch.rb
+++ b/rake/cldr/patch.rb
@@ -810,7 +810,7 @@ module Worldwide
           source_content = File.read(file_path)
           flattened = FlattenHash.run(YAML.safe_load(source_content, permitted_classes: [Symbol]))
           filtered = flattened.select { |key, _value| paths_to_keep.any? { |path| path == key[0...path.size] } }
-          if filtered.blank?
+          if Util.blank?(filtered)
             File.delete(file_path)
             return true
           end

--- a/rake/cldr/puller.rb
+++ b/rake/cldr/puller.rb
@@ -45,11 +45,10 @@ module Worldwide
         end
 
         def normalize_components(components)
-          components = components.presence
           components = components.split(",").map(&:strip).map(&:to_sym).sort if components
 
           invalid_selected_components = (components || []) - ::Cldr::Export::Data.components
-          raise ArgumentError, "Requested unknown CLDR components: #{invalid_selected_components}" if invalid_selected_components.present?
+          raise ArgumentError, "Requested unknown CLDR components: #{invalid_selected_components}" if Util.present?(invalid_selected_components)
 
           components ||= DEFAULT_COMPONENTS
 

--- a/rake/tasks/cldr.rake
+++ b/rake/tasks/cldr.rake
@@ -10,6 +10,8 @@ namespace :cldr do
     desc <<~DESCRIPTION
       Cleans up the pre-existing data in preparation for an upgrade to a new version of CLDR.
       Necessary, since some of the files may no longer be needed in the new version.
+
+      eg.: bundle exec rake cldr:data:clean
     DESCRIPTION
     task :clean do
       Worldwide::Cldr::Cleaner.perform
@@ -18,15 +20,17 @@ namespace :cldr do
     desc <<~DESCRIPTION
       Downloads and exports the data from CLDR (http://cldr.unicode.org)
 
+      The `VERSION` environment variable can be used to specify the version of CLDR to download (see the current version
+      in data/cldr/versions.yml).
+
       eg.: Download v40 of CLDR and export all components
-        rake cldr:data:import VERSION=40
+        bundle exec rake cldr:data:import VERSION=40
 
       eg.: Download v40 of CLDR and export the `Units` and `Calendars` components
-        rake cldr:data:import VERSION=40 COMPONENTS=Units,Calendars
+        bundle exec rake cldr:data:import VERSION=40 COMPONENTS=Units,Calendars
 
       eg.: Download the CLDR data from latest commit of https://github.com/unicode-org/cldr-staging and export all components
-        rake cldr:data:import
-
+        bundle exec rake cldr:data:import
     DESCRIPTION
     task :import, :environment do
       version = ENV["VERSION"]
@@ -37,13 +41,21 @@ namespace :cldr do
     desc <<~DESCRIPTION
       Apply Shopify patches to the upstream CLDR data
 
-      rake cldr:data:patch
+      This task depends on the data in `vendor/ruby-cldr`, so you should run `rake cldr:data:import` first.
+
+      eg.: bundle exec rake cldr:data:patch
     DESCRIPTION
     task :patch do
       Worldwide::Cldr::Patch::Patcher.new.perform
     end
 
-    desc "Generate additional data files from the CLDR data."
+    desc <<~DESCRIPTION
+      Generate additional data from the CLDR data, including missing plurals.
+
+      Run this after importing and patching data from CLDR.
+
+      eg.: bundle exec rake cldr:data:generate
+    DESCRIPTION
     task :generate do
       generator = Worldwide::Cldr::LocaleGenerator.new
       generator.perform


### PR DESCRIPTION
The `cldr:data:import` and `cldr:data:patch` rake tasks were broken because this code was moved over from another repo that depended on some Rails convenience methods.

- The first commit in this PR replaces calls to `.present?` and `.blank?` with the corresponding `Util` methods (similar to https://github.com/Shopify/worldwide/pull/57).

- The second commit removes a patch that was raising an exception: `zh-TW` doesn't exist until a few lines below when it's created based on the contents of `zh-Hant`. I could've moved the call to the method that copies that locale up, but instead chose to remove the redundant patch.

- The third commit adds some useful details to the rake task descriptions.

- The fourth commit removes an unnecessary exception from the patch task that causes the task to return a non-zero status if sorting doesn't do anything. No reason for this.

- The fifth commit fixes a bug in the generate task that was creating changes in the generated data files due to generated files not being in the right order. To get files in the right order (right being defined as "the currently committed order") you had to run the rake task twice. This is because the data wasn't being reloaded and resorted everywhere that it should have been.

Note: I'm not 100% sure the committed order actually is the most correct for all files. I don't think all our generated YAML files (let alone the hand-edited ones) are strictly sorted, and they probably should be. That's a task for another day, however.

Now, if you run `cldr:data:import`, `cldr:data:patch`, then `cldr:data:generate`, all three will succeed without creating any changes to the committed data files. This PR was a hell of a lot of work for "nothing" 😉.