### PR TITLE
NPM Package Version 0.2.1

### DIFF
--- a/lang/typescript/.changeset/dirty-jobs-kick.md
+++ b/lang/typescript/.changeset/dirty-jobs-kick.md
@@ -1,5 +1,0 @@
----
-'@shopify/worldwide': patch
----
-
-Include ESM module

--- a/lang/typescript/CHANGELOG.md
+++ b/lang/typescript/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @shopify/worldwide
 
+## 0.2.1
+
+### Patch Changes
+
+- 40adfed: Include ESM module
+
 ## 0.2.0
 
 ### Minor Changes

--- a/lang/typescript/package.json
+++ b/lang/typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/worldwide",
   "description": "Utilities for parsing and formatting address fields",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "repository": "git@github.com:Shopify/worldwide.git",
   "author": "Shopify Inc.",
   "license": "MIT",
@@ -18,7 +18,7 @@
   ],
   "exports": {
     ".": {
-      "import":  {
+      "import": {
         "types": "./dist/index.d.ts",
         "import": "./dist/index.mjs"
       },


### PR DESCRIPTION
### What are you trying to accomplish?
<!--
Link to an issue or provide enough context so that someone new can understand the 'why' behind this change.
-->

Update npm package version to 0.2.1 with new ES Module output.

Replaces #197 because github-actions bot cannot sign the CLA, will need to fix that in the future but I want to make sure this gets published.