### PR TITLE
Add address field concatenation methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-nil.
-
----
+- Add Address#concatenated_address1 and Address#concatenated_address2 methods [#158](https://github.com/Shopify/worldwide/pull/158)
 
 ## [0.12.2] - 2024-05-21
 

--- a/test/worldwide/address_test.rb
+++ b/test/worldwide/address_test.rb
@@ -51,5 +51,101 @@ module Worldwide
       assert_nil address.zip
       assert_equal "ZZ", address.country_code
     end
+
+    test "concatenated_address1 returns empty string when neither address1 nor additional address fields are present" do
+      nil_address = Address.new(country_code: "BR")
+      blank_address = Address.new(address1: "", street_name: "", street_number: "", country_code: "BR")
+
+      assert_equal "", nil_address.concatenated_address1
+      assert_equal "", blank_address.concatenated_address1
+    end
+
+    test "concatenated_address1 ignores additional address fields if they are not defined for the country" do
+      nil_address1 = Address.new(street_name: "Other Street", street_number: "456", country_code: "US")
+      blank_address1 = Address.new(address1: "", street_name: "Other Street", street_number: "456", country_code: "US")
+
+      assert_equal "", nil_address1.concatenated_address1
+      assert_equal "", blank_address1.concatenated_address1
+    end
+
+    test "concatenated_address1 returns address1 when address1 is present" do
+      cl_address = Address.new(address1: "Main Street 123", street_name: "Other Street", street_number: "456", country_code: "CL")
+      us_address = Address.new(address1: "123 Main Street", street_name: "Other Street", street_number: "456", country_code: "CL")
+
+      assert_equal "Main Street 123", cl_address.concatenated_address1
+      assert_equal "123 Main Street", us_address.concatenated_address1
+    end
+
+    test "concatenated_address1 returns street name with no delimiter and no decorator when only street name is present" do
+      cl_address = Address.new(street_name: "Main Street", country_code: "CL")
+      br_address = Address.new(street_name: "Main Street", country_code: "BR")
+
+      assert_equal "Main Street", cl_address.concatenated_address1
+      assert_equal "Main Street", br_address.concatenated_address1
+    end
+
+    test "concatenated_address1 returns street number prefixed by a delimiter and no decorator when only street number is present" do
+      cl_address = Address.new(street_number: "123", country_code: "CL")
+      br_address = Address.new(street_number: "123", country_code: "BR")
+
+      assert_equal " 123", cl_address.concatenated_address1
+      assert_equal " 123", br_address.concatenated_address1
+    end
+
+    test "concatenated_address1 returns street name concatenated with street number separated by delimiter" do
+      address = Address.new(street_name: "Main Street", street_number: "123", country_code: "CL")
+
+      assert_equal "Main Street 123", address.concatenated_address1
+    end
+
+    test "concatenated_address1 returns street name concatenated with street number separated by delimiter and decorator" do
+      address = Address.new(street_name: "Main Street", street_number: "123", country_code: "BR")
+
+      assert_equal "Main Street, 123", address.concatenated_address1
+    end
+
+    test "concatenated_address2 returns empty string when neither address2 nor additional address fields are present" do
+      nil_address = Address.new(country_code: "BR")
+      blank_address = Address.new(address2: "", neighborhood: "", country_code: "BR")
+
+      assert_equal "", nil_address.concatenated_address2
+      assert_equal "", blank_address.concatenated_address2
+    end
+
+    test "concatenated_address2 ignores additional address fields if they are not defined for the country" do
+      nil_address2 = Address.new(neighborhood: "Centretown", country_code: "US")
+      blank_address2 = Address.new(address2: "", neighborhood: "Centretown", country_code: "US")
+
+      assert_equal "", nil_address2.concatenated_address2
+      assert_equal "", blank_address2.concatenated_address2
+    end
+
+    test "concatenated_address2 returns address2 with no delimiters when only address2 is present" do
+      cl_address = Address.new(address2: "dpto 4", country_code: "CL")
+      br_address = Address.new(address2: "dpto 4", country_code: "BR")
+
+      assert_equal "dpto 4", cl_address.concatenated_address2
+      assert_equal "dpto 4", br_address.concatenated_address2
+    end
+
+    test "concatenated_address2 returns neighborhood with delimiter when only neighborhood is present" do
+      cl_address = Address.new(neighborhood: "Centro", country_code: "CL")
+      br_address = Address.new(neighborhood: "Centro", country_code: "BR")
+
+      assert_equal " Centro", cl_address.concatenated_address2
+      assert_equal " Centro", br_address.concatenated_address2
+    end
+
+    test "concatenated_address2 returns address2 concatenated with neighborhood separated by delimiter" do
+      address = Address.new(address2: "dpto 4", neighborhood: "Centro", country_code: "CL")
+
+      assert_equal "dpto 4 Centro", address.concatenated_address2
+    end
+
+    test "concatenated_address2 returns address2 concatenated with neighborhood separated by delimiter and decorator" do
+      address = Address.new(address2: "dpto 4", neighborhood: "Centro", country_code: "BR")
+
+      assert_equal "dpto 4, Centro", address.concatenated_address2
+    end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Resolves https://github.com/Shopify/address/issues/2561

This PR builds on https://github.com/Shopify/worldwide/pull/148, using the additional address field definitions to provide methods that can concatenate additional address fields into standard address fields.

### What approach did you choose and why?

I defined the methods on the existing Address class, as it already contains address formatting methods.

1. Added `street_name`, `street_number`, and `neighborhood` attributes to the class
2. Added `concatenated_address1` and `concatenated_address2` methods, which use the additional address field definitions from Region

### What should reviewers focus on?

1. Better method names?
2. Have the tests covered all the edge cases?
  a. They currently make the assumption that street name is the first additional field to concatenate and street number is the second (same with address2 and neighborhood). I could generalize the test names, but I think they will be harder to understand (e.g. "concatenated_address1 returns first additional address field with no delimiter when only first additional address field is present")

### Checklist

* [ ] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
