### PR TITLE
Update additional_address_fields and combined_address_format defn's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 - Created npm package `@shopify/worldwide` (see [README.md](./lang/typescript/README.md)) [#167](https://github.com/Shopify/worldwide/pull/167)
+- Update additional_address_fields and introduce combined_address_format definitions, introduce Region#{field}_required? methods for street_name, street_number, and neighborhood [#177](https://github.com/Shopify/worldwide/pull/177)
 
 ---
-
 ## [0.14.0] - 2024-05-29
 
 - Add support for a line2 address field [#173](https://github.com/Shopify/worldwide/pull/173)

--- a/db/data/regions/BE.yml
+++ b/db/data/regions/BE.yml
@@ -27,10 +27,13 @@ format:
 format_extended:
   edit: "{country}_{firstName}{lastName}_{company}_{streetName}{streetNumber}_{address2}_{zip}{city}_{phone}"
 additional_address_fields:
+  - name: streetName
+    required: true
+  - name: streetNumber
+    required: true
+combined_address_format:
   address1:
     - key: streetName
-      required: true
     - key: streetNumber
-      required: true
 emoji: "\U0001F1E7\U0001F1EA"
 timezone: Europe/Brussels

--- a/db/data/regions/BR.yml
+++ b/db/data/regions/BR.yml
@@ -22,18 +22,21 @@ format:
 format_extended:
   edit: "{country}_{firstName}{lastName}_{company}_{zip}_{streetName}{streetNumber}_{line2}{neighborhood}_{city}{province}_{phone}"
 additional_address_fields:
+  - name: streetName
+    required: true
+  - name: streetNumber
+    required: true
+  - name: line2
+  - name: neighborhood
+combined_address_format:
   address1:
     - key: streetName
-      required: true
     - key: streetNumber
       decorator: ","
-      required: true
   address2:
     - key: line2
-      required: false
     - key: neighborhood
       decorator: ","
-      required: false
 emoji: "\U0001F1E7\U0001F1F7"
 localized_data:
 - name: tax_credential_br

--- a/db/data/regions/CL.yml
+++ b/db/data/regions/CL.yml
@@ -17,16 +17,19 @@ format:
 format_extended:
   edit: "{country}_{firstName}{lastName}_{company}_{streetName}{streetNumber}_{line2}{neighborhood}_{zip}{city}_{province}_{phone}"
 additional_address_fields:
+  - name: streetName
+    required: true
+  - name: streetNumber
+    required: true
+  - name: line2
+  - name: neighborhood
+combined_address_format:
   address1:
     - key: streetName
-      required: true
     - key: streetNumber
-      required: true
   address2:
     - key: line2
-      required: false
     - key: neighborhood
-      required: false
 emoji: "\U0001F1E8\U0001F1F1"
 languages:
   - es

--- a/db/data/regions/CO.yml
+++ b/db/data/regions/CO.yml
@@ -18,11 +18,12 @@ format:
 format_extended:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{line2}{neighborhood}_{city}{province}{zip}_{phone}"
 additional_address_fields:
+  - name: line2
+  - name: neighborhood
+combined_address_format:
   address2:
     - key: line2
-      required: false
     - key: neighborhood
-      required: false
 emoji: "\U0001F1E8\U0001F1F4"
 languages:
   - es

--- a/db/data/regions/ES.yml
+++ b/db/data/regions/ES.yml
@@ -24,11 +24,14 @@ format:
 format_extended:
   edit: "{country}_{firstName}{lastName}_{company}_{streetName}{streetNumber}_{address2}_{zip}{city}{province}_{phone}"
 additional_address_fields:
+  - name: streetName
+    required: true
+  - name: streetNumber
+    required: true
+combined_address_format:
   address1:
     - key: streetName
-      required: true
     - key: streetNumber
-      required: true
 emoji: "\U0001F1EA\U0001F1F8"
 zones:
 - name: A Coruña

--- a/db/data/regions/ID.yml
+++ b/db/data/regions/ID.yml
@@ -20,12 +20,13 @@ format:
 format_extended:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{line2}{neighborhood}_{city}_{province}{zip}_{phone}"
 additional_address_fields:
+  - name: line2
+  - name: neighborhood
+combined_address_format:
   address2:
     - key: line2
-      required: false
     - key: neighborhood
       decorator: ","
-      required: false
 emoji: "\U0001F1EE\U0001F1E9"
 zones:
 - name: Aceh

--- a/db/data/regions/IL.yml
+++ b/db/data/regions/IL.yml
@@ -19,11 +19,14 @@ format:
 format_extended:
   edit: "{country}_{firstName}{lastName}_{company}_{streetName}{streetNumber}_{address2}_{zip}{city}_{phone}"
 additional_address_fields:
+  - name: streetName
+    required: true
+  - name: streetNumber
+    required: true
+combined_address_format:
   address1:
     - key: streetNumber
-      required: true
     - key: streetName
-      required: true
 emoji: "\U0001F1EE\U0001F1F1"
 languages:
   - ar

--- a/db/data/regions/MX.yml
+++ b/db/data/regions/MX.yml
@@ -18,16 +18,19 @@ format:
 format_extended:
   edit: "{country}_{firstName}{lastName}_{company}_{streetName}{streetNumber}_{line2}{neighborhood}_{zip}{city}{province}_{phone}"
 additional_address_fields:
+  - name: streetName
+    required: true
+  - name: streetNumber
+    required: true
+  - name: line2
+  - name: neighborhood
+combined_address_format:
   address1:
     - key: streetName
-      required: true
     - key: streetNumber
-      required: true
   address2:
     - key: line2
-      required: false
     - key: neighborhood
-      required: false
 emoji: "\U0001F1F2\U0001F1FD"
 languages:
   - es

--- a/db/data/regions/NL.yml
+++ b/db/data/regions/NL.yml
@@ -26,10 +26,13 @@ format:
 format_extended:
   edit: "{country}_{firstName}{lastName}_{company}_{streetName}{streetNumber}_{address2}_{zip}{city}_{phone}"
 additional_address_fields:
+  - name: streetName
+    required: true
+  - name: streetNumber
+    required: true
+combined_address_format:
   address1:
     - key: streetName
-      required: true
     - key: streetNumber
-      required: true
 emoji: "\U0001F1F3\U0001F1F1"
 timezone: Europe/Amsterdam

--- a/db/data/regions/PH.yml
+++ b/db/data/regions/PH.yml
@@ -18,12 +18,14 @@ format:
 format_extended:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{line2}{neighborhood}_{zip}{city}_{province}_{phone}"
 additional_address_fields:
+  - name: line2
+  - name: neighborhood
+    required: true
+combined_address_format:
   address2:
     - key: line2
-      required: false
     - key: neighborhood
       decorator: " Barangay"
-      required: true
 emoji: "\U0001F1F5\U0001F1ED"
 languages:
   - en

--- a/db/data/regions/TR.yml
+++ b/db/data/regions/TR.yml
@@ -19,11 +19,13 @@ format:
 format_extended:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{line2}{neighborhood}_{zip}{city}_{phone}"
 additional_address_fields:
+  - name: line2
+  - name: neighborhood
+    required: true
+combined_address_format:
   address2:
     - key: line2
-      required: false
     - key: neighborhood
-      required: false
 emoji: "\U0001F1F9\U0001F1F7"
 languages:
   - tr

--- a/db/data/regions/TW.yml
+++ b/db/data/regions/TW.yml
@@ -19,6 +19,14 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 format_extended:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{line2}_{neighborhood}{city}{zip}_{phone}"
+additional_address_fields:
+  - name: line2
+  - name: neighborhood
+    required: true
+combined_address_format:
+  address2:
+    - key: line2
+    - key: neighborhood
 emoji: "\U0001F1F9\U0001F1FC"
 languages:
   - "zh-TW"

--- a/db/data/regions/VN.yml
+++ b/db/data/regions/VN.yml
@@ -16,12 +16,14 @@ format:
 format_extended:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{line2}_{neighborhood}_{city}{zip}_{phone}"
 additional_address_fields:
+  - name: line2
+  - name: neighborhood
+    required: true
+combined_address_format:
   address2:
     - key: line2
-      required: false
     - key: neighborhood
       decorator: ", Quận"
-      required: false
 emoji: "\U0001F1FB\U0001F1F3"
 languages:
   - fr

--- a/lib/worldwide/address.rb
+++ b/lib/worldwide/address.rb
@@ -149,23 +149,23 @@ module Worldwide
     def concatenated_address1
       return address1 if address1.present?
 
-      additional_fields = region.additional_address_fields["address1"] || []
+      additional_fields = region.combined_address_format["address1"] || []
       concatenate_fields(additional_fields)
     end
 
     def concatenated_address2
-      additional_fields = region.additional_address_fields["address2"] || []
+      additional_fields = region.combined_address_format["address2"] || []
       concatenate_fields(additional_fields)
     end
 
     def split_address1
-      additional_fields = region.additional_address_fields["address1"] || []
+      additional_fields = region.combined_address_format["address1"] || []
       split_fields_arr = address1&.split(RESERVED_DELIMITER) || []
       split_fields(additional_fields, split_fields_arr)
     end
 
     def split_address2
-      additional_fields = region.additional_address_fields["address2"] || []
+      additional_fields = region.combined_address_format["address2"] || []
       split_fields_arr = address2&.split(RESERVED_DELIMITER) || []
       split_fields(additional_fields, split_fields_arr)
     end

--- a/lib/worldwide/regions_loader.rb
+++ b/lib/worldwide/regions_loader.rb
@@ -95,7 +95,8 @@ module Worldwide
     end
 
     def apply_territory_attributes(region, spec)
-      region.additional_address_fields = spec["additional_address_fields"] || {}
+      region.additional_address_fields = spec["additional_address_fields"] || []
+      region.combined_address_format = spec["combined_address_format"] || {}
       region.building_number_required = spec["building_number_required"] || false
       region.building_number_may_be_in_address2 = spec["building_number_may_be_in_address2"] || false
       currency_code = spec["currency"]

--- a/test/worldwide/region_test.rb
+++ b/test/worldwide/region_test.rb
@@ -282,6 +282,45 @@ module Worldwide
       end
     end
 
+    test "street_name_required? returns values as expected" do
+      street_name_not_required_countries = [:ca, :us, :id]
+      street_name_required_countries = [:nl, :be, :br, :cl, :es]
+
+      street_name_not_required_countries.each do |country_code|
+        assert_equal false, Worldwide.region(code: country_code).street_name_required?
+      end
+
+      street_name_required_countries.each do |country_code|
+        assert_predicate Worldwide.region(code: country_code), :street_name_required?
+      end
+    end
+
+    test "street_number_required? returns values as expected" do
+      street_number_not_required_countries = [:ca, :us, :id]
+      street_number_required_countries = [:be, :br, :cl, :es]
+
+      street_number_not_required_countries.each do |country_code|
+        assert_equal false, Worldwide.region(code: country_code).street_number_required?
+      end
+
+      street_number_required_countries.each do |country_code|
+        assert_predicate Worldwide.region(code: country_code), :street_number_required?
+      end
+    end
+
+    test "neighborhood_required? returns values as expected" do
+      neighborhood_not_required_countries = [:ca, :cl, :mx, :id]
+      neighborhood_required_countries = [:ph, :vn, :tr]
+
+      neighborhood_not_required_countries.each do |country_code|
+        assert_equal false, Worldwide.region(code: country_code).neighborhood_required?
+      end
+
+      neighborhood_required_countries.each do |country_code|
+        assert_predicate Worldwide.region(code: country_code), :neighborhood_required?
+      end
+    end
+
     test "associated_country returns the expected country" do
       {
         ca: "CA",
@@ -353,26 +392,35 @@ module Worldwide
       end
     end
 
-    test "additional_address_fields returns values as expected" do
+    test "combined_address_format returns values as expected" do
       [
         [:us, {}],
         [:il, {
-          "address1" => [{ "key" => "streetNumber", "required" => true }, { "key" => "streetName", "required" => true }],
-        },],
-        [:be, {
-          "address1" => [{ "key" => "streetName", "required" => true }, { "key" => "streetNumber", "required" => true }],
+          "address1" => [{ "key" => "streetNumber" }, { "key" => "streetName" }],
         },],
         [:br, {
-          "address1" => [{ "key" => "streetName", "required" => true }, { "key" => "streetNumber", "decorator" => ",", "required" => true }],
-          "address2" => [{ "key" => "line2", "required" => false }, { "key" => "neighborhood", "decorator" => ",", "required" => false }],
+          "address1" => [{ "key" => "streetName" }, { "key" => "streetNumber", "decorator" => "," }],
+          "address2" => [{ "key" => "line2" }, { "key" => "neighborhood", "decorator" => "," }],
         },],
         [:cl, {
-          "address1" => [{ "key" => "streetName", "required" => true }, { "key" => "streetNumber", "required" => true }],
-          "address2" => [{ "key" => "line2", "required" => false }, { "key" => "neighborhood", "required" => false }],
+          "address1" => [{ "key" => "streetName" }, { "key" => "streetNumber" }],
+          "address2" => [{ "key" => "line2" }, { "key" => "neighborhood" }],
         },],
         [:id, {
-          "address2" => [{ "key" => "line2", "required" => false }, { "key" => "neighborhood", "decorator" => ",", "required" => false }],
+          "address2" => [{ "key" => "line2" }, { "key" => "neighborhood", "decorator" => "," }],
         },],
+      ].each do |region_code, expected_value|
+        assert_equal expected_value, Worldwide.region(code: region_code).combined_address_format
+      end
+    end
+
+    test "additional_address_fields returns values as expected" do
+      [
+        [:us, []],
+        [:br, [{ "name" => "streetName", "required" => true }, { "name" => "streetNumber", "required" => true }, { "name" => "line2" }, { "name" => "neighborhood" }]],
+        [:be, [{ "name" => "streetName", "required" => true }, { "name" => "streetNumber", "required" => true }]],
+        [:id, [{ "name" => "line2" }, { "name" => "neighborhood" }]],
+        [:tr, [{ "name" => "line2" }, { "name" => "neighborhood", "required" => true }]],
       ].each do |region_code, expected_value|
         assert_equal expected_value, Worldwide.region(code: region_code).additional_address_fields
       end


### PR DESCRIPTION
### What are you trying to accomplish?
These include the changes necessary for presence validation on the additional address fields. 

_Part of https://github.com/Shopify/address/issues/2569_

### What approach did you choose and why?
`Region.rb`
- added `combined_address_format` attribute 
- added the following instance methods
  - `street_name_required?`
  - `street_number_required?`
  - `neighborhood_required?`
- did not add `line_2_required?` as no countries will have this requirement


`Address.rb`
- updated concat + splitting methods to leverage `combined_address_format` 

`regions/*.yml`
- updated `additional_address_fields` definitions to return an array of fields + field requirements
- introduced `combined_address_format` defn to return a hash of the address1 and address2 format 

`TW.yml` 
- added base definitions for fields and combined format 

Added consistency tests to ensure that
1. a region's `additional_address_fields` name values are allowed 
2. a region's `additional_address_fields` are present in the `combined_address_format` definition

### What should reviewers focus on?
Double check the yml definitions. 

### The impact of these changes
Allows callers to check for field requirement. 

`additional_address_fields` will now return an array of fields + field requirements

No impact on concatenation and splitting logic. 

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

...

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
