### PR TITLE
Handle empty strings zip normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-- Nil.
+- Handle blank strings for Region, country_code parameter in Zip normalization
+  [#138](https://github.com/Shopify/worldwide/pull/138)
 
 ---
 

--- a/lib/worldwide/zip.rb
+++ b/lib/worldwide/zip.rb
@@ -85,7 +85,7 @@ module Worldwide
     def normalize(country_code:, zip:, allow_autofill: true, strip_extraneous_characters: false)
       input = zip # preserve the original zip, in case we need to fall back to it
 
-      return input if country_code.nil?
+      return input if Util.blank?(country_code)
 
       country = Worldwide.region(code: country_code)
       return zip if country.nil? || NORMALIZATION_DISABLED_COUNTRIES.include?(country.iso_code)


### PR DESCRIPTION
### What are you trying to accomplish?
<!--
Link to an issue or provide enough context so that someone new can understand the 'why' behind this change.
-->

Before:
```ruby
[10] pry(main)> Worldwide::Zip.normalize(country_code: "", zip: nil)
ArgumentError: Must specify exactly one of cldr:, code: or name:. (code: is preferred)
from /Users/devanandersen/.gem/ruby/3.2.1/gems/worldwide-0.10.3/lib/worldwide/regions.rb:28:in `region'
[11] pry(main)>
```

After:
```ruby
irb(main):001:0> Worldwide::Zip.normalize(country_code: "", zip: nil)
=> nil
```

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
