### PR TITLE
Attempt to fix stringio incompatibility with Ruby 3.3 (deployment error)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   [#138](https://github.com/Shopify/worldwide/pull/138)
 - Reposition zip in NF show: format to come after country, not before city. [#142](https://github.com/Shopify/worldwide/pull/142)
 - Allow building number on address2 for CH [#143](https://github.com/Shopify/worldwide/pull/143)
+- Attempt to fix stringio incompatibility with Ruby 3.3 (deployment error) [#145](https://github.com/Shopify/worldwide/pull/145)
 
 ## [0.11.0] - 2024-04-11
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,7 +104,7 @@ GEM
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     sorbet-runtime (0.5.10648)
-    stringio (3.0.6)
+    stringio (3.1.0)
     syntax_tree (5.3.0)
       prettier_print (>= 1.2.0)
     thor (1.2.1)


### PR DESCRIPTION
### What are you trying to accomplish?
```
Using worldwide 0.11.1 from source at `.`
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

current directory:
/app/data/bundler/ruby/3.3.0/gems/stringio-3.0.6/ext/stringio
/usr/local/ruby/bin/ruby extconf.rb
checking for rb_io_extract_modeenc() in ruby/io.h... yes
creating Makefile
...
compiling stringio.c
stringio.c: In function ‘strio_init’:
stringio.c:359:24: error: storage size of ‘convconfig’ isn’t known
     struct rb_io_enc_t convconfig;
                        ^
stringio.c:359:24: warning: unused variable ‘convconfig’ [-Wunused-variable]
stringio.c: In function ‘strio_set_encoding’:
stringio.c:1822:25: error: storage size of ‘convconfig’ isn’t known
      struct rb_io_enc_t convconfig;
                         ^
stringio.c:1822:25: warning: unused variable ‘convconfig’ [-Wunused-variable]
stringio.c: At top level:
cc1: warning: unrecognized command line option ‘-Wno-tautological-compare’
cc1: warning: unrecognized command line option ‘-Wno-self-assign’
cc1: warning: unrecognized command line option ‘-Wno-parentheses-equality’
cc1: warning: unrecognized command line option ‘-Wno-constant-logical-operand’
cc1: warning: unrecognized command line option ‘-Wno-cast-function-type’
Makefile:247: recipe for target 'stringio.o' failed
make: *** [stringio.o] Error 1
make failed, exit code 2
```
Which is very close to https://github.com/ruby/stringio/pull/54, fixed as part of stringio 3.0.7, a release that adds support for Ruby 3.3.


### What approach did you choose and why?
Bump stringio to the latest release.

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
