### PR TITLE
Regionalize '_unknown_for_address' error strings 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-- Nil.
+- Add regional language for zip_unknown_for_address, province_unknown_for_address. Remove error message for zip_unknown_for_street_and_city [#121](https://github.com/Shopify/worldwide/pull/121)
 
 ---
 

--- a/db/data/regions/CA/en.yml
+++ b/db/data/regions/CA/en.yml
@@ -12,3 +12,5 @@ en:
             unknown_for_city_and_zip: Enter a valid province for %{city}, %{zip}
             unknown_for_city: Select a valid province for %{city}
             unknown_for_zip: Select a valid province for %{zip}
+            unknown_for_address: Province may be incorrect.
+

--- a/db/data/regions/US/en.yml
+++ b/db/data/regions/US/en.yml
@@ -13,6 +13,8 @@ en:
             unknown_for_city_and_zip: Enter a valid state for %{city}, %{zip}
             unknown_for_city: Select a valid state for %{city}
             unknown_for_zip: Select a valid state for %{zip}
+            unknown_for_address: State may be incorrect.
+
         zip:
           label:
             default: ZIP code
@@ -27,3 +29,4 @@ en:
             contains_emojis: The ZIP code cannot contain emojis
             contains_restricted_characters: The ZIP code cannot have restricted characters
             contains_html_tags: The ZIP code value cannot contain HTML tags.
+            unknown_for_address: ZIP code may be incorrect.

--- a/db/data/regions/_default/bg-BG.yml
+++ b/db/data/regions/_default/bg-BG.yml
@@ -171,8 +171,6 @@ bg-BG:
               Въведете нов адрес и опитайте отново.
             unknown_for_province: Въведете валиден пощенски код за %{province}
             invalid_for_province: Въведете валиден пощенски код за %{province}
-            unknown_for_street_and_city: Възможно е пощенският код за %{street}, %{city}
-              да е неправилен
             unknown_for_address: Възможно е пощенският код да е неправилен.
         address:
           errors:

--- a/db/data/regions/_default/cs.yml
+++ b/db/data/regions/_default/cs.yml
@@ -163,8 +163,6 @@ cs:
               adresu a zkuste to znovu.
             unknown_for_province: 'Zadejte platné PSČ pro: %{province}'
             invalid_for_province: 'Zadejte platné PSČ pro: %{province}.'
-            unknown_for_street_and_city: PSČ může být pro ulici %{street} a město
-              %{city} nesprávné.
             unknown_for_address: PSČ může být nesprávné.
         address:
           errors:

--- a/db/data/regions/_default/da.yml
+++ b/db/data/regions/_default/da.yml
@@ -167,8 +167,6 @@ da:
               Angiv en ny adresse, og prøv igen.
             unknown_for_province: Angiv et gyldigt postnummer for %{province}
             invalid_for_province: Angiv et gyldigt postnummer for %{province}
-            unknown_for_street_and_city: Postnummer kan være forkert for %{street},
-              %{city}
             unknown_for_address: Postnummer kan være forkert.
         address:
           errors:

--- a/db/data/regions/_default/de.yml
+++ b/db/data/regions/_default/de.yml
@@ -170,8 +170,6 @@ de:
               Gib eine neue Adresse ein und versuche es erneut.
             unknown_for_province: Eine gültige Postleitzahl für %{province} eingeben
             invalid_for_province: Eine gültige Postleitzahl für %{province} eingeben
-            unknown_for_street_and_city: Postleitzahl stimmt ggf. nicht mit %{street},
-              %{city} überein
             unknown_for_address: Postleitzahl ist ggf. falsch.
         address:
           errors:

--- a/db/data/regions/_default/el.yml
+++ b/db/data/regions/_default/el.yml
@@ -178,8 +178,6 @@ el:
               Εισαγάγετε νέα διεύθυνση και δοκιμάστε ξανά.
             unknown_for_province: Εισαγάγετε έγκυρο ταχυδρομικό κώδικα για %{province}
             invalid_for_province: Εισαγάγετε έγκυρο ταχυδρομικό κώδικα για %{province}
-            unknown_for_street_and_city: Ενδέχεται να υπάρχει λάθος στον ταχυδρομικό
-              κώδικα για την τοποθεσία %{street}, %{city}
             unknown_for_address: Ενδέχεται να υπάρχει λάθος στον ταχυδρομικό κώδικα.
         address:
           errors:

--- a/db/data/regions/_default/en.yml
+++ b/db/data/regions/_default/en.yml
@@ -147,7 +147,6 @@ en:
               new address and try again.
             contains_html_tags: Postal code cannot contain HTML tags.
             unknown_for_province: Enter a valid postal code for %{province}
-            unknown_for_street_and_city: Postal code may be incorrect for %{street}, %{city}
             unknown_for_address: Postal code may be incorrect.
         phone:
           label:

--- a/db/data/regions/_default/es.yml
+++ b/db/data/regions/_default/es.yml
@@ -173,8 +173,6 @@ es:
               nueva dirección e intenta de nuevo.
             unknown_for_province: Introduce un código postal válido para %{province}
             invalid_for_province: Introduce un código postal válido para %{province}.
-            unknown_for_street_and_city: Puede que el código postal para %{street}
-              (%{city}) sea incorrecto.
             unknown_for_address: Puede que el código postal esté incorrecto.
         address:
           errors:

--- a/db/data/regions/_default/fi.yml
+++ b/db/data/regions/_default/fi.yml
@@ -166,8 +166,6 @@ fi:
               ja yritä uudelleen.
             unknown_for_province: Anna kelvollinen postinumero maassa %{province}
             invalid_for_province: Anna kelvollinen postinumero alueelle %{province}
-            unknown_for_street_and_city: 'Postikoodi voi olla väärä seuraaville osoitteen
-              osille: %{street}, %{city}'
             unknown_for_address: Postikoodi voi olla väärä.
         address:
           errors:

--- a/db/data/regions/_default/fr.yml
+++ b/db/data/regions/_default/fr.yml
@@ -173,8 +173,6 @@ fr:
               le moment. Saisissez une nouvelle adresse et réessayez.
             unknown_for_province: Saisissez un code postal valide pour %{province}
             invalid_for_province: Saisissez un code postal valide pour %{province}
-            unknown_for_street_and_city: Le code postal peut être erroné pour %{street},
-              %{city}
             unknown_for_address: Le code postal peut être erroné.
         address:
           errors:

--- a/db/data/regions/_default/hi.yml
+++ b/db/data/regions/_default/hi.yml
@@ -162,8 +162,6 @@ hi:
             contains_restricted_characters: पोस्टल कोड में सिर्फ अक्षर, संख्याएं,
               स्थानीय वर्ण और विशेष वर्ण हो सकते हैं
             invalid_for_province: "%{province} के लिए एक मान्य डाक कोड डालें"
-            unknown_for_street_and_city: "%{street}, %{city} के लिए डाक कोड गलत हो
-              सकता है"
             unknown_for_address: डाक कोड गलत हो सकता है.
         address:
           errors:

--- a/db/data/regions/_default/hr-HR.yml
+++ b/db/data/regions/_default/hr-HR.yml
@@ -173,8 +173,6 @@ hr-HR:
             contains_restricted_characters: Poštanski broj smije sadržavati samo slova,
               brojeve, lokalne znakove i posebne znakove
             invalid_for_province: Unesite valjani poštanski broj za %{province}
-            unknown_for_street_and_city: Možda nije točan poštanski broj za %{street},
-              %{city}
             unknown_for_address: Možda nije točan poštanski broj.
         address:
           errors:

--- a/db/data/regions/_default/hu.yml
+++ b/db/data/regions/_default/hu.yml
@@ -177,8 +177,6 @@ hu:
               helyi karaktereket és különleges karaktereket tartalmazhat
             invalid_for_province: 'Olyan irányítószámot írj be, amely itt található:
               %{province}'
-            unknown_for_street_and_city: Vélhetően nem felel meg az irányítószám a
-              címnek (%{city}, %{street})
             unknown_for_address: Vélhetően helytelen az irányítószám.
         address:
           errors:

--- a/db/data/regions/_default/id.yml
+++ b/db/data/regions/_default/id.yml
@@ -165,8 +165,6 @@ id:
             contains_restricted_characters: Kode pos hanya boleh terdiri dari huruf,
               angka, karakter lokal, dan karakter khusus
             invalid_for_province: Masukkan kode pos yang valid untuk %{province}
-            unknown_for_street_and_city: Kode pos untuk %{street}, %{city} mungkin
-              salah
             unknown_for_address: Kode pos mungkin salah.
         address:
           errors:

--- a/db/data/regions/_default/it.yml
+++ b/db/data/regions/_default/it.yml
@@ -175,8 +175,6 @@ it:
             contains_restricted_characters: Il codice di avviamento postale può contenere
               solo lettere, numeri, caratteri locali e caratteri speciali
             invalid_for_province: Inserisci un codice postale valido per %{province}
-            unknown_for_street_and_city: Il codice postale potrebbe non essere corretto
-              per la %{street} e la %{city}
             unknown_for_address: Il codice postale potrebbe non essere corretto.
         address:
           errors:

--- a/db/data/regions/_default/ja.yml
+++ b/db/data/regions/_default/ja.yml
@@ -143,7 +143,6 @@ ja:
             contains_mathematical_symbols: 郵便番号に数学記号を含めることはできません
             contains_restricted_characters: 郵便番号には、文字、数字、地域の文字、特殊文字のみを含めることができます。
             invalid_for_province: "%{province}の有効な郵便番号を入力してください"
-            unknown_for_street_and_city: "%{city}、%{street}の郵便番号は正しくない可能性があります。"
             unknown_for_address: 郵便番号は正しくない可能性があります。
         address:
           errors:

--- a/db/data/regions/_default/ko.yml
+++ b/db/data/regions/_default/ko.yml
@@ -144,7 +144,6 @@ ko:
             contains_mathematical_symbols: 우편 번호에 수학 기호를 포함할 수 없음
             contains_restricted_characters: 우편 번호에는 문자, 숫자, 지역 문자, 특수 문자만 포함될 수 있습니다
             invalid_for_province: "%{province}의 유효한 우편 번호 입력"
-            unknown_for_street_and_city: "%{city}, %{street}에 대한 우편 번호가 잘못되었을 수 있습니다."
             unknown_for_address: 우편 번호가 잘못되었을 수 있습니다.
         address:
           errors:

--- a/db/data/regions/_default/lt-LT.yml
+++ b/db/data/regions/_default/lt-LT.yml
@@ -176,8 +176,6 @@ lt-LT:
             contains_restricted_characters: Pašto kodą gali sudaryti tik raidės, skaičiai,
               vietiniai simboliai ir specialieji simboliai
             invalid_for_province: Įveskite teisingą %{province} pašto kodą
-            unknown_for_street_and_city: Adreso %{street}, %{city}, pašto kodas gali
-              būti neteisingas.
             unknown_for_address: Pašto kodas gali būti neteisingas.
         address:
           errors:

--- a/db/data/regions/_default/ms.yml
+++ b/db/data/regions/_default/ms.yml
@@ -167,7 +167,6 @@ ms:
             contains_restricted_characters: Poskod hanya boleh mengandungi huruf,
               nombor, aksara tempatan dan aksara khas
             invalid_for_province: Masukkan poskod yang sah untuk %{province}
-            unknown_for_street_and_city: Poskod mungkin salah untuk %{street}, %{city}
             unknown_for_address: Poskod mungkin salah.
         address:
           errors:

--- a/db/data/regions/_default/nb.yml
+++ b/db/data/regions/_default/nb.yml
@@ -166,8 +166,6 @@ nb:
             contains_restricted_characters: Postnummer kan kun inneholde bokstaver,
               tall, lokale tegn og spesialtegn
             invalid_for_province: Skriv inn et gyldig postnummer for %{province}
-            unknown_for_street_and_city: Postnummeret kan være feil for %{street},
-              %{city}
             unknown_for_address: Postnummeret kan være feil.
         address:
           errors:

--- a/db/data/regions/_default/nl.yml
+++ b/db/data/regions/_default/nl.yml
@@ -167,8 +167,6 @@ nl:
             contains_restricted_characters: Het veld Postcode mag alleen letters,
               cijfers, lokale tekens en speciale tekens bevatten
             invalid_for_province: Voer een geldige postcode in voor %{province}.
-            unknown_for_street_and_city: De postcode is mogelijk onjuist voor %{street},
-              %{city}
             unknown_for_address: De postcode is mogelijk onjuist.
         address:
           errors:

--- a/db/data/regions/_default/pl.yml
+++ b/db/data/regions/_default/pl.yml
@@ -167,8 +167,6 @@ pl:
             contains_restricted_characters: Pole Kod pocztowy może zawierać litery,
               cyfry, znaki lokalne i znaki specjalne.
             invalid_for_province: Wprowadź prawidłowy kod pocztowy dla %{province}
-            unknown_for_street_and_city: Kod pocztowy może być nieprawidłowy dla %{street},
-              %{city}
             unknown_for_address: Kod pocztowy może być nieprawidłowy.
         address:
           errors:

--- a/db/data/regions/_default/pt-BR.yml
+++ b/db/data/regions/_default/pt-BR.yml
@@ -162,8 +162,6 @@ pt-BR:
             contains_restricted_characters: O CEP pode conter apenas letras, números,
               caracteres locais e caracteres especiais
             invalid_for_province: Insira um CEP válido para %{province}
-            unknown_for_street_and_city: Talvez haja um erro no CEP de %{street},
-              %{city}.
             unknown_for_address: Talvez haja um erro no CEP.
         address:
           errors:

--- a/db/data/regions/_default/pt-PT.yml
+++ b/db/data/regions/_default/pt-PT.yml
@@ -168,8 +168,6 @@ pt-PT:
             contains_restricted_characters: O campo "Código postal" só pode conter
               letras, números, caracteres locais e caracteres especiais
             invalid_for_province: 'Introduza um código postal válido para: %{province}'
-            unknown_for_street_and_city: O código postal pode estar incorreto para
-              %{street}, %{city}
             unknown_for_address: O código postal pode estar incorreto.
         address:
           errors:

--- a/db/data/regions/_default/ro-RO.yml
+++ b/db/data/regions/_default/ro-RO.yml
@@ -177,8 +177,6 @@ ro-RO:
             contains_restricted_characters: Codul poștal poate conține numai litere,
               cifre, caractere locale și caractere speciale
             invalid_for_province: Introdu un cod poștal valid pentru %{province}
-            unknown_for_street_and_city: Este posibil ca valoarea din câmpul Cod poștal
-              să fie incorectă pentru %{street}, %{city}
             unknown_for_address: Este posibil ca valoarea din câmpul Cod poștal să
               fie incorectă.
         address:

--- a/db/data/regions/_default/ru.yml
+++ b/db/data/regions/_default/ru.yml
@@ -174,8 +174,6 @@ ru:
             contains_restricted_characters: Поле «Почтовый индекс» может содержать
               только буквы, цифры, а также местные и специальные символы
             invalid_for_province: Укажите действительный почтовый индекс для %{province}
-            unknown_for_street_and_city: Почтовый индекс может быть указан неправильно
-              для %{street}, %{city}.
             unknown_for_address: Почтовый индекс может быть указан неправильно.
         address:
           errors:

--- a/db/data/regions/_default/sk-SK.yml
+++ b/db/data/regions/_default/sk-SK.yml
@@ -167,8 +167,6 @@ sk-SK:
               len písmená, číslice, miestne znaky a špeciálne znaky
             invalid_for_province: Zadajte platné poštové smerovacie číslo pre provinciu
               %{province}
-            unknown_for_street_and_city: PSČ pre ulicu %{street}, mesto %{city} môže
-              byť nesprávne.
             unknown_for_address: PSČ môže byť nesprávne.
         address:
           errors:

--- a/db/data/regions/_default/sl-SI.yml
+++ b/db/data/regions/_default/sl-SI.yml
@@ -173,8 +173,6 @@ sl-SI:
               številke, lokalne znake in posebne znake
             invalid_for_province: Vnesite veljavno poštno številko za zvezno državo
               %{province}
-            unknown_for_street_and_city: Poštna številka morda ni pravilna za %{street},
-              %{city}
             unknown_for_address: Poštna številka morda ni pravilna.
         address:
           errors:

--- a/db/data/regions/_default/sv.yml
+++ b/db/data/regions/_default/sv.yml
@@ -168,8 +168,6 @@ sv:
             contains_restricted_characters: Postnummer får endast innehålla bokstäver,
               siffror, lokala tecken och specialtecken
             invalid_for_province: Ange ett giltigt postnummer för %{province}
-            unknown_for_street_and_city: Postnumret kan vara felaktigt för %{street},
-              %{city}
             unknown_for_address: Postnumret kan vara felaktigt.
         address:
           errors:

--- a/db/data/regions/_default/th.yml
+++ b/db/data/regions/_default/th.yml
@@ -160,7 +160,6 @@ th:
             contains_restricted_characters: รหัสไปรษณีย์สามารถประกอบด้วยตัวอักษร ตัวเลข
               อักขระท้องถิ่น และอักขระพิเศษได้เท่านั้น
             invalid_for_province: ป้อนรหัสไปรษณีย์ที่ถูกต้องสำหรับ %{province}
-            unknown_for_street_and_city: รหัสไปรษณีย์สำหรับ %{street} %{city} อาจไม่ถูกต้อง
             unknown_for_address: รหัสไปรษณีย์อาจไม่ถูกต้อง
         address:
           errors:

--- a/db/data/regions/_default/tr.yml
+++ b/db/data/regions/_default/tr.yml
@@ -160,8 +160,6 @@ tr:
             contains_restricted_characters: Posta kodu yalnızca harfler, sayılar,
               yerel karakterler ve özel karakterler içerebilir
             invalid_for_province: "%{province} için geçerli bir posta kodu girin"
-            unknown_for_street_and_city: "%{street}, %{city} için posta kodu yanlış
-              olabilir"
             unknown_for_address: Posta kodu yanlış olabilir.
         address:
           errors:

--- a/db/data/regions/_default/vi.yml
+++ b/db/data/regions/_default/vi.yml
@@ -162,8 +162,6 @@ vi:
             contains_restricted_characters: Mã bưu chính chỉ được chứa chữ cái, chữ
               số, ký tự địa phương và ký tự đặc biệt
             invalid_for_province: Nhập mã bưu chính hợp lệ cho %{province}
-            unknown_for_street_and_city: Mã bưu chính có thể không chính xác đối với
-              %{street}, %{city}
             unknown_for_address: Mã bưu chính có thể không chính xác.
         address:
           errors:

--- a/db/data/regions/_default/zh-CN.yml
+++ b/db/data/regions/_default/zh-CN.yml
@@ -143,7 +143,6 @@ zh-CN:
             contains_mathematical_symbols: 邮政编码不能包含数学符号
             contains_restricted_characters: "“邮政编码”字段只能包含字母、数字、当地字符和特殊字符"
             invalid_for_province: 请输入 %{province} 对应的有效邮政编码
-            unknown_for_street_and_city: 邮政编码可能与 %{city} %{street} 不匹配
             unknown_for_address: 邮政编码可能不正确。
         address:
           errors:

--- a/db/data/regions/_default/zh-TW.yml
+++ b/db/data/regions/_default/zh-TW.yml
@@ -143,7 +143,6 @@ zh-TW:
             contains_mathematical_symbols: "「郵遞區號」不得包含數學符號"
             contains_restricted_characters: 郵遞區號僅可包含字母、數字、當地字元和特殊字元
             invalid_for_province: 請輸入%{province}的有效郵遞區號
-            unknown_for_street_and_city: "%{city}，%{street} 的郵遞區號可能並不正確"
             unknown_for_address: 郵遞區號可能並不正確。
         address:
           errors:


### PR DESCRIPTION
### What are you trying to accomplish?

`commit 1` adds localized error messages on `zip_unknown_for_address`, and `province_unknown_for_address` for US and CA. 

`commit 2` removes the error strings for `zip_unknown_for_street_and_city`. These were recently introduced, but as of https://github.com/Shopify/atlas_engine/pull/159 are no longer necessary. 

### What approach did you choose and why?
Updated the strings for US and CA. 

Find and delete of all strings for `zip_unknown_for_street_and_city`

### What should reviewers focus on?
<!--
Outline anything you'd like reviewers to pay extra attention to. List open questions for discussion.
-->

...

### The impact of these changes
The error strings for key `zip_unknown_for_street_and_city` will no longer be available. 

US / `zip_unknown_for_address` will return `ZIP code may be incorrect.` instead of `Postal code may be incorrect.`
US / `province_unknown_for_address` will return `State may be incorrect.` instead of `Region may be incorrect.`
CA / `province_unknown_for_address` will return `Province may be incorrect.` instead of `Region may be incorrect.`


### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

...

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
