### PR TITLE
Add initial additional address field definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 - Add pry-byebug gem [#149](https://github.com/Shopify/worldwide/pull/149)
+- Introduce additional_address_fields to Region class and define them for BE, BR, CL, CO, ES, ID, MX, NL, PH, TR, VN [#148](https://github.com/Shopify/worldwide/pull/148)
 
 ## [0.11.1] - 2024-05-13
 

--- a/db/data/regions/BE.yml
+++ b/db/data/regions/BE.yml
@@ -24,5 +24,11 @@ languages:
 format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
+additional_address_fields:
+  address1:
+    - key: streetName
+      required: true
+    - key: streetNumber
+      required: false
 emoji: "\U0001F1E7\U0001F1EA"
 timezone: Europe/Brussels

--- a/db/data/regions/BR.yml
+++ b/db/data/regions/BR.yml
@@ -19,6 +19,19 @@ languages:
 format:
   edit: "{country}_{firstName}{lastName}_{company}_{zip}_{address1}_{address2}_{city}{province}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city} {province}_{country}_{phone}"
+additional_address_fields:
+  address1:
+    - key: streetName
+      required: true
+    - key: streetNumber
+      decorator: ","
+      required: true
+  address2:
+    - key: address2
+      required: false
+    - key: neighborhood
+      decorator: ","
+      required: false
 emoji: "\U0001F1E7\U0001F1F7"
 localized_data:
 - name: tax_credential_br

--- a/db/data/regions/CL.yml
+++ b/db/data/regions/CL.yml
@@ -14,6 +14,17 @@ week_start_day: sunday
 format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{province}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{province}_{country}_{phone}"
+additional_address_fields:
+  address1:
+    - key: streetName
+      required: true
+    - key: streetNumber
+      required: false
+  address2:
+    - key: address2
+      required: false
+    - key: neighborhood
+      required: false
 emoji: "\U0001F1E8\U0001F1F1"
 languages:
   - es

--- a/db/data/regions/CO.yml
+++ b/db/data/regions/CO.yml
@@ -15,6 +15,12 @@ week_start_day: sunday
 format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{city}{province}{zip}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city} {province}_{country}_{phone}"
+additional_address_fields:
+  address2:
+    - key: address2
+      required: false
+    - key: neighborhood
+      required: false
 emoji: "\U0001F1E8\U0001F1F4"
 languages:
   - es

--- a/db/data/regions/ES.yml
+++ b/db/data/regions/ES.yml
@@ -21,6 +21,12 @@ languages:
 format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}{province}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{province}_{country}_{phone}"
+additional_address_fields:
+  address1:
+    - key: streetName
+      required: true
+    - key: streetNumber
+      required: false
 emoji: "\U0001F1EA\U0001F1F8"
 zones:
 - name: A Coruña

--- a/db/data/regions/ID.yml
+++ b/db/data/regions/ID.yml
@@ -17,6 +17,13 @@ languages:
 format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{province}{zip}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{province} {zip}_{country}_{phone}"
+additional_address_fields:
+  address2:
+    - key: address2
+      required: false
+    - key: neighborhood
+      decorator: ","
+      required: false
 emoji: "\U0001F1EE\U0001F1E9"
 zones:
 - name: Aceh

--- a/db/data/regions/MX.yml
+++ b/db/data/regions/MX.yml
@@ -15,6 +15,17 @@ week_start_day: sunday
 format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}{province}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city} {province}_{country}_{phone}"
+additional_address_fields:
+  address1:
+    - key: streetName
+      required: true
+    - key: streetNumber
+      required: false
+  address2:
+    - key: address2
+      required: false
+    - key: neighborhood
+      required: true
 emoji: "\U0001F1F2\U0001F1FD"
 languages:
   - es

--- a/db/data/regions/NL.yml
+++ b/db/data/regions/NL.yml
@@ -23,5 +23,11 @@ languages:
 format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
+additional_address_fields:
+  address1:
+    - key: streetName
+      required: true
+    - key: streetNumber
+      required: true
 emoji: "\U0001F1F3\U0001F1F1"
 timezone: Europe/Amsterdam

--- a/db/data/regions/PH.yml
+++ b/db/data/regions/PH.yml
@@ -15,6 +15,13 @@ week_start_day: sunday
 format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{province}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{province}_{country}_{phone}"
+additional_address_fields:
+  address2:
+    - key: address2
+      required: false
+    - key: neighborhood
+      decorator: "Barangay"
+      required: true
 emoji: "\U0001F1F5\U0001F1ED"
 languages:
   - en

--- a/db/data/regions/TR.yml
+++ b/db/data/regions/TR.yml
@@ -16,6 +16,12 @@ week_start_day: monday
 format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
+additional_address_fields:
+  address2:
+    - key: address2
+      required: false
+    - key: neighborhood
+      required: false
 emoji: "\U0001F1F9\U0001F1F7"
 languages:
   - tr

--- a/db/data/regions/VN.yml
+++ b/db/data/regions/VN.yml
@@ -13,6 +13,13 @@ week_start_day: monday
 format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{city}{zip}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}"
+additional_address_fields:
+  address2:
+    - key: address2
+      required: false
+    - key: neighborhood
+      decorator: ", Quận"
+      required: false
 emoji: "\U0001F1FB\U0001F1F3"
 languages:
   - fr

--- a/lib/worldwide/region.rb
+++ b/lib/worldwide/region.rb
@@ -32,6 +32,7 @@ module Worldwide
       :zip_example,
       :zip_regex,
       :zip_requirement,
+      :additional_address_fields,
     ]
 
     # A region may have more than one parent.
@@ -189,6 +190,9 @@ module Worldwide
     # If true, then the province is optional for addresses in this region.
     attr_accessor :province_optional
 
+    # A hash of additional address fields and the rules for concatening them into the standard fields
+    attr_accessor :additional_address_fields
+
     def initialize(
       alpha_three: nil,
       continent: false,
@@ -224,6 +228,7 @@ module Worldwide
       @tax_rate = tax_rate
       @use_zone_code_as_short_name = use_zone_code_as_short_name
 
+      @additional_address_fields = {}
       @building_number_required = false
       @building_number_may_be_in_address2 = false
       @currency = nil

--- a/lib/worldwide/regions_loader.rb
+++ b/lib/worldwide/regions_loader.rb
@@ -95,6 +95,7 @@ module Worldwide
     end
 
     def apply_territory_attributes(region, spec)
+      region.additional_address_fields = spec["additional_address_fields"] || {}
       region.building_number_required = spec["building_number_required"] || false
       region.building_number_may_be_in_address2 = spec["building_number_may_be_in_address2"] || false
       currency_code = spec["currency"]

--- a/test/worldwide/region_test.rb
+++ b/test/worldwide/region_test.rb
@@ -350,5 +350,27 @@ module Worldwide
         assert_equal expected_value, Worldwide.region(code: region_code).building_number_required
       end
     end
+
+    test "additional_address_fields returns values as expected" do
+      [
+        [:us, {}],
+        [:be, {
+          "address1" => [{ "key" => "streetName", "required" => true }, { "key" => "streetNumber", "required" => false }],
+        },],
+        [:br, {
+          "address1" => [{ "key" => "streetName", "required" => true }, { "key" => "streetNumber", "decorator" => ",", "required" => true }],
+          "address2" => [{ "key" => "address2", "required" => false }, { "key" => "neighborhood", "decorator" => ",", "required" => false }],
+        },],
+        [:cl, {
+          "address1" => [{ "key" => "streetName", "required" => true }, { "key" => "streetNumber", "required" => false }],
+          "address2" => [{ "key" => "address2", "required" => false }, { "key" => "neighborhood", "required" => false }],
+        },],
+        [:id, {
+          "address2" => [{ "key" => "address2", "required" => false }, { "key" => "neighborhood", "decorator" => ",", "required" => false }],
+        },],
+      ].each do |region_code, expected_value|
+        assert_equal expected_value, Worldwide.region(code: region_code).additional_address_fields
+      end
+    end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Part of https://github.com/Shopify/address/issues/2559

1. Adds a new attribute to the Region class: `additonal_address_fields`
2. Defines `additonal_address_fields` for [all countries in scope](https://docs.google.com/spreadsheets/d/1LQ-WN_LNc4OmpKZUm4SxfQrlKGUW0I8dbPbsPx8JSNg/edit#gid=601847841) for the project, except for Taiwan. Taiwan will be introduced in a follow up PR as it will have a more complex definition.

These additional address field definitions will be used in concatenation (going from an extended address to a standard one) and splitting (going from a standard address to an extended one) methods. See [this prototype branch](https://github.com/Shopify/worldwide/compare/main...additional-address-fields-proto) for an idea of what these methods will look like.

### What approach did you choose and why?
The field definitions are grouped by the standard field they should be concatenated into (e.g. address1 or address2). They include:
- a key (a required identifier - the english name for the field)
- a decorator (an optional char/word to be used in combination with the reserved delimiter when concatenating, e.g. comma). I analyzed 1000 addresses from each country and [noted](https://docs.google.com/document/d/1mFuPUypjAgyPOUcxU9iRooRZkBg8Xb_AeQA9iZw5FxQ/edit#heading=h.n3i0osiau3ba) the most common delimiters used to separate street, house number, and neighborhood. 


### What should reviewers focus on?

For the Philippines and Vietnam, the decorators are actually words. Are there any foreseeable issues with this? When concatenated addresses are split on the non breaking space, these decorator words should be removed from the resulting strings (we don't need to prefix the neighborhood with the word "neighborhood" once it's in the neighborhood field).

Previously we have used the name "house number", but I've changed this to "building number" as it is more accurate.

I have also chosen the American spelling for neighborhood 🤷‍♀️ Let me know if you have any objections.

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
