### PR TITLE
Use `>=` instead of `~>` for activesupport in `.gemspec`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ PATH
   remote: .
   specs:
     worldwide (0.12.0)
-      activesupport (~> 7.0)
+      activesupport (>= 7.0)
       i18n
       phonelib (~> 0.8)
 

--- a/worldwide.gemspec
+++ b/worldwide.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 3.0.0"
 
-  spec.add_dependency("activesupport", "~> 7.0")
+  spec.add_dependency("activesupport", ">= 7.0")
   spec.add_dependency("i18n")
   spec.add_dependency("phonelib", "~> 0.8")
 end


### PR DESCRIPTION
## Context

In this week's [Rails Upgrade](https://github.com/Shopify/shopify/pull/505944) in core, we needed to bump to a [commit](https://github.com/rails/rails/commit/94c6de51bc1272c42344014ad6ff74aecd6e77d1) of `rails` that falls after [the beginning of Rails 8.0 development](https://github.com/rails/rails/commit/37fd0e7fe4990c4e5db10813bae3bba10c8be479).

The version of all rails libraries (activesupport, activejob, etc) are subsequently bumped to version `8.0`, this creates an error with this gem as the `.gemspec` has a minimum required version of `activesupport` set to `7.0`.

This PR refactors the requirement on `activesupport` to `>= 7.0` to unblock the rails upgrade today and ensure this doesn't occur in the future.