### PR TITLE
update street_name and street_number too_long error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Security in case of vulnerabilities.
 
 ## [Unreleased]
+- update street_name and street_number too_long error message [#203](https://github.com/Shopify/worldwide/pull/203)
 
 --
 

--- a/db/data/regions/_default/en.yml
+++ b/db/data/regions/_default/en.yml
@@ -100,7 +100,7 @@ en:
           errors:
             blank_instructional: Enter a street
             blank_informative: Street is missing
-            too_long_instructional: Street is too long (maximum is 255 characters)
+            too_long_instructional: Street is too long (maximum is %{limit} characters)
             too_long_informative: Street is too long
             contains_emojis_instructional: Street can't contain emojis
             contains_emojis_informative: Street can't contain emojis
@@ -128,7 +128,7 @@ en:
           errors:
             blank_instructional: Enter a building number
             blank_informative: Building number is missing
-            too_long_instructional: Building number is too long (maximum is 255 characters)
+            too_long_instructional: Building number is too long (maximum is %{limit} characters)
             too_long_informative: Building number is too long
             contains_emojis_instructional: Building number can't contain emojis
             contains_emojis_informative: Building number can't contain emojis


### PR DESCRIPTION
### What are you trying to accomplish?
Noticed while testing validation that the error messages for street_name and street_number indicates a limit of 255. 

Neighborhood and line2 errors already use a dynamic limit; street_name and street_number need to be similarly updated. 

part of https://github.com/Shopify/address/issues/2569

### What approach did you choose and why?
Updated all street_name and street_number error messages, replacing `255` with `%{limit}`


### What should reviewers focus on?
I've updated all language files manually; still required to request translations async. I do not expect this to cause issues. 

### The impact of these changes
Error messages for street_name and street_number `too_long` will accept an option, ie 
```
Worlwide.region(code: CA).field(key: street_name)&.error(code: :too_long, options: { limit: limit }).to_s
```
### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

...

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
