### PR TITLE
added country prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Security in case of vulnerabilities.
 
 ## [Unreleased]
+- Add country_prefix to phone [#133](https://github.com/Shopify/worldwide/pull/133)
 - Add autofill_city to region [#132](https://github.com/Shopify/worldwide/pull/132)
 - Re-introduce city from UAE address form and disable city autofill [#131](https://github.com/Shopify/worldwide/pull/131)
 - Add translations for regionalized zip_unknown_for_address, province_unknown_for_address [#125](https://github.com/Shopify/worldwide/pull/125), [#126](https://github.com/Shopify/worldwide/pull/126)

--- a/lib/worldwide/phone.rb
+++ b/lib/worldwide/phone.rb
@@ -48,6 +48,11 @@ module Worldwide
       @parsed_number.valid?
     end
 
+    # Returns the country prefix for the phone number
+    def country_prefix
+      @parsed_number.country_code
+    end
+
     private
 
     # For various reasons, Worldwide considers these territories to be zones inside the USA

--- a/test/worldwide/phone_test.rb
+++ b/test/worldwide/phone_test.rb
@@ -114,6 +114,20 @@ module Worldwide
       # rubocop:enable Metrics/ParameterLists
     end
 
+    test "correct country prefix" do
+      # rubocop:disable Metrics/ParameterLists
+      [
+        [:ca, "613-356-6900", "(613) 356-6900", "+16133566900", "+1 613-356-6900", "CA", "1"], # IBM Ottawa
+
+      ].each do |input_country, input_number, domestic, e164, international, country, prefix|
+        phone = Phone.new(number: input_number, country_code: input_country)
+        validate_phone(phone, input_number, domestic, e164, international, country)
+
+        assert_equal prefix, phone.country_prefix
+      end
+      # rubocop:enable Metrics/ParameterLists
+    end
+
     private
 
     # rubocop:disable Metrics/ParameterLists


### PR DESCRIPTION
### What are you trying to accomplish?
Relates to: https://github.com/Shopify/address/issues/2513

In Core, we use GlobalPhone to parse phone numbers and call `.country_code`, this returns the one-or-two digit country prefix (i.e 1 for CA and USA). There's no way to access this in Worldwide, the current `country_code` method returns the 2-character ISO code (i.e CA). 

### What approach did you choose and why?
Added the method
### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
