### PR TITLE
Merge language field in region ymls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-- Nil.
+- Merge duplicate language definition on some region yaml files to restore missing languages; `NO` adds "en" and "nb", `SA` adds "en", SG does not change [#188](https://github.com/Shopify/worldwide/pull/188)
 
 ---
 

--- a/db/data/regions/NO.yml
+++ b/db/data/regions/NO.yml
@@ -17,10 +17,9 @@ week_start_day: monday
 languages:
   - en
   - nb
+  - "no"
 format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1F3\U0001F1F4"
-languages:
-  - "no"
 timezone: Europe/Oslo

--- a/db/data/regions/SA.yml
+++ b/db/data/regions/SA.yml
@@ -19,6 +19,4 @@ format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{city}{zip}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}"
 emoji: "\U0001F1F8\U0001F1E6"
-languages:
-  - ar
 timezone: Asia/Riyadh

--- a/db/data/regions/SG.yml
+++ b/db/data/regions/SG.yml
@@ -15,13 +15,10 @@ week_start_day: sunday
 autofill_city_enabled: true
 languages:
   - en
+  - ms
   - zh-CN
 format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{zip}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{country} {zip}_{phone}"
 emoji: "\U0001F1F8\U0001F1EC"
-languages:
-  - en
-  - ms
-  - "zh-CN"
 timezone: Asia/Singapore


### PR DESCRIPTION
### What are you trying to accomplish?
<!--
Link to an issue or provide enough context so that someone new can understand the 'why' behind this change.
-->

Merge duplicate `language` fields in a few region yamls (`NO`, `SA`, `SG`).

### What approach did you choose and why?
<!--
There are many ways to solve a problem. How did you approach this problem and why?
-->

Merged to include all languages specified across the file. 

### What should reviewers focus on?
<!--
Outline anything you'd like reviewers to pay extra attention to. List open questions for discussion.
-->

Double check to make sure the updated languages are correct. 

### The impact of these changes
<!--
Are there any specific impacts from this change that you'd like to call out?
-->

Confirmed that ruby uses the last definition in the yaml for conflicts:
- `NO` changes from `no` to `en, nb, no`
- `SA` changes from `ar` to `en, ar`
- `SG` doesn't change

~Depending on how ruby handles parsing the yaml, this could mean the languages are changing. Unsure if it was silently merging, picking the last definition's values, or the first definition's values.~

This fix is necessary for the upcoming JS implementation as duplicate field definitions break parsing.

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

Tested using the snippet @cejaekl provided:
```ruby
%w(NO SA SG).map{|cc| [cc, Worldwide.region(code: cc).languages.join(",")]}
```

Output:
```
[["NO", "en,nb,no"], ["SA", "ar,en"], ["SG", "en,ms,zh-CN"]]
```

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
