### PR TITLE
Stable release, 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-- update neighborhood too_long error message, add MX, PH neighborhood labels [#182](https://github.com/Shopify/worldwide/pull/182)
+- Nil.
 
 ---
+
+## [1.0.0] - 2024-05-30
+
+- update neighborhood too_long error message, add MX, PH neighborhood labels [#182](https://github.com/Shopify/worldwide/pull/182)
+
 ## [0.15.0] - 2024-05-30
 
 - Created npm package `@shopify/worldwide` (see [README.md](./lang/typescript/README.md)) [#167](https://github.com/Shopify/worldwide/pull/167)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (0.15.0)
+    worldwide (1.0.0)
       activesupport (>= 7.0)
       i18n
       phonelib (~> 0.8)

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "0.15.0"
+  VERSION = "1.0.0"
 end


### PR DESCRIPTION
### What are you trying to accomplish?
<!--
Link to an issue or provide enough context so that someone new can understand the 'why' behind this change.
-->

* With the release of our demonstration site for https://github.com/Shopify/atlas_engine, we'd like to bump AtlasEngine and Worldwide to a stable release version of > 1.0.0.
* Only functional changes in this release are:
  * update neighborhood too_long error message, add MX, PH neighborhood labels [#182](https://github.com/Shopify/worldwide/pull/182)

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
