### PR TITLE
Bump to 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,14 +26,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Security in case of vulnerabilities.
 
 ## [Unreleased]
+
+- Nil.
+
+---
+
+## [0.11.0] - 2024-04-11
+
 - Add country_prefix to phone [#133](https://github.com/Shopify/worldwide/pull/133)
 - Add autofill_city to region [#132](https://github.com/Shopify/worldwide/pull/132)
 - Re-introduce city from UAE address form and disable city autofill [#131](https://github.com/Shopify/worldwide/pull/131)
 - Add translations for regionalized zip_unknown_for_address, province_unknown_for_address [#125](https://github.com/Shopify/worldwide/pull/125), [#126](https://github.com/Shopify/worldwide/pull/126)
 - Remove city from UAE address form and enable city autofill [#127](https://github.com/Shopify/worldwide/pull/127)
 - Add logic for known-to-exist extant outcodes for GB [#136](https://github.com/Shopify/worldwide/pull/136)
-
----
 
 ## [0.10.3] - 2024-03-14
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (0.10.3)
+    worldwide (0.11.0)
       activesupport (~> 7.0)
       i18n
       phonelib (~> 0.8)
@@ -44,7 +44,6 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    mini_portile2 (2.8.5)
     minitest (5.17.0)
     minitest-focus (1.3.1)
       minitest (>= 4, < 6)
@@ -56,9 +55,6 @@ GEM
     mocha (2.0.2)
       ruby2_keywords (>= 0.0.5)
     mutex_m (0.1.2)
-    nokogiri (1.16.2)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
     nokogiri (1.16.2-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.2-x86_64-linux)

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "0.10.3"
+  VERSION = "0.11.0"
 end


### PR DESCRIPTION
### What are you trying to accomplish?
<!--
Link to an issue or provide enough context so that someone new can understand the 'why' behind this change.
-->

Changes:
- Add country_prefix to phone [#133](https://github.com/Shopify/worldwide/pull/133)
- Add autofill_city to region [#132](https://github.com/Shopify/worldwide/pull/132)
- Re-introduce city from UAE address form and disable city autofill [#131](https://github.com/Shopify/worldwide/pull/131)
- Add translations for regionalized zip_unknown_for_address, province_unknown_for_address [#125](https://github.com/Shopify/worldwide/pull/125), [#126](https://github.com/Shopify/worldwide/pull/126)
- Remove city from UAE address form and enable city autofill [#127](https://github.com/Shopify/worldwide/pull/127)
- Add logic for known-to-exist extant outcodes for GB [#136](https://github.com/Shopify/worldwide/pull/136)

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
