### PR TITLE
NPM Package Version 0.2.2

### DIFF
--- a/lang/typescript/.changeset/silver-mice-taste.md
+++ b/lang/typescript/.changeset/silver-mice-taste.md
@@ -1,5 +1,0 @@
----
-'@shopify/worldwide': patch
----
-
-Remove names from bundled region map

--- a/lang/typescript/CHANGELOG.md
+++ b/lang/typescript/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @shopify/worldwide
 
+## 0.2.2
+
+### Patch Changes
+
+- 5219bcb: Remove names from bundled region map
+
 ## 0.2.1
 
 ### Patch Changes

--- a/lang/typescript/package.json
+++ b/lang/typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/worldwide",
   "description": "Utilities for parsing and formatting address fields",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "repository": "git@github.com:Shopify/worldwide.git",
   "author": "Shopify Inc.",
   "license": "MIT",


### PR DESCRIPTION
### What are you trying to accomplish?
<!--
Link to an issue or provide enough context so that someone new can understand the 'why' behind this change.
-->

Update npm package version to 0.2.2 with reduced bundle size from removing name from regions.

Replaces #197 because github-actions bot cannot sign the CLA, will need to fix that in the future but I want to make sure this gets published.