### PR TITLE
introduce additional field support for Israel, update required fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ nil.
 - Add Address#concatenated_address1 and Address#concatenated_address2 methods [#158](https://github.com/Shopify/worldwide/pull/158)
 - Updated root translation keys for regional locales `bg-BG`, `hr-HR`, `lt-LT`, `ro-RO`, `sk-SK`, `sl-SI`  to the base locale (e.g. `bg`) [#164](https://github.com/Shopify/worldwide/pull/164).
 - Remove city from UAE address form and enable city autofill [#159](https://github.com/Shopify/worldwide/pull/159)
+- Support additional fields in IL, update streetNumber and neighborhood requirement for BE, CL, ES, MX [#166](https://github.com/Shopify/worldwide/pull/166)
+
+---
 
 ## [0.12.2] - 2024-05-21
 

--- a/db/data/regions/BE.yml
+++ b/db/data/regions/BE.yml
@@ -31,6 +31,6 @@ additional_address_fields:
     - key: streetName
       required: true
     - key: streetNumber
-      required: false
+      required: true
 emoji: "\U0001F1E7\U0001F1EA"
 timezone: Europe/Brussels

--- a/db/data/regions/CL.yml
+++ b/db/data/regions/CL.yml
@@ -21,7 +21,7 @@ additional_address_fields:
     - key: streetName
       required: true
     - key: streetNumber
-      required: false
+      required: true
   address2:
     - key: address2
       required: false

--- a/db/data/regions/ES.yml
+++ b/db/data/regions/ES.yml
@@ -28,7 +28,7 @@ additional_address_fields:
     - key: streetName
       required: true
     - key: streetNumber
-      required: false
+      required: true
 emoji: "\U0001F1EA\U0001F1F8"
 zones:
 - name: A Coruña

--- a/db/data/regions/IL.yml
+++ b/db/data/regions/IL.yml
@@ -16,6 +16,14 @@ week_start_day: sunday
 format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
+format_extended:
+  edit: "{country}_{firstName}{lastName}_{company}_{streetName}{streetNumber}_{address2}_{zip}{city}_{phone}"
+additional_address_fields:
+  address1:
+    - key: streetNumber
+      required: true
+    - key: streetName
+      required: true
 emoji: "\U0001F1EE\U0001F1F1"
 languages:
   - ar

--- a/db/data/regions/MX.yml
+++ b/db/data/regions/MX.yml
@@ -22,12 +22,12 @@ additional_address_fields:
     - key: streetName
       required: true
     - key: streetNumber
-      required: false
+      required: true
   address2:
     - key: address2
       required: false
     - key: neighborhood
-      required: true
+      required: false
 emoji: "\U0001F1F2\U0001F1FD"
 languages:
   - es

--- a/test/worldwide/region_test.rb
+++ b/test/worldwide/region_test.rb
@@ -356,15 +356,18 @@ module Worldwide
     test "additional_address_fields returns values as expected" do
       [
         [:us, {}],
+        [:il, {
+          "address1" => [{ "key" => "streetNumber", "required" => true }, { "key" => "streetName", "required" => true }],
+        },],
         [:be, {
-          "address1" => [{ "key" => "streetName", "required" => true }, { "key" => "streetNumber", "required" => false }],
+          "address1" => [{ "key" => "streetName", "required" => true }, { "key" => "streetNumber", "required" => true }],
         },],
         [:br, {
           "address1" => [{ "key" => "streetName", "required" => true }, { "key" => "streetNumber", "decorator" => ",", "required" => true }],
           "address2" => [{ "key" => "address2", "required" => false }, { "key" => "neighborhood", "decorator" => ",", "required" => false }],
         },],
         [:cl, {
-          "address1" => [{ "key" => "streetName", "required" => true }, { "key" => "streetNumber", "required" => false }],
+          "address1" => [{ "key" => "streetName", "required" => true }, { "key" => "streetNumber", "required" => true }],
           "address2" => [{ "key" => "address2", "required" => false }, { "key" => "neighborhood", "required" => false }],
         },],
         [:id, {


### PR DESCRIPTION
### What are you trying to accomplish?
Israel will support the extended address form, splitting address1 into street_name, street_number. There is no need to support neighborhood at this time. 

Scanned a sample of 1000 IL addresses (image of 20 shown below). The sample for address1, address2 lines show there is no consistent delimiter used to separate the street number and street name. 
![Screenshot 2024-05-24 at 12 33 40 PM](https://github.com/Shopify/worldwide/assets/145736265/f349d10d-2606-4415-93ff-27d68e630a8f)

_closes https://github.com/Shopify/address/issues/2598_

### What approach did you choose and why?
IL.yml
- Added `format_extended` definition
- Introduced `additional_address_fields` definition
  - no decorator specified  

To reflect recent product decisions, made streetNumber required for all countries in project scope. 

### What should reviewers focus on?
<!--
Outline anything you'd like reviewers to pay extra attention to. List open questions for discussion.
-->

...

### The impact of these changes
Support extended form definition for Israel.

### Testing
`bundle exec rake console` 
```
irb(main):005:0> il = Worldwide.region(code:"IL")
=> #<Worldwide::Region:55840 @alpha_three="ISR", @building_number_required=...
irb(main):006:0> il.format_extended
=>
{"edit"=>
  "{country}_{firstName}{lastName}_{company}_{streetName}{streetNumber}_{address2}_{zip}{city}_{phone}"}
irb(main):007:0> il.additional_address_fields
=>
{"address1"=>
  [{"key"=>"streetName", "required"=>true},
   {"key"=>"streetNumber", "required"=>true}]}
```

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
