### PR TITLE
Add missing format keys for GB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- Add missing `address1` and `address1_with_unit` formatting keys for GB [#160](https://github.com/Shopify/worldwide/pull/160).
+
 ---
 
 ## [0.12.1] - 2024-05-17

--- a/db/data/regions/GB.yml
+++ b/db/data/regions/GB.yml
@@ -19,6 +19,8 @@ building_number_required: true
 week_start_day: monday
 omit_components: true
 format:
+  address1: "{building_num} {street}"
+  address1_with_unit: "{unit}, {building_num} {street}"
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{city}{zip}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}"
 emoji: "\U0001F1EC\U0001F1E7"


### PR DESCRIPTION
### What are you trying to accomplish?

We are missing formatting keys in GB for address1 with unit

### What approach did you choose and why?

Add the missing keys back

### What should reviewers focus on?

Is this the correct approach?

### The impact of these changes
<!--
Are there any specific impacts from this change that you'd like to call out?
-->

...

### Testing

<img width="705" alt="image" src="https://github.com/Shopify/worldwide/assets/107632104/0029324a-8ab3-4681-9852-67b4ed16fe54">


### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
