### PR TITLE
Autofill city in UAE addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 - Add translations for regionalized zip_unknown_for_address, province_unknown_for_address [#125](https://github.com/Shopify/worldwide/pull/125), [#126](https://github.com/Shopify/worldwide/pull/126)
-
+- Remove city from UAE address form and enable city autofill [#127](https://github.com/Shopify/worldwide/pull/127)
 ---
 
 ## [0.10.3] - 2024-03-14

--- a/db/data/regions/AE.yml
+++ b/db/data/regions/AE.yml
@@ -10,9 +10,10 @@ group_name: Asia
 phone_number_prefix: 971
 building_number_required: true
 week_start_day: saturday
+autofill_city_enabled: true
 format:
-  edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{city}{province}_{phone}"
-  show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city} {province}_{country}_{phone}"
+  edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{province}_{phone}"
+  show: "{firstName} {lastName}_{company}_{address1}_{address2} {province}_{country}_{phone}"
 emoji: "\U0001F1E6\U0001F1EA"
 languages:
   - ar

--- a/db/data/regions/AE/bg-BG.yml
+++ b/db/data/regions/AE/bg-BG.yml
@@ -9,3 +9,6 @@ bg-BG:
             optional: Емирство (незадължително)
           errors:
             blank: Изберете емирство
+        city:
+          # This is the placeholder city text for an address in the United Arab Emirates.
+          autofill: "-"

--- a/db/data/regions/AE/cs.yml
+++ b/db/data/regions/AE/cs.yml
@@ -9,3 +9,6 @@ cs:
             optional: Emirát (volitelné)
           errors:
             blank: Vyberte emirát
+        city:
+          # This is the placeholder city text for an address in the United Arab Emirates.
+          autofill: "-"

--- a/db/data/regions/AE/da.yml
+++ b/db/data/regions/AE/da.yml
@@ -9,3 +9,6 @@ da:
             optional: Emirat (valgfrit)
           errors:
             blank: Vælg et emirat
+        city:
+          # This is the placeholder city text for an address in the United Arab Emirates.
+          autofill: "-"

--- a/db/data/regions/AE/de.yml
+++ b/db/data/regions/AE/de.yml
@@ -9,3 +9,6 @@ de:
             optional: Emirat (optional)
           errors:
             blank: Wähle ein Emirat aus
+        city:
+          # This is the placeholder city text for an address in the United Arab Emirates.
+          autofill: "-"

--- a/db/data/regions/AE/el.yml
+++ b/db/data/regions/AE/el.yml
@@ -9,3 +9,6 @@ el:
             optional: Εμιράτο (προαιρετικά)
           errors:
             blank: Επιλέξτε εμιράτο
+        city:
+          # This is the placeholder city text for an address in the United Arab Emirates.
+          autofill: "-"

--- a/db/data/regions/AE/en.yml
+++ b/db/data/regions/AE/en.yml
@@ -9,3 +9,6 @@ en:
             optional: Emirate (optional)
           errors:
             blank: Select an emirate
+        city:
+          # This is the placeholder city text for an address in the United Arab Emirates.
+          autofill: "-"

--- a/db/data/regions/AE/es.yml
+++ b/db/data/regions/AE/es.yml
@@ -9,3 +9,6 @@ es:
             optional: Emirato (opcional)
           errors:
             blank: Selecciona un emirato
+        city:
+          # This is the placeholder city text for an address in the United Arab Emirates.
+          autofill: "-"

--- a/db/data/regions/AE/fi.yml
+++ b/db/data/regions/AE/fi.yml
@@ -9,3 +9,6 @@ fi:
             optional: Emiraatti (valinnainen)
           errors:
             blank: Valitse emiraatti
+        city:
+          # This is the placeholder city text for an address in the United Arab Emirates.
+          autofill: "-"

--- a/db/data/regions/AE/fr.yml
+++ b/db/data/regions/AE/fr.yml
@@ -9,3 +9,6 @@ fr:
             optional: Émirat (facultatif)
           errors:
             blank: Sélectionner un émirat
+        city:
+          # This is the placeholder city text for an address in the United Arab Emirates.
+          autofill: "-"

--- a/db/data/regions/AE/hi.yml
+++ b/db/data/regions/AE/hi.yml
@@ -9,3 +9,6 @@ hi:
             optional: अमीरात (वैकल्पिक)
           errors:
             blank: एक अमीरात चुनें
+        city:
+          # This is the placeholder city text for an address in the United Arab Emirates.
+          autofill: "-"

--- a/db/data/regions/AE/hr-HR.yml
+++ b/db/data/regions/AE/hr-HR.yml
@@ -9,3 +9,6 @@ hr-HR:
             optional: Emirat (neobavezno)
           errors:
             blank: Odaberi emirat
+        city:
+          # This is the placeholder city text for an address in the United Arab Emirates.
+          autofill: "-"

--- a/db/data/regions/AE/hu.yml
+++ b/db/data/regions/AE/hu.yml
@@ -9,3 +9,6 @@ hu:
             optional: Emírség (nem kötelező megadni)
           errors:
             blank: Válassz emírséget
+        city:
+          # This is the placeholder city text for an address in the United Arab Emirates.
+          autofill: "-"

--- a/db/data/regions/AE/id.yml
+++ b/db/data/regions/AE/id.yml
@@ -9,3 +9,6 @@ id:
             optional: Emirat (opsional)
           errors:
             blank: Pilih emirat
+        city:
+          # This is the placeholder city text for an address in the United Arab Emirates.
+          autofill: "-"

--- a/db/data/regions/AE/it.yml
+++ b/db/data/regions/AE/it.yml
@@ -9,3 +9,6 @@ it:
             optional: Emirato (facoltativo)
           errors:
             blank: Seleziona un emirato
+        city:
+          # This is the placeholder city text for an address in the United Arab Emirates.
+          autofill: "-"

--- a/db/data/regions/AE/ja.yml
+++ b/db/data/regions/AE/ja.yml
@@ -9,3 +9,6 @@ ja:
             optional: 首長国 (任意)
           errors:
             blank: 首長国を選択してください
+        city:
+          # This is the placeholder city text for an address in the United Arab Emirates.
+          autofill: "-"

--- a/db/data/regions/AE/ko.yml
+++ b/db/data/regions/AE/ko.yml
@@ -9,3 +9,6 @@ ko:
             optional: 토후국(선택 사항)
           errors:
             blank: 에미레이트 선택
+        city:
+          # This is the placeholder city text for an address in the United Arab Emirates.
+          autofill: "-"

--- a/db/data/regions/AE/lt-LT.yml
+++ b/db/data/regions/AE/lt-LT.yml
@@ -9,3 +9,6 @@ lt-LT:
             optional: Emyratas (pasirinktinai)
           errors:
             blank: Pasirinkite emyratą
+        city:
+          # This is the placeholder city text for an address in the United Arab Emirates.
+          autofill: "-"

--- a/db/data/regions/AE/ms.yml
+++ b/db/data/regions/AE/ms.yml
@@ -9,3 +9,5 @@ ms:
             optional: Emiriah (opsyenal)
           errors:
             blank: Pilih amiriah
+        city:
+          autofill: "-"

--- a/db/data/regions/AE/nb.yml
+++ b/db/data/regions/AE/nb.yml
@@ -9,3 +9,6 @@ nb:
             optional: Emirat (valgfritt)
           errors:
             blank: Velg et emirat
+        city:
+          # This is the placeholder city text for an address in the United Arab Emirates.
+          autofill: "-"

--- a/db/data/regions/AE/nl.yml
+++ b/db/data/regions/AE/nl.yml
@@ -9,3 +9,6 @@ nl:
             optional: Emiraat (optioneel)
           errors:
             blank: Selecteer een emiraat
+        city:
+          # This is the placeholder city text for an address in the United Arab Emirates.
+          autofill: "-"

--- a/db/data/regions/AE/pl.yml
+++ b/db/data/regions/AE/pl.yml
@@ -9,3 +9,6 @@ pl:
             optional: Emirat (opcjonalnie)
           errors:
             blank: Wybierz emirat
+        city:
+          # This is the placeholder city text for an address in the United Arab Emirates.
+          autofill: "-"

--- a/db/data/regions/AE/pt-BR.yml
+++ b/db/data/regions/AE/pt-BR.yml
@@ -9,3 +9,6 @@ pt-BR:
             optional: Emirado (opcional)
           errors:
             blank: Selecione um emirado
+        city:
+          # This is the placeholder city text for an address in the United Arab Emirates.
+          autofill: "-"

--- a/db/data/regions/AE/pt-PT.yml
+++ b/db/data/regions/AE/pt-PT.yml
@@ -9,3 +9,6 @@ pt-PT:
             optional: Emirado (opcional)
           errors:
             blank: Selecione um emirato
+        city:
+          # This is the placeholder city text for an address in the United Arab Emirates.
+          autofill: "-"

--- a/db/data/regions/AE/ro-RO.yml
+++ b/db/data/regions/AE/ro-RO.yml
@@ -9,3 +9,6 @@ ro-RO:
             optional: Emirat (opțional)
           errors:
             blank: Selectează un emirat
+        city:
+          # This is the placeholder city text for an address in the United Arab Emirates.
+          autofill: "-"

--- a/db/data/regions/AE/ru.yml
+++ b/db/data/regions/AE/ru.yml
@@ -9,3 +9,6 @@ ru:
             optional: Эмират (необязательно)
           errors:
             blank: Выберите эмират
+        city:
+          # This is the placeholder city text for an address in the United Arab Emirates.
+          autofill: "-"

--- a/db/data/regions/AE/sk-SK.yml
+++ b/db/data/regions/AE/sk-SK.yml
@@ -9,3 +9,6 @@ sk-SK:
             optional: Emirát (voliteľné)
           errors:
             blank: Vyberte emirát
+        city:
+          # This is the placeholder city text for an address in the United Arab Emirates.
+          autofill: "-"

--- a/db/data/regions/AE/sl-SI.yml
+++ b/db/data/regions/AE/sl-SI.yml
@@ -9,3 +9,6 @@ sl-SI:
             optional: Emirat (izbirno)
           errors:
             blank: Izberite emirat
+        city:
+          # This is the placeholder city text for an address in the United Arab Emirates.
+          autofill: "-"

--- a/db/data/regions/AE/sv.yml
+++ b/db/data/regions/AE/sv.yml
@@ -9,3 +9,6 @@ sv:
             optional: Emirat (valfritt)
           errors:
             blank: Välj ett emirat
+        city:
+          # This is the placeholder city text for an address in the United Arab Emirates.
+          autofill: "-"

--- a/db/data/regions/AE/th.yml
+++ b/db/data/regions/AE/th.yml
@@ -9,3 +9,6 @@ th:
             optional: เอมิเรต (ไม่จำเป็น)
           errors:
             blank: เลือกเอมิเรต
+        city:
+          # This is the placeholder city text for an address in the United Arab Emirates.
+          autofill: "-"

--- a/db/data/regions/AE/tr.yml
+++ b/db/data/regions/AE/tr.yml
@@ -9,3 +9,6 @@ tr:
             optional: Emirlik (isteğe bağlı)
           errors:
             blank: Emirlik seçin
+        city:
+          # This is the placeholder city text for an address in the United Arab Emirates.
+          autofill: "-"

--- a/db/data/regions/AE/vi.yml
+++ b/db/data/regions/AE/vi.yml
@@ -9,3 +9,6 @@ vi:
             optional: Tiểu vương quốc (không bắt buộc)
           errors:
             blank: Chọn tiểu vương quốc
+        city:
+          # This is the placeholder city text for an address in the United Arab Emirates.
+          autofill: "-"

--- a/db/data/regions/AE/zh-CN.yml
+++ b/db/data/regions/AE/zh-CN.yml
@@ -9,3 +9,6 @@ zh-CN:
             optional: 酋长国（可选）
           errors:
             blank: 选择酋长国
+        city:
+          # This is the placeholder city text for an address in the United Arab Emirates.
+          autofill: "-"

--- a/db/data/regions/AE/zh-TW.yml
+++ b/db/data/regions/AE/zh-TW.yml
@@ -9,3 +9,6 @@ zh-TW:
             optional: 大公國 (選填)
           errors:
             blank: 選擇一個大公國
+        city:
+          # This is the placeholder city text for an address in the United Arab Emirates.
+          autofill: "-"

--- a/test/worldwide/field_test.rb
+++ b/test/worldwide/field_test.rb
@@ -31,6 +31,7 @@ module Worldwide
 
     test "autofills city as expected when there is a country_code" do
       [
+        [:en, :ae, "-"],
         [:en, :sg, "Singapore"],
         [:fr, :sg, "Singapour"],
         [:ja, :sg, "シンガポール"],


### PR DESCRIPTION
Replica of https://github.com/Shopify/country_db/pull/1622

### WHAT are you trying to accomplish with this PR?

Shipping addresses in the UAE do not require a city ([source1](https://pe.usps.com/text/imm/tz_017.htm#:~:text=All%20mail%20must%20include%20the,and%20email%20address%2C%20if%20available.), [source2](https://www.dubaifaqs.com/zip-code-addresses-dubai-uae.php)). We therefore should not block checkouts for missing cities. This is causing an [issue](https://github.com/Shopify/shopify/issues/456098) with Google Pay express checkouts, because Google does not include cities in their UAE addresses.

A [sample of 1000 UAE addresses](https://docs.google.com/spreadsheets/d/1-LcjkPQHvmd4-4NB8mLapNDIGjEoLlD7nI14SFfxKWk/edit#gid=0) from checkout shows that buyers will often repeat he emirate or put bogus filler data in the city field in order to pass validations.

### Proposed solution
We cannot simply remove the city field or make city optional, because our many address models (in Atlas and core) require a city value. We can remove the city input field, but we need some value to fill the city with.

We have other countries that don’t include a city in their addresses, like Singapore. However, these countries all have just one possible city value, so we store these in CountryDB, and use the `autofill_city` method to fetch the value. This `autofill_city` method is called many times in core, essentially anywhere an address is built, to ensure a city value is present in our models.

I am proposing that we 1) remove the city field from UAE addresses and 2) fill the city with a filler value `-` as many buyers are currently doing. This leverages the existing city autofill logic in CountryDB and does not require any changes to core. A potential concern with this approach is the unknown downstream effects for any 3P apps that consume our addresses. My hypothesis though is that this will not be a significant issue, given that buyers are often already inputting filler data in this field.

### Alternative Solutions

Another solution I considered was filling the city with the emirate (a.k.a. province) value. I don't think this has much more value than a placeholder, but it is more presentable. However, ContryDB does not have access to this user-inputted data - it would need to be passed from core. We could add a new optional parameter, the `autofill_city` method. When the country code is `AE`, we fill the city value using the given argument. This would require passing in a new argument everywhere in core where `autofill_city` is called. A complication with this solution: what do we pass as an argument? Do we pass the province name? Not every address object in core has access to this. Some would need to use CountryDB to convert province code to province name. Moreover, it’s not ideal for core to know what address fields are relevant to the autofill logic. What if, in the future, we want to autofill using a different address field? We might need to change all these `autofill_city` calls again. A more flexible approach would be to pass in the whole address object as an argument. However, all of these address objects in core have different interfaces. Some have a province, some have a zone, etc. 

Alternatively, instead of building on the existing `autofill_city` method, we could use CountryDB to tell core (or checkout) which **field** to fill the city value with. However, this poses a similar problem to the previous solution, because we have different address interfaces with different attribute names. We do have a mapping on checkout of CountryDB address field names to checkout address field names, and this may be an ideal place to fill the city value, before or as the form submits. This is not a trivial change, and would need more context of the checkout.

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
