### PR TITLE
Release 0.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-- Add missing `address1` and `address1_with_unit` formatting keys for GB [#160](https://github.com/Shopify/worldwide/pull/160).
+nil.
 
 ---
+
+## [0.12.2] - 2024-05-21
+
+- Add missing `address1` and `address1_with_unit` formatting keys for GB [#160](https://github.com/Shopify/worldwide/pull/160).
 
 ## [0.12.1] - 2024-05-17
 - Use `>=` instead of `~>` for `activesupport` in `.gemspec` [#156](https://github.com/Shopify/worldwide/pull/156)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (0.12.1)
+    worldwide (0.12.2)
       activesupport (>= 7.0)
       i18n
       phonelib (~> 0.8)

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "0.12.1"
+  VERSION = "0.12.2"
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Release
- Add missing `address1` and `address1_with_unit` formatting keys for GB [#160](https://github.com/Shopify/worldwide/pull/160).

### What approach did you choose and why?
<!--
There are many ways to solve a problem. How did you approach this problem and why?
-->

...

### What should reviewers focus on?
<!--
Outline anything you'd like reviewers to pay extra attention to. List open questions for discussion.
-->

...

### The impact of these changes
<!--
Are there any specific impacts from this change that you'd like to call out?
-->

...

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

...

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
