### PR TITLE
Add format_extended and additional field defns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Security in case of vulnerabilities.
 
 ## [Unreleased]
+- Additional field definitions in AE, CR, KW, PA, PE, SA, updated decorators for PH, VN  [#206](https://github.com/Shopify/worldwide/pull/206)
 - update street_name and street_number too_long error message [#203](https://github.com/Shopify/worldwide/pull/203)
-
 - Update translations for neighborhood too_long error message, add translations for localized neighborhood errors in MX, PH [#191](https://github.com/Shopify/worldwide/pull/191)
 - Generate concatenated address1/2 values when some additional field values are present [#199](https://github.com/Shopify/worldwide/pull/199)
 

--- a/db/data/regions/AE.yml
+++ b/db/data/regions/AE.yml
@@ -13,6 +13,17 @@ week_start_day: saturday
 format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{city}{province}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city} {province}_{country}_{phone}"
+format_extended:
+  edit: "{country}_{firstName}{lastName}_{company}_{address1}_{line2}{neighborhood}_{city}{province}_{phone}"
+additional_address_fields:
+  - name: line2
+  - name: neighborhood
+    required: true
+combined_address_format:
+  address2:
+    - key: line2
+    - key: neighborhood
+      decorator: ","
 emoji: "\U0001F1E6\U0001F1EA"
 languages:
   - ar

--- a/db/data/regions/CR.yml
+++ b/db/data/regions/CR.yml
@@ -13,6 +13,17 @@ week_start_day: sunday
 format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{province}{city}{zip}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{province} {city}_{zip}_{country}_{phone}"
+format_extended:
+  edit: "{country}_{firstName}{lastName}_{company}_{address1}_{line2}{neighborhood}_{city}{province}_{zip}_{phone}"
+additional_address_fields:
+  - name: line2
+  - name: neighborhood
+    required: true
+combined_address_format:
+  address2:
+    - key: line2
+    - key: neighborhood
+      decorator: ","
 emoji: "\U0001F1E8\U0001F1F7"
 languages:
   - es

--- a/db/data/regions/KW.yml
+++ b/db/data/regions/KW.yml
@@ -13,6 +13,16 @@ week_start_day: saturday
 format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{province}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{province}_{country}_{phone}"
+format_extended:
+  edit: "{country}_{firstName}{lastName}_{company}_{address1}_{line2}{neighborhood}_{zip}{city}_{province}_{phone}"
+additional_address_fields:
+  - name: line2
+  - name: neighborhood
+    required: true
+combined_address_format:
+  address2:
+    - key: line2
+    - key: neighborhood
 emoji: "\U0001F1F0\U0001F1FC"
 languages:
   - ar

--- a/db/data/regions/PA.yml
+++ b/db/data/regions/PA.yml
@@ -17,6 +17,17 @@ format:
   # Note that there ought to be a comma after zip if it's non-blank.
   # https://github.com/Shopify/address/issues/725
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{province}_{country}_{phone}"
+format_extended:
+  edit: "{country}_{firstName}{lastName}_{company}_{address1}_{line2}{neighborhood}_{zip}{city}{province}_{phone}"
+additional_address_fields:
+  - name: line2
+  - name: neighborhood
+    required: true
+combined_address_format:
+  address2:
+    - key: line2
+    - key: neighborhood
+      decorator: ","
 emoji: "\U0001F1F5\U0001F1E6"
 languages:
   - es

--- a/db/data/regions/PE.yml
+++ b/db/data/regions/PE.yml
@@ -13,6 +13,16 @@ week_start_day: sunday
 format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{city}{province}{zip}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{province}_{country}_{phone}"
+format_extended:
+  edit: "{country}_{firstName}{lastName}_{company}_{address1}_{line2}{neighborhood}_{city}{province}{zip}_{phone}"
+additional_address_fields:
+  - name: line2
+  - name: neighborhood
+    required: true
+combined_address_format:
+  address2:
+    - key: line2
+    - key: neighborhood
 emoji: "\U0001F1F5\U0001F1EA"
 languages:
   - es

--- a/db/data/regions/PH.yml
+++ b/db/data/regions/PH.yml
@@ -25,7 +25,6 @@ combined_address_format:
   address2:
     - key: line2
     - key: neighborhood
-      decorator: " Barangay"
 emoji: "\U0001F1F5\U0001F1ED"
 languages:
   - en

--- a/db/data/regions/SA.yml
+++ b/db/data/regions/SA.yml
@@ -18,5 +18,16 @@ languages:
 format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{city}{zip}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}"
+format_extended:
+  edit: "{country}_{firstName}{lastName}_{company}_{address1}_{line2}_{neighborhood}_{city}{zip}_{phone}"
+additional_address_fields:
+  - name: line2
+  - name: neighborhood
+    required: true
+combined_address_format:
+  address2:
+    - key: line2
+    - key: neighborhood
+      decorator: ","
 emoji: "\U0001F1F8\U0001F1E6"
 timezone: Asia/Riyadh

--- a/db/data/regions/VN.yml
+++ b/db/data/regions/VN.yml
@@ -23,7 +23,7 @@ combined_address_format:
   address2:
     - key: line2
     - key: neighborhood
-      decorator: ", Quận"
+      decorator: ","
 emoji: "\U0001F1FB\U0001F1F3"
 languages:
   - fr

--- a/lang/typescript/src/extended-address/concatenateAddress2.test.ts
+++ b/lang/typescript/src/extended-address/concatenateAddress2.test.ts
@@ -143,14 +143,14 @@ describe('concatenateAddress2', () => {
         line2: 'apt 4',
         neighborhood: '294',
       }),
-    ).toBe('apt 4 Barangay\u00A0294');
+    ).toBe('apt 4\u00A0294');
     expect(
       concatenateAddress2({
         countryCode: 'VN',
         line2: 'apt 4',
         neighborhood: 'Cầu Giấy',
       }),
-    ).toBe('apt 4, Quận\u00A0Cầu Giấy');
+    ).toBe('apt 4,\u00A0Cầu Giấy');
   });
 
   test('returns line2 with no delimiter or decorator if neighborhood is missing', () => {

--- a/test/worldwide/address_test.rb
+++ b/test/worldwide/address_test.rb
@@ -168,8 +168,8 @@ module Worldwide
       vn_address = Address.new(line2: "apt 4", neighborhood: "Cầu Giấy", country_code: "VN")
 
       assert_equal "dpto 4, Centro", br_address.concatenate_address2
-      assert_equal "apt 4 Barangay 294", ph_address.concatenate_address2
-      assert_equal "apt 4, Quận Cầu Giấy", vn_address.concatenate_address2
+      assert_equal "apt 4 294", ph_address.concatenate_address2
+      assert_equal "apt 4, Cầu Giấy", vn_address.concatenate_address2
     end
 
     test "split_address1 returns nil when additional address fields are not defined for the country" do
@@ -259,7 +259,7 @@ module Worldwide
 
     test "split_address2 returns line2 and neighborhood when both values are present and seperated by a delimiter and a decorator" do
       br_address = Address.new(address2: "dpto 4, Centro", country_code: "BR")
-      ph_address = Address.new(address2: "dpto 4 Barangay 294", country_code: "PH")
+      ph_address = Address.new(address2: "dpto 4 294", country_code: "PH")
       expected_hash_br = { "line2" => "dpto 4", "neighborhood" => "Centro" }
       expected_hash_ph = { "line2" => "dpto 4", "neighborhood" => "294" }
 


### PR DESCRIPTION
### What are you trying to accomplish?
Add the format_extended and additional field definitions for all remaining countries in scope 

Also removed any word-decorators, replacing with the default nbsp. 

part of https://github.com/Shopify/address/issues/2616

### What approach did you choose and why?
Added the following keys to the region yml's:
- format_extended
- additional_address_fields
- combined_address_format


### What should reviewers focus on?
Double check the list of countries, and the required and decorator specifications (linked from the original issue) 

### The impact of these changes
When leveraged, will render the extended format for the relevant countries. 

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

...

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
