### PR TITLE
Set specific pnpm version in CI

### DIFF
--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 9.1.3
       - name: Install dependencies
         run: pnpm install
       - name: Typecheck

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -10,7 +10,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   release:
     name: Release
-    runs-on: shopify-ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -23,7 +23,7 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 9.1.3
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Create release Pull Request or publish to NPM


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes a TS build issue in the CI introduced in #167 due to strict package manager versioning. Also uses correct runner in the npm release job.

See: https://github.com/Shopify/worldwide/actions/runs/9303226439/job/25605062451

### What approach did you choose and why?

Went with making the pnpm version at `9.1.3` in the GH Actions to abide by strict mode.

Alternatively could disable strict mode, if this causes more problems will do that in the future: See https://github.com/pnpm/pnpm/issues/8087

### What should reviewers focus on?

...

### The impact of these changes

<!--
Are there any specific impacts from this change that you'd like to call out?
-->

...

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

See this PR's passing GH CI build.

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
