### PR TITLE
All error translations now have a _instructional and _informative message key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,12 +26,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Security in case of vulnerabilities.
 
 ## [Unreleased]
-- Additional field definitions in AE, CR, KW, PA, PE, SA, updated decorators for PH, VN  [#206](https://github.com/Shopify/worldwide/pull/206)
-- update street_name and street_number too_long error message [#203](https://github.com/Shopify/worldwide/pull/203)
-- Update translations for neighborhood too_long error message, add translations for localized neighborhood errors in MX, PH [#191](https://github.com/Shopify/worldwide/pull/191)
-- Generate concatenated address1/2 values when some additional field values are present [#199](https://github.com/Shopify/worldwide/pull/199)
 
 --
+
+## [1.3.0] - 2024-06-10
+
+- Update translations for neighborhood too_long error message, add translations for localized neighborhood errors in MX, PH [#191](https://github.com/Shopify/worldwide/pull/191)
+- Generate concatenated address1/2 values when some additional field values are present [#199](https://github.com/Shopify/worldwide/pull/199)
+- update street_name and street_number too_long error message [#203](https://github.com/Shopify/worldwide/pull/203)
+- Additional field definitions in AE, CR, KW, PA, PE, SA, updated decorators for PH, VN  [#206](https://github.com/Shopify/worldwide/pull/206)
+- All error messages now contain an `_instructional` and `_informative` key. If the `Worldwide::Field::error` method is called with a `code` that does not end in either `_instructional` or `_informative`, the `Worldwide::Field::error` method will append `_instructional` to the `code` and returns this error message. [#205](https://github.com/Shopify/worldwide/pull/205)
 
 ## [1.2.0] - 2024-06-05
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (1.2.0)
+    worldwide (1.3.0)
       activesupport (>= 7.0)
       i18n
       phonelib (~> 0.8)

--- a/db/data/regions/AT/en.yml
+++ b/db/data/regions/AT/en.yml
@@ -15,4 +15,5 @@ en:
             default: Additional address
             optional: Additional address (optional)
           errors:
-            blank: Enter additional address information
+            blank_instructional: Enter additional address information
+            blank_informative: Additional address information is missing

--- a/db/data/regions/CA/en.yml
+++ b/db/data/regions/CA/en.yml
@@ -16,5 +16,6 @@ en:
             unknown_for_city_informative: Province isn't valid for %{city}
             unknown_for_zip_instructional: Select a valid province for %{zip}
             unknown_for_zip_informative: Province isn't valid for %{zip}
-            unknown_for_address: Province may be incorrect
+            unknown_for_address_instructional: Province may be incorrect
+            unknown_for_address_informative: Province may be incorrect
 

--- a/db/data/regions/CL/en.yml
+++ b/db/data/regions/CL/en.yml
@@ -8,18 +8,28 @@ en:
             default: Commune
             optional: Commune (optional)
           errors:
-            blank: Enter a commune
-            too_long: Commune is too long (maximum is %{limit} characters)
-            contains_emojis: Commune cannot contain emojis
-            contains_mathematical_symbols: Commune cannot contain mathematical symbols
-            contains_restricted_characters: Commune can only contain letters, numbers,
+            blank_instructional: Enter a commune
+            blank_informative: Commune is missing
+            too_long_instructional: Commune is too long (maximum is %{limit} characters)
+            too_long_informative: Commune is too long
+            contains_emojis_instructional: Commune can't contain emojis
+            contains_emojis_informative: Commune can't contain emojis
+            contains_mathematical_symbols_instructional: Commune can't contain mathematical symbols
+            contains_mathematical_symbols_informative: Commune can't contain mathematical symbols
+            contains_restricted_characters_instructional: Commune can only contain letters, numbers,
               local characters, and special characters
-            contains_too_many_words: Commune cannot have more than %{word_count}
-              words
-            contains_html_tags: Commune cannot contain HTML tags.
-            contains_url: Commune cannot contain URLs.
-            unknown_for_city: Enter a valid commune name for %{city}.
-            unknown_for_zip: Enter a valid commune name for %{zip}.
-            unknown_for_address: Commune may be incorrect.
+            contains_restricted_characters_informative: Commune can't contain restricted characters
+            contains_too_many_words_instructional: Commune must have fewer than %{word_count} words
+            contains_too_many_words_informative: Commune must have fewer than %{word_count} words
+            contains_html_tags_instructional: Commune can't contain HTML tags
+            contains_html_tags_informative: Commune can't contain HTML tags
+            contains_url_instructional: Commune can't contain URLs
+            contains_url_informative: Commune can't contain URLs
+            unknown_for_city_instructional: Enter a valid commune for %{city}
+            unknown_for_city_informative: Enter a valid commune for %{city}
+            unknown_for_zip_instructional: Enter a valid commune for %{zip}
+            unknown_for_zip_informative: Enter a valid commune for %{zip}
+            unknown_for_address_instructional: Commune may be incorrect
+            unknown_for_address_informative: Commune may be incorrect
           warnings:
             contains_too_many_words: Commune is recommended to have less than %{word_count} words

--- a/db/data/regions/MX/en.yml
+++ b/db/data/regions/MX/en.yml
@@ -22,18 +22,28 @@ en:
             default: Colony
             optional: Colony (optional)
           errors:
-            blank: Enter a colony
-            too_long: Colony is too long (maximum is %{limit} characters)
-            contains_emojis: Colony cannot contain emojis
-            contains_mathematical_symbols: Colony cannot contain mathematical symbols
-            contains_restricted_characters: Colony can only contain letters, numbers,
+            blank_instructional: Enter a colony
+            blank_informative: Colony is missing
+            too_long_instructional: Colony is too long (maximum is %{limit} characters)
+            too_long_informative: Colony is too long
+            contains_emojis_instructional: Colony can't contain emojis
+            contains_emojis_informative: Colony can't contain emojis
+            contains_mathematical_symbols_instructional: Colony can't contain mathematical symbols
+            contains_mathematical_symbols_informative: Colony can't contain mathematical symbols
+            contains_restricted_characters_instructional: Colony can only contain letters, numbers,
               local characters, and special characters
-            contains_too_many_words: Colony cannot have more than %{word_count}
-              words
-            contains_html_tags: Colony cannot contain HTML tags.
-            contains_url: Colony cannot contain URLs.
-            unknown_for_city: Enter a valid colony name for %{city}.
-            unknown_for_zip: Enter a valid colony name for %{zip}.
-            unknown_for_address: Colony may be incorrect.
+            contains_restricted_characters_informative: Colony can't contain restricted characters
+            contains_too_many_words_instructional: Colony must have fewer than %{word_count} words
+            contains_too_many_words_informative: Colony must have fewer than %{word_count} words
+            contains_html_tags_informative: Colony can't contain HTML
+            contains_html_tags_instructional: Colony can't contain HTML
+            contains_url_instructional: Colony can't contain a URL
+            contains_url_informative: Colony can't contain a URL
+            unknown_for_city_instructional: Enter a valid colony for %{city}
+            unknown_for_city_informative: Enter a valid colony for %{city}
+            unknown_for_zip_instructional: Enter a valid colony for %{zip}
+            unknown_for_zip_informative: Enter a valid colony for %{zip}
+            unknown_for_address_instructional: Colony may be incorrect
+            unknown_for_address_informative: Colony may be incorrect
           warnings:
             contains_too_many_words: Colony is recommended to have less than %{word_count} words

--- a/db/data/regions/PH/en.yml
+++ b/db/data/regions/PH/en.yml
@@ -8,18 +8,28 @@ en:
             default: Barangay
             optional: Barangay (optional)
           errors:
-            blank: Enter a barangay
-            too_long: Barangay is too long (maximum is %{limit} characters)
-            contains_emojis: Barangay cannot contain emojis
-            contains_mathematical_symbols: Barangay cannot contain mathematical symbols
-            contains_restricted_characters: Barangay can only contain letters, numbers,
+            blank_instructional: Enter a barangay
+            blank_informative: Barangay is missing
+            too_long_instructional: Barangay is too long (maximum is %{limit} characters)
+            too_long_informative: Barangay is too long
+            contains_emojis_instructional: Barangay can't contain emojis
+            contains_emojis_informative: Barangay can't contain emojis
+            contains_mathematical_symbols_instructional: Barangay can't contain mathematical symbols
+            contains_mathematical_symbols_informative: Barangay can't contain mathematical symbols
+            contains_restricted_characters_instructional: Barangay can only contain letters, numbers,
               local characters, and special characters
-            contains_too_many_words: Barangay cannot have more than %{word_count}
-              words
-            contains_html_tags: Barangay cannot contain HTML tags.
-            contains_url: Barangay cannot contain URLs.
-            unknown_for_city: Enter a valid barangay name for %{city}.
-            unknown_for_zip: Enter a valid barangay name for %{zip}.
-            unknown_for_address: Barangay may be incorrect.
+            contains_restricted_characters_informative: Barangay can't contain restricted characters
+            contains_too_many_words_instructional: Barangay must have fewer than %{word_count} words
+            contains_too_many_words_informative: Barangay must have fewer than %{word_count} words
+            contains_html_tags_instructional: Barangay can't contain HTML
+            contains_html_tags_informative: Barangay can't contain HTML
+            contains_url_instructional: Barangay can't contain a URL
+            contains_url_informative: Barangay can't contain a URL
+            unknown_for_city_instructional: Enter a valid barangay name for %{city}
+            unknown_for_city_informative: Enter a valid barangay name for %{city}
+            unknown_for_zip_instructional: Enter a valid barangay name for %{zip}
+            unknown_for_zip_informative: Enter a valid barangay name for %{zip}
+            unknown_for_address_instructional: Barangay may be incorrect
+            unknown_for_address_informative: Barangay may be incorrect
           warnings:
             contains_too_many_words: Barangay is recommended to have less than %{word_count} words

--- a/db/data/regions/TH/en.yml
+++ b/db/data/regions/TH/en.yml
@@ -8,5 +8,5 @@ en:
             default: Province
             optional: Province (optional)
           errors:
-            blank_intructional: Select a province
+            blank_instructional: Select a province
             blank_informative: Province is missing

--- a/db/data/regions/TR/en.yml
+++ b/db/data/regions/TR/en.yml
@@ -29,6 +29,7 @@ en:
             unknown_for_city_informative: District isn't valid for %{city}
             unknown_for_zip_instructional: Enter a valid district for %{zip}
             unknown_for_zip_informative: District isn't valid for %{zip}
-            unknown_for_address: District may be incorrect
+            unknown_for_address_instructional: District may be incorrect
+            unknown_for_address_informative: District may be incorrect
           warnings:
             contains_too_many_words: District is recommended to have less than %{word_count} words

--- a/db/data/regions/TW/en.yml
+++ b/db/data/regions/TW/en.yml
@@ -29,6 +29,7 @@ en:
             unknown_for_city_informative: District isn't valid for %{city}
             unknown_for_zip_instructional: Enter a valid district for %{zip}
             unknown_for_zip_informative: District isn't valid for %{zip}
-            unknown_for_address: District may be incorrect
+            unknown_for_address_instructional: District may be incorrect
+            unknown_for_address_informative: District may be incorrect
           warnings:
             contains_too_many_words: District is recommended to have less than %{word_count} words

--- a/db/data/regions/US/en.yml
+++ b/db/data/regions/US/en.yml
@@ -18,7 +18,8 @@ en:
             unknown_for_city_informative: State isn't valid for %{city}
             unknown_for_zip_instructional: Select a valid state for %{zip}
             unknown_for_zip_informative: State isn't valid for %{zip}
-            unknown_for_address: State may be incorrect
+            unknown_for_address_instructional: State may be incorrect
+            unknown_for_address_informative: State may be incorrect
         zip:
           label:
             default: ZIP code
@@ -26,8 +27,8 @@ en:
           errors:
             blank_instructional: Enter a ZIP code
             blank_informative: ZIP code is missing
-            invalid_for_country_instructional: Enter a valid ZIP code for %{country}
-            invalid_for_country_informative: ZIP code isn't valid for %{country}
+            invalid_for_country_instructional: Enter a valid ZIP code for the %{country}
+            invalid_for_country_informative: ZIP code isn't valid for the %{country}
             invalid_for_province_instructional: Enter a valid ZIP code for %{province}
             invalid_for_province_informative: ZIP code isn't valid for %{province}
             invalid_for_country_and_province_instructional: Enter a valid ZIP code for %{province},
@@ -41,4 +42,5 @@ en:
             contains_restricted_characters_informative: ZIP code can't contain restricted characters
             contains_html_tags_instructional: ZIP code can't contain HTML
             contains_html_tags_informative: ZIP code can't contain HTML
-            unknown_for_address: ZIP code may be incorrect
+            unknown_for_address_instructional: ZIP code may be incorrect
+            unknown_for_address_informative: ZIP code may be incorrect

--- a/db/data/regions/UY/en.yml
+++ b/db/data/regions/UY/en.yml
@@ -8,5 +8,5 @@ en:
             default: Department
             optional: Department (optional)
           errors:
-            blank_informational: Select a department
-            blank_instructional: Department is missing
+            blank_instructional: Select a department
+            blank_informative: Department is missing

--- a/db/data/regions/VN/en.yml
+++ b/db/data/regions/VN/en.yml
@@ -28,7 +28,8 @@ en:
             unknown_for_city_instructional: Enter a valid ward name for %{city}
             unknown_for_city_informative: Ward doesn't match %{city}
             unknown_for_zip_instructional: Enter a valid ward name for %{zip}
-            unknown_for_zip_informational: Ward doesn't match %{zip}
-            unknown_for_address: Ward may be incorrect
+            unknown_for_zip_informative: Ward doesn't match %{zip}
+            unknown_for_address_instructional: Ward may be incorrect
+            unknown_for_address_informative: Ward may be incorrect
           warnings:
             contains_too_many_words: Ward is recommended to have less than %{word_count} words

--- a/db/data/regions/_default/en.yml
+++ b/db/data/regions/_default/en.yml
@@ -110,9 +110,9 @@ en:
               local characters, and special characters
             contains_restricted_characters_informative: Street can't contain restricted characters
             contains_too_many_words_instructional: Street can't have more than %{word_count} words
-            contains_too_many_words_informational: Street can't have more than %{word_count} words
+            contains_too_many_words_informative: Street can't have more than %{word_count} words
             contains_html_tags_instructional: Street can't contain HTML
-            contains_html_tags_informational: Street can't contain HTML
+            contains_html_tags_informative: Street can't contain HTML
             contains_url_instructional: Street can't contain a URL
             contains_url_informative: Street can't contain a URL
             street_unknown_for_zip_instructional: Enter a valid street for %{zip}
@@ -157,22 +157,28 @@ en:
             blank_instructional: Enter an apartment, suite, etc
             blank_informative: Apartment or suite is missing
             too_long_instructional: Address line 2 is too long (maximum is 255 characters)
-            too_long_informational: Address line 2 is too long
-            contains_emojis: Address line 2 can't contain emojis
-            contains_mathematical_symbols: Address line 2 can't contain mathematical symbols
-            contains_restricted_characters: Address line 2 can only contain letters, numbers,
+            too_long_informative: Address line 2 is too long
+            contains_emojis_instructional: Address line 2 can't contain emojis
+            contains_emojis_informative: Address line 2 can't contain emojis
+            contains_mathematical_symbols_instructional: Address line 2 can't contain mathematical symbols
+            contains_mathematical_symbols_informative: Address line 2 can't contain mathematical symbols
+            contains_restricted_characters_instructional: Address line 2 can only contain letters, numbers,
               local characters, and special characters
-            contains_too_many_words: Address line 2 can't have more than %{word_count}
-              words
-            contains_html_tags: Address line 2 can't contain HTML
-            contains_url: Address line 2 can't contain a URL
+            contains_restricted_characters_informative: Address line 2 can't contain restricted characters
+            contains_too_many_words_instructional: Address line 2 must have fewer than %{word_count} words
+            contains_too_many_words_informative: Address line 2 must have fewer than %{word_count} words
+            contains_html_tags_instructional: Address line 2 can't contain HTML
+            contains_html_tags_informative: Address line 2 can't contain HTML
+            contains_url_instructional: Address line 2 can't contain a URL
+            contains_url_informative: Address line 2 can't contain a URL
             missing_building_number_instructional: Add a building number if you have one
             missing_building_number_informative: Building number may be missing
             street_unknown_for_zip_instructional: Enter a valid street name for %{zip}
             street_unknown_for_zip_informative: Street name isn't valid for %{zip}
             building_number_invalid_instructional: Building number couldn't be located for %{street}, %{zip}
             building_number_invalid_informative: Building number couldn't be located for %{street}, %{zip}
-            unknown_for_address: Address line 2 may be incorrect
+            unknown_for_address_instructional: Address line 2 may be incorrect
+            unknown_for_address_informative: Address line 2 may be incorrect
           warnings:
             contains_too_many_words: Address line 2 is recommended to have less than %{word_count} words
         line2:
@@ -197,11 +203,16 @@ en:
             contains_html_tags_informative: The second address line can't contain HTML tags
             contains_url_instructional: The second address line can't contain a URL
             contains_url_informative: The second address line can't contain a URL
-            missing_building_number: Add a building number if you have one
-            street_unknown_for_zip: Enter a valid street name for %{zip}
-            building_number_invalid: Building number couldn't be located for %{street},
+            missing_building_number_instructional: Add a building number if you have one
+            missing_building_number_informative: Add a building number if you have one
+            street_unknown_for_zip_instructional: Enter a valid street name for %{zip}
+            street_unknown_for_zip_informative: Enter a valid street name for %{zip}
+            building_number_invalid_instructional: Building number couldn't be located for %{street},
               %{zip}
-            unknown_for_address: The second address line may be incorrect
+            building_number_invalid_informative: Building number couldn't be located for %{street},
+              %{zip}
+            unknown_for_address_instructional: The second address line may be incorrect
+            unknown_for_address_informative: The second address line may be incorrect
           warnings:
             contains_too_many_words: The second address line is recommended to have less than %{word_count} words
         neighborhood:
@@ -209,19 +220,29 @@ en:
             default: Neighborhood
             optional: Neighborhood (optional)
           errors:
-            blank: Enter a neighborhood
-            too_long: Neighborhood is too long (maximum is %{limit} characters)
-            contains_emojis: Neighborhood can't contain emojis
-            contains_mathematical_symbols: Neighborhood can't contain mathematical symbols
-            contains_restricted_characters: Neighborhood can only contain letters, numbers,
+            blank_instructional: Enter a neighborhood
+            blank_informative: Neighborhood is missing
+            too_long_instructional: Neighborhood is too long (maximum is %{limit} characters)
+            too_long_informative: Neighborhood is too long
+            contains_emojis_instructional: Neighborhood can't contain emojis
+            contains_emojis_informative: Neighborhood can't contain emojis
+            contains_mathematical_symbols_instructional: Neighborhood can't contain mathematical symbols
+            contains_mathematical_symbols_informative: Neighborhood can't contain mathematical symbols
+            contains_restricted_characters_instructional: Neighborhood can only contain letters, numbers,
               local characters, and special characters
-            contains_too_many_words: Neighborhood can't have more than %{word_count}
-              words
-            contains_html_tags: Neighborhood can't contain HTML tags
-            contains_url: Neighborhood can't contain URLs
-            unknown_for_city: Enter a valid neighborhood name for %{city}
-            unknown_for_zip: Enter a valid neighborhood name for %{zip}
-            unknown_for_address: Neighborhood may be incorrect
+            contains_restricted_characters_informative: Neighborhood can't contain restricted characters
+            contains_too_many_words_instructional: Neighborhood must have fewer than %{word_count} words
+            contains_too_many_words_informative: Neighborhood must have fewer than %{word_count} words
+            contains_html_tags_instructional: Neighborhood can't contain HTML tags
+            contains_html_tags_informative: Neighborhood can't contain HTML tags
+            contains_url_instructional: Neighborhood can't contain URLs
+            contains_url_informative: Neighborhood can't contain URLs
+            unknown_for_city_instructional: Enter a valid neighborhood name for %{city}
+            unknown_for_city_informative: Enter a valid neighborhood name for %{city}
+            unknown_for_zip_instructional: Enter a valid neighborhood name for %{zip}
+            unknown_for_zip_informative: Enter a valid neighborhood name for %{zip}
+            unknown_for_address_instructional: Neighborhood may be incorrect
+            unknown_for_address_informative: Neighborhood may be incorrect
           warnings:
             contains_too_many_words: Neighborhood is recommended to have less than %{word_count} words
         city:
@@ -231,21 +252,29 @@ en:
           errors:
             blank_instructional: Enter a city
             blank_informative: City is missing
-            too_long: City is too long (maximum is 255 characters)
-            contains_emojis: City can't contain emojis
-            contains_mathematical_symbols: City can't contain mathematical symbols
-            contains_restricted_characters: City can only contain letters, numbers,
+            too_long_instructional: City is too long (maximum is 255 characters)
+            too_long_informative: City is too long
+            contains_emojis_instructional: City can't contain emojis
+            contains_emojis_informative: City can't contain emojis
+            contains_mathematical_symbols_instructional: City can't contain mathematical symbols
+            contains_mathematical_symbols_informative: City can't contain mathematical symbols
+            contains_restricted_characters_instructional: City can only contain letters, numbers,
               local characters, and special characters
-            contains_too_many_words: City can't have more than %{word_count} words
-            contains_html_tags: City can't contain HTML
-            contains_url: City can't contain a URL
+            contains_restricted_characters_informative: City can't contain restricted characters
+            contains_too_many_words_instructional: City must have fewer than %{word_count} words
+            contains_too_many_words_informative: City must have fewer than %{word_count} words
+            contains_html_tags_instructional: City can't contain HTML
+            contains_html_tags_informative: City can't contain HTML
+            contains_url_instructional: City can't contain a URL
+            contains_url_informative: City can't contain a URL
             unknown_for_zip_instructional: Enter a valid city for %{zip}
             unknown_for_zip_informative: City doesn't match %{zip}
             unknown_for_province_instructional: Enter a valid city for %{province}
             unknown_for_province_informative: City doesn't match %{province}
             unknown_for_zip_and_province_instructional: Enter a valid city for %{zip}, %{province}
             unknown_for_zip_and_province_informative: City may be incorrect
-            unknown_for_address: City may be incorrect
+            unknown_for_address_instructional: City may be incorrect
+            unknown_for_address_informative: City may be incorrect
         province:
           label:
             default: Region
@@ -263,7 +292,8 @@ en:
             unknown_for_city_instructional: Region doesn't match %{city}
             unknown_for_zip_instructional: Select a valid region for %{zip}
             unknown_for_zip_informative: Region doesn't match %{zip}
-            unknown_for_address: Region may be incorrect
+            unknown_for_address_instructional: Region may be incorrect
+            unknown_for_address_informative: Region may be incorrect
         country:
           label:
             default: Country/region
@@ -284,7 +314,8 @@ en:
           errors:
             blank_instructional: Enter a postal code
             blank_informative: Postal code is missing
-            blocked_address: This location isn't supported
+            blocked_address_instructional: This location isn't supported
+            blocked_address_informative: This location isn't supported
             invalid_instructional: Enter a valid postal code
             invalid_informative: Postal code isn't valid
             invalid_for_country_instructional: Enter a valid postal code for %{country}
@@ -293,17 +324,23 @@ en:
             invalid_for_province_informative: Postal code doesn't match %{province}
             invalid_for_country_and_province_instructional: Enter a valid postal code for %{province}, %{country}
             invalid_for_country_and_province_informative: Postal code doesn't match %{province}, %{country}
-            too_long: The postal code is too long
-            contains_emojis: Postal code can't contain emojis
-            contains_mathematical_symbols: Postal code can't contain mathematical symbols
-            contains_restricted_characters: Postal code can only contain letters,
+            too_long_instructional: Postal code is too long
+            too_long_informative: Postal code is too long
+            contains_emojis_instructional: Postal code can't contain emojis
+            contains_emojis_informative: Postal code can't contain emojis
+            contains_mathematical_symbols_instructional: Postal code can't contain mathematical symbols
+            contains_mathematical_symbols_informative: Postal code can't contain mathematical symbols
+            contains_restricted_characters_instructional: Postal code can only contain letters,
               numbers, local characters, and special characters
+            contains_restricted_characters_informative: Postal code can't contain restricted characters
             not_supported_instructional: Postal code not supported. Enter a new address and try again
-            not_supported_informativel: Postal code not supported
-            contains_html_tags: Postal code can't contain HTML
+            not_supported_informative: Postal code not supported
+            contains_html_tags_instructional: Postal code can't contain HTML
+            contains_html_tags_informative: Postal code can't contain HTML
             unknown_for_province_instructional: Enter a valid postal code for %{province}
             unknown_for_province_informative: Postal code is invalid for %{province}
-            unknown_for_address: Postal code may be incorrect
+            unknown_for_address_instructional: Postal code may be incorrect
+            unknown_for_address_informative: Postal code may be incorrect
         phone:
           label:
             default: Phone
@@ -315,10 +352,13 @@ en:
             invalid_informative: Phone number isn't valid
             too_long_instructional: Phone number is too long
             too_long_informative: Phone number is too long
-            contains_emojis: Phone number can't contain emojis
-            contains_mathematical_symbols: Phone number can't contain mathematical symbols
-            contains_restricted_characters: Phone number can only contain letters,
+            contains_emojis_instructional: Phone number can't contain emojis
+            contains_emojis_informative: Phone number can't contain emojis
+            contains_mathematical_symbols_instructional: Phone number can't contain mathematical symbols
+            contains_mathematical_symbols_informative: Phone number can't contain mathematical symbols
+            contains_restricted_characters_instructional: Phone number can only contain letters,
               numbers, local characters, and special characters
+            contains_restricted_characters_informative: Phone number can't contain restricted characters
         address:
           errors:
             may_not_exist_instructional: Address not found or doesn't exist

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "1.2.0"
+  VERSION = "1.3.0"
 end

--- a/test/worldwide/field_data_consistency_test.rb
+++ b/test/worldwide/field_data_consistency_test.rb
@@ -37,6 +37,21 @@ module Worldwide
         value.keys.each do |key|
           assert_includes(permitted_keys, key)
         end
+
+        assert_instructional_informative_error_messages(value["errors"], file_name, key)
+      end
+    end
+
+    def assert_instructional_informative_error_messages(errors, file_name, field_key)
+      return if errors.nil?
+      return unless file_name.end_with?("en.yml")
+
+      errors.keys.each do |error_key|
+        assert_msg = "Translation: " + file_name + " -- field_key: " + field_key + " -- error_key: " + error_key
+
+        # rubocop:disable Minitest/AssertWithExpectedArgument
+        assert(error_key.end_with?("_instructional", "_informative"), assert_msg)
+        # rubocop:enable Minitest/AssertWithExpectedArgument
       end
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

This PR fixes the inconsistent error messaging scheme introduced in https://github.com/Shopify/worldwide/pull/140.

All error messages will now have both have an `_instructional` and `_informative` suffix on their key's. This is asserted in the `FieldDataConsistencyTest`.

If the `Worldwide::Field::error` method is called with a `code` that does not end in either `_instructional` or `_informative`, the `Worldwide::Field::error` method will append `_instructional` to the `code` and attempt to return this message(an empty string is returned if no value is found).

### What approach did you choose and why?

Much simpler as there is no complicated fall back logic. All error translations have both an `_instructional` and `_informative` suffix key for future expansion.

### What should reviewers focus on?

### The impact of these changes

### Testing

### Checklist
* [x] Bump version following [these steps](https://github.com/Shopify/worldwide/pull/140#issuecomment-2138062266) 
* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)