### PR TITLE
Add ESM output to the npm package

### DIFF
--- a/lang/typescript/.changeset/dirty-jobs-kick.md
+++ b/lang/typescript/.changeset/dirty-jobs-kick.md
@@ -1,0 +1,5 @@
+---
+'@shopify/worldwide': patch
+---
+
+Include ESM module

--- a/lang/typescript/README.md
+++ b/lang/typescript/README.md
@@ -126,6 +126,12 @@ pnpm build
 
 This will use Rollup to generate `dist/`, which is our bundled JS package.
 
+Verify the npm package is bundled correctly with [publint](https://publint.dev/). This should only need to be done when changing `rollup.config.ts` to modify the bundle output:
+
+```sh
+npx publint
+```
+
 ### Other commands
 
 ```sh

--- a/lang/typescript/package.json
+++ b/lang/typescript/package.json
@@ -9,8 +9,25 @@
   "publishConfig": {
     "access": "public"
   },
-  "main": "dist/index.js",
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist/**/*"
+  ],
+  "exports": {
+    ".": {
+      "import":  {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "require": "./dist/index.cjs"
+      }
+    }
+  },
   "packageManager": "pnpm@9.1.3+sha512.7c2ea089e1a6af306409c4fc8c4f0897bdac32b772016196c469d9428f1fe2d5a21daf8ad6512762654ac645b5d9136bb210ec9a00afa8dbc4677843ba362ecd",
   "scripts": {
     "build": "rollup -c rollup.config.ts --configPlugin typescript --bundleConfigAsCjs",
@@ -20,7 +37,7 @@
     "format": "prettier src *.config.ts --write",
     "test": "vitest run --config vitest.config.ts",
     "test:watch": "vitest",
-    "release": "pnpm build && changeset publish"
+    "release": "pnpm build && changeset publish --no-git-tag"
   },
   "devDependencies": {
     "@babel/core": "^7.24.5",

--- a/lang/typescript/rollup.config.ts
+++ b/lang/typescript/rollup.config.ts
@@ -32,11 +32,18 @@ function transformRegionYaml(data: ValidYamlType) {
 
 export const mainConfig = {
   input: 'src/index.ts',
-  output: {
-    dir: 'dist',
-    format: 'cjs',
-    sourcemap: true,
-  },
+  output: [
+    {
+      file: 'dist/index.mjs',
+      format: 'esm',
+      sourcemap: true,
+    },
+    {
+      file: 'dist/index.cjs',
+      format: 'cjs',
+      sourcemap: true,
+    },
+  ],
   plugins: [
     {
       // Custom yaml parsing plugin to load all region yamls as one object
@@ -70,14 +77,19 @@ export const mainConfig = {
         return undefined;
       },
     },
-    typescript(),
+    typescript({
+      exclude: ['**/*.config.ts', '**/*.test.ts'],
+    }),
   ],
 };
 
 const dtsConfig = {
   // path to your declaration files root
   input: './dist/dts/src/index.d.ts',
-  output: [{file: 'dist/index.d.ts', format: 'cjs'}],
+  output: [
+    {file: 'dist/index.d.ts', format: 'esm'},
+    {file: 'dist/index.d.cts', format: 'cjs'},
+  ],
   plugins: [dts()],
 };
 


### PR DESCRIPTION
### What are you trying to accomplish?
<!--
Link to an issue or provide enough context so that someone new can understand the 'why' behind this change.
-->

Resolves https://github.com/Shopify/address/issues/2622

Includes an ES Module as part of the npm package and also excludes test/config files from the bundled output. This allows better [tree shaking](https://developer.mozilla.org/en-US/docs/Glossary/Tree_shaking) among other benefits.

This also turns off git tagging for the changeset publish step as we don't want to conflict with the Ruby gem tags and excludes test/config files from the bundle output.

### What approach did you choose and why?
<!--
There are many ways to solve a problem. How did you approach this problem and why?
-->

Opted to bundle both ESM and CJS modules in the package to offer flexibility to users, rather than just switching from CJS to ESM outright. This is somewhat common in open source packages as ESM is the present/future but a lot of JS code does not support ESM yet. Rollup makes it fairly simple to configure this, so its not a huge lift and the code is written in TypeScript anyway so we're always including a compilation step. [More on ESM vs CommonJS](https://nikolasbarwicki.com/articles/commonjs-vs-es-modules-the-shift-from-require-to-import/)

### What should reviewers focus on?
<!--
Outline anything you'd like reviewers to pay extra attention to. List open questions for discussion.
-->

...

### The impact of these changes
<!--
Are there any specific impacts from this change that you'd like to call out?
-->

...

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

Since there's no functional changes to the actual package code, just how it's bundled for distribution for use in other projects, I ran a linter thats made for checking npm package setup and a test project that imports the locally built version of the package.

Ran the [publint](https://publint.dev/) tool using `npx publint` to check that the package was setup correctly with best practices and to catch errors early.

<img width="588" alt="Screenshot 2024-06-07 at 1 47 00 PM" src="https://github.com/Shopify/worldwide/assets/1051880/04608000-1b26-4913-99f3-4f42e3749983">

Also imported the package in a test project. The test project includes ESM, CJS, and TS versions of the same code, which just test that concatenate functions work. Included some snippets from that project here.

<details><summary><code>index.{ts,mjs,cjs}</code></summary>

```js
// ESM/TS
import { concatenateAddress1 } from "@shopify/worldwide";
// CJS
// const { concatenateAddress1 } = require('@shopify/worldwide')

const usConcat = concatenateAddress1({
  countryCode: "US",
  address1: "123 Main",
});
const usConcatValid = usConcat === "123 Main";
console.log(`US: ${usConcat} ${usConcatValid ? "✅" : "❌"}`);

const brConcat = concatenateAddress1({
  countryCode: "BR",
  streetName: "Main",
  streetNumber: "123",
});
const brConcatValid = brConcat === "Main,\u00A0123";
console.log(`BR: ${brConcat} ${brConcatValid ? "✅" : "❌"}`);
```

</details> 

<details><summary><code>package.json</code></summary>

```json
{
  "name": "test-worldwide",
  "version": "1.0.0",
  "scripts": {
    "cjs": "node index.cjs",
    "esm": "node index.mjs",
    "ts-cjs": "tsc --project tsconfig.cjs.json && echo '{\"type\": \"commonjs\"}' > cjs/package.json && node cjs/index.js",
    "ts-esm": "tsc --project tsconfig.esm.json && echo '{\"type\": \"module\"}' > esm/package.json && node esm/index.js"
  },
  "author": "",
  "license": "ISC",
  "description": "",
  "dependencies": {
    "typescript": "^5.4.5",
    "@shopify/worldwide": "file:RELATIVE_PATH_TO_LANG_TYPESCRIPT"
  },
  "packageManager": "pnpm@9.1.3+sha512.7c2ea089e1a6af306409c4fc8c4f0897bdac32b772016196c469d9428f1fe2d5a21daf8ad6512762654ac645b5d9136bb210ec9a00afa8dbc4677843ba362ecd"
}
```

</details> 

<img width="745" alt="Screenshot 2024-06-07 at 2 05 40 PM" src="https://github.com/Shopify/worldwide/assets/1051880/67799b9b-1963-4bb0-ab24-e70ed29ee0c7">

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
