### PR TITLE
Add support for a `line2` address field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-nil.
+- Add support for a line2 address field [#173](https://github.com/Shopify/worldwide/pull/173)
 
 ---
 

--- a/db/data/regions/BR.yml
+++ b/db/data/regions/BR.yml
@@ -20,7 +20,7 @@ format:
   edit: "{country}_{firstName}{lastName}_{company}_{zip}_{address1}_{address2}_{city}{province}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city} {province}_{country}_{phone}"
 format_extended:
-  edit: "{country}_{firstName}{lastName}_{company}_{zip}_{streetName}{streetNumber}_{address2}{neighborhood}_{city}{province}_{phone}"
+  edit: "{country}_{firstName}{lastName}_{company}_{zip}_{streetName}{streetNumber}_{line2}{neighborhood}_{city}{province}_{phone}"
 additional_address_fields:
   address1:
     - key: streetName
@@ -29,7 +29,7 @@ additional_address_fields:
       decorator: ","
       required: true
   address2:
-    - key: address2
+    - key: line2
       required: false
     - key: neighborhood
       decorator: ","

--- a/db/data/regions/CL.yml
+++ b/db/data/regions/CL.yml
@@ -15,7 +15,7 @@ format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{province}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{province}_{country}_{phone}"
 format_extended:
-  edit: "{country}_{firstName}{lastName}_{company}_{streetName}{streetNumber}_{address2}{neighborhood}_{zip}{city}_{province}_{phone}"
+  edit: "{country}_{firstName}{lastName}_{company}_{streetName}{streetNumber}_{line2}{neighborhood}_{zip}{city}_{province}_{phone}"
 additional_address_fields:
   address1:
     - key: streetName
@@ -23,7 +23,7 @@ additional_address_fields:
     - key: streetNumber
       required: true
   address2:
-    - key: address2
+    - key: line2
       required: false
     - key: neighborhood
       required: false

--- a/db/data/regions/CO.yml
+++ b/db/data/regions/CO.yml
@@ -16,10 +16,10 @@ format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{city}{province}{zip}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city} {province}_{country}_{phone}"
 format_extended:
-  edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}{neighborhood}_{city}{province}{zip}_{phone}"
+  edit: "{country}_{firstName}{lastName}_{company}_{address1}_{line2}{neighborhood}_{city}{province}{zip}_{phone}"
 additional_address_fields:
   address2:
-    - key: address2
+    - key: line2
       required: false
     - key: neighborhood
       required: false

--- a/db/data/regions/ID.yml
+++ b/db/data/regions/ID.yml
@@ -18,10 +18,10 @@ format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{province}{zip}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{province} {zip}_{country}_{phone}"
 format_extended:
-  edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}{neighborhood}_{city}_{province}{zip}_{phone}"
+  edit: "{country}_{firstName}{lastName}_{company}_{address1}_{line2}{neighborhood}_{city}_{province}{zip}_{phone}"
 additional_address_fields:
   address2:
-    - key: address2
+    - key: line2
       required: false
     - key: neighborhood
       decorator: ","

--- a/db/data/regions/MX.yml
+++ b/db/data/regions/MX.yml
@@ -16,7 +16,7 @@ format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}{province}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city} {province}_{country}_{phone}"
 format_extended:
-  edit: "{country}_{firstName}{lastName}_{company}_{streetName}{streetNumber}_{address2}{neighborhood}_{zip}{city}{province}_{phone}"
+  edit: "{country}_{firstName}{lastName}_{company}_{streetName}{streetNumber}_{line2}{neighborhood}_{zip}{city}{province}_{phone}"
 additional_address_fields:
   address1:
     - key: streetName
@@ -24,7 +24,7 @@ additional_address_fields:
     - key: streetNumber
       required: true
   address2:
-    - key: address2
+    - key: line2
       required: false
     - key: neighborhood
       required: false

--- a/db/data/regions/PH.yml
+++ b/db/data/regions/PH.yml
@@ -16,10 +16,10 @@ format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{province}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{province}_{country}_{phone}"
 format_extended:
-  edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}{neighborhood}_{zip}{city}_{province}_{phone}"
+  edit: "{country}_{firstName}{lastName}_{company}_{address1}_{line2}{neighborhood}_{zip}{city}_{province}_{phone}"
 additional_address_fields:
   address2:
-    - key: address2
+    - key: line2
       required: false
     - key: neighborhood
       decorator: " Barangay"

--- a/db/data/regions/TR.yml
+++ b/db/data/regions/TR.yml
@@ -17,10 +17,10 @@ format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 format_extended:
-  edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}{neighborhood}_{zip}{city}_{phone}"
+  edit: "{country}_{firstName}{lastName}_{company}_{address1}_{line2}{neighborhood}_{zip}{city}_{phone}"
 additional_address_fields:
   address2:
-    - key: address2
+    - key: line2
       required: false
     - key: neighborhood
       required: false

--- a/db/data/regions/TW.yml
+++ b/db/data/regions/TW.yml
@@ -18,7 +18,7 @@ format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{city}{zip}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 format_extended:
-  edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{neighborhood}{city}{zip}_{phone}"
+  edit: "{country}_{firstName}{lastName}_{company}_{address1}_{line2}_{neighborhood}{city}{zip}_{phone}"
 emoji: "\U0001F1F9\U0001F1FC"
 languages:
   - "zh-TW"

--- a/db/data/regions/VN.yml
+++ b/db/data/regions/VN.yml
@@ -14,10 +14,10 @@ format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{city}{zip}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}"
 format_extended:
-  edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{neighborhood}_{city}{zip}_{phone}"
+  edit: "{country}_{firstName}{lastName}_{company}_{address1}_{line2}_{neighborhood}_{city}{zip}_{phone}"
 additional_address_fields:
   address2:
-    - key: address2
+    - key: line2
       required: false
     - key: neighborhood
       decorator: ", Quận"

--- a/db/data/regions/_default/en.yml
+++ b/db/data/regions/_default/en.yml
@@ -121,13 +121,35 @@ en:
             unknown_for_address: Address line 2 may be incorrect.
           warnings:
             contains_too_many_words: Address line 2 is recommended to have less than %{word_count} words
+        line2:
+          label:
+            default: Apartment, suite, etc.
+            optional: Apartment, suite, etc. (optional)
+          errors:
+            blank: Enter an apartment, suite, etc.
+            too_long: The second address line is too long (maximum is %{limit} characters)
+            contains_emojis: The second address line cannot contain emojis
+            contains_mathematical_symbols: The second address line cannot contain mathematical symbols
+            contains_restricted_characters: The second address line can only contain letters, numbers,
+              local characters, and special characters
+            contains_too_many_words: The second address line cannot have more than %{word_count}
+              words
+            contains_html_tags: The second address line cannot contain HTML tags.
+            contains_url: The second address line cannot contain URLs.
+            missing_building_number: Add a building number if you have one.
+            street_unknown_for_zip: Enter a valid street name for %{zip}.
+            building_number_invalid: Building number couldn't be located for %{street},
+              %{zip}.
+            unknown_for_address: The second address line may be incorrect.
+          warnings:
+            contains_too_many_words: The second address line is recommended to have less than %{word_count} words
         neighborhood:
           label:
             default: Neighborhood
             optional: Neighborhood (optional)
           errors:
             blank: Enter a neighborhood
-            too_long: Neighborhood is too long (maximum is 255 characters)
+            too_long: Neighborhood is too long (maximum is %{limit} characters)
             contains_emojis: Neighborhood cannot contain emojis
             contains_mathematical_symbols: Neighborhood cannot contain mathematical symbols
             contains_restricted_characters: Neighborhood can only contain letters, numbers,

--- a/lib/worldwide/address.rb
+++ b/lib/worldwide/address.rb
@@ -14,6 +14,7 @@ module Worldwide
       :phone,
       :street_name,
       :street_number,
+      :line2,
       :neighborhood
 
     def initialize(
@@ -29,6 +30,7 @@ module Worldwide
       phone: nil,
       street_name: nil,
       street_number: nil,
+      line2: nil,
       neighborhood: nil
     )
       @first_name = first_name
@@ -43,6 +45,7 @@ module Worldwide
       @phone = phone
       @street_name = street_name
       @street_number = street_number
+      @line2 = line2
       @neighborhood = neighborhood
     end
 

--- a/lib/worldwide/field.rb
+++ b/lib/worldwide/field.rb
@@ -14,6 +14,7 @@ module Worldwide
       :street_name,
       :street_number,
       :address2,
+      :line2,
       :neighborhood,
       :city,
       :province,

--- a/test/worldwide/address_test.rb
+++ b/test/worldwide/address_test.rb
@@ -106,7 +106,7 @@ module Worldwide
 
     test "concatenated_address2 returns empty string when neither address2 nor additional address fields are present" do
       nil_address = Address.new(country_code: "BR")
-      blank_address = Address.new(address2: "", neighborhood: "", country_code: "BR")
+      blank_address = Address.new(address2: "", line2: "", neighborhood: "", country_code: "BR")
 
       assert_equal "", nil_address.concatenated_address2
       assert_equal "", blank_address.concatenated_address2
@@ -114,15 +114,15 @@ module Worldwide
 
     test "concatenated_address2 ignores additional address fields if they are not defined for the country" do
       nil_address2 = Address.new(neighborhood: "Centretown", country_code: "US")
-      blank_address2 = Address.new(address2: "", neighborhood: "Centretown", country_code: "US")
+      blank_address2 = Address.new(address2: "", line2: "#2", neighborhood: "Centretown", country_code: "US")
 
       assert_equal "", nil_address2.concatenated_address2
       assert_equal "", blank_address2.concatenated_address2
     end
 
-    test "concatenated_address2 returns address2 with no delimiters when only address2 is present" do
-      cl_address = Address.new(address2: "dpto 4", country_code: "CL")
-      br_address = Address.new(address2: "dpto 4", country_code: "BR")
+    test "concatenated_address2 returns address2 with no delimiters when only line2 is present" do
+      cl_address = Address.new(line2: "dpto 4", country_code: "CL")
+      br_address = Address.new(line2: "dpto 4", country_code: "BR")
 
       assert_equal "dpto 4", cl_address.concatenated_address2
       assert_equal "dpto 4", br_address.concatenated_address2
@@ -136,16 +136,16 @@ module Worldwide
       assert_equal " Centro", br_address.concatenated_address2
     end
 
-    test "concatenated_address2 returns address2 concatenated with neighborhood separated by delimiter" do
-      address = Address.new(address2: "dpto 4", neighborhood: "Centro", country_code: "CL")
+    test "concatenated_address2 returns line2 concatenated with neighborhood separated by delimiter" do
+      address = Address.new(line2: "dpto 4", neighborhood: "Centro", country_code: "CL")
 
       assert_equal "dpto 4 Centro", address.concatenated_address2
     end
 
-    test "concatenated_address2 returns address2 concatenated with neighborhood separated by delimiter and decorator" do
-      br_address = Address.new(address2: "dpto 4", neighborhood: "Centro", country_code: "BR")
-      ph_address = Address.new(address2: "apt 4", neighborhood: "294", country_code: "PH")
-      vn_address = Address.new(address2: "apt 4", neighborhood: "Cầu Giấy", country_code: "VN")
+    test "concatenated_address2 returns line2 concatenated with neighborhood separated by delimiter and decorator" do
+      br_address = Address.new(line2: "dpto 4", neighborhood: "Centro", country_code: "BR")
+      ph_address = Address.new(line2: "apt 4", neighborhood: "294", country_code: "PH")
+      vn_address = Address.new(line2: "apt 4", neighborhood: "Cầu Giấy", country_code: "VN")
 
       assert_equal "dpto 4, Centro", br_address.concatenated_address2
       assert_equal "apt 4 Barangay 294", ph_address.concatenated_address2
@@ -214,9 +214,9 @@ module Worldwide
       assert_equal expected_hash, nil_address2.split_address2
     end
 
-    test "split_address2 returns only address2 when address2 does not contain a delimiter" do
+    test "split_address2 returns only line2 when address2 does not contain a delimiter" do
       address = Address.new(address2: "dpto 4", country_code: "CL") # regular space
-      expected_hash = { "address2" => "dpto 4" }
+      expected_hash = { "line2" => "dpto 4" }
 
       assert_equal expected_hash, address.split_address2
     end
@@ -230,18 +230,18 @@ module Worldwide
       assert_equal expected_hash, br_address.split_address2
     end
 
-    test "split_address2 returns address2 and neighborhood when both values are present and seperated by a delimiter" do
+    test "split_address2 returns line2 and neighborhood when both values are present and seperated by a delimiter" do
       cl_address = Address.new(address2: "dpto 4 Centro", country_code: "CL")
-      expected_hash = { "address2" => "dpto 4", "neighborhood" => "Centro" }
+      expected_hash = { "line2" => "dpto 4", "neighborhood" => "Centro" }
 
       assert_equal expected_hash, cl_address.split_address2
     end
 
-    test "split_address2 returns address2 and neighborhood when both values are present and seperated by a delimiter and a decorator" do
+    test "split_address2 returns line2 and neighborhood when both values are present and seperated by a delimiter and a decorator" do
       br_address = Address.new(address2: "dpto 4, Centro", country_code: "BR")
       ph_address = Address.new(address2: "dpto 4 Barangay 294", country_code: "PH")
-      expected_hash_br = { "address2" => "dpto 4", "neighborhood" => "Centro" }
-      expected_hash_ph = { "address2" => "dpto 4", "neighborhood" => "294" }
+      expected_hash_br = { "line2" => "dpto 4", "neighborhood" => "Centro" }
+      expected_hash_ph = { "line2" => "dpto 4", "neighborhood" => "294" }
 
       assert_equal expected_hash_br, br_address.split_address2
       assert_equal expected_hash_ph, ph_address.split_address2

--- a/test/worldwide/region_test.rb
+++ b/test/worldwide/region_test.rb
@@ -364,14 +364,14 @@ module Worldwide
         },],
         [:br, {
           "address1" => [{ "key" => "streetName", "required" => true }, { "key" => "streetNumber", "decorator" => ",", "required" => true }],
-          "address2" => [{ "key" => "address2", "required" => false }, { "key" => "neighborhood", "decorator" => ",", "required" => false }],
+          "address2" => [{ "key" => "line2", "required" => false }, { "key" => "neighborhood", "decorator" => ",", "required" => false }],
         },],
         [:cl, {
           "address1" => [{ "key" => "streetName", "required" => true }, { "key" => "streetNumber", "required" => true }],
-          "address2" => [{ "key" => "address2", "required" => false }, { "key" => "neighborhood", "required" => false }],
+          "address2" => [{ "key" => "line2", "required" => false }, { "key" => "neighborhood", "required" => false }],
         },],
         [:id, {
-          "address2" => [{ "key" => "address2", "required" => false }, { "key" => "neighborhood", "decorator" => ",", "required" => false }],
+          "address2" => [{ "key" => "line2", "required" => false }, { "key" => "neighborhood", "decorator" => ",", "required" => false }],
         },],
       ].each do |region_code, expected_value|
         assert_equal expected_value, Worldwide.region(code: region_code).additional_address_fields

--- a/test/worldwide/region_yml_consistency_test.rb
+++ b/test/worldwide/region_yml_consistency_test.rb
@@ -83,7 +83,7 @@ module Worldwide
 
     test "format_extended keys must belong to a limited set of required and allowed keys" do
       required_format_keys = ["{firstName}", "{lastName}", "{company}", "{country}", "{phone}"]
-      allowed_format_keys = ["{address1}", "{address2}", "{streetName}", "{streetNumber}", "{neighborhood}", "{city}", "{zip}", "{province}"]
+      allowed_format_keys = ["{address1}", "{address2}", "{streetName}", "{streetNumber}", "{line2}", "{neighborhood}", "{city}", "{zip}", "{province}"]
 
       Regions.all.select(&:country?).each do |country|
         next if country.format_extended.blank?


### PR DESCRIPTION
### What are you trying to accomplish?
Part of https://github.com/Shopify/address/issues/2609

### What approach did you choose and why?
Following the same steps we carried out introduce streetName, streetNumber and neighborhood fields to the Address model. Split/concatenation no longer overload address2 as both an input and output parameter.

New translations for line2 largely repeat the copy for address2 (as an apartment/unit field, mostly), but substitute "address2" with "the second address line" in some messages.

Making `neighborhood.errors.too_long` and `line2.errors.too_long` both parameterized, accepting a `size` parameter.  The former was introduced a few days ago, and is not used anywhere yet.

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
