### PR TITLE
Change delimiter from Non-Breaking Space to Word Joiner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 - Add localized error strings for neighborhood in AE, CR, KW, PA, PE, SA [#215](https://github.com/Shopify/worldwide/pull/215)
+- Change delimiter from Non-Breaking Space to Word Joiner [#221](https://github.com/Shopify/worldwide/pull/221)
 
 --
 

--- a/db/data/regions/AE.yml
+++ b/db/data/regions/AE.yml
@@ -23,7 +23,7 @@ combined_address_format:
   address2:
     - key: line2
     - key: neighborhood
-      decorator: ","
+      decorator: ", "
 emoji: "\U0001F1E6\U0001F1EA"
 languages:
   - ar

--- a/db/data/regions/BE.yml
+++ b/db/data/regions/BE.yml
@@ -35,5 +35,6 @@ combined_address_format:
   address1:
     - key: streetName
     - key: streetNumber
+      decorator: " "
 emoji: "\U0001F1E7\U0001F1EA"
 timezone: Europe/Brussels

--- a/db/data/regions/BR.yml
+++ b/db/data/regions/BR.yml
@@ -32,11 +32,11 @@ combined_address_format:
   address1:
     - key: streetName
     - key: streetNumber
-      decorator: ","
+      decorator: ", "
   address2:
     - key: line2
     - key: neighborhood
-      decorator: ","
+      decorator: ", "
 emoji: "\U0001F1E7\U0001F1F7"
 localized_data:
 - name: tax_credential_br

--- a/db/data/regions/CL.yml
+++ b/db/data/regions/CL.yml
@@ -27,9 +27,11 @@ combined_address_format:
   address1:
     - key: streetName
     - key: streetNumber
+      decorator: " "
   address2:
     - key: line2
     - key: neighborhood
+      decorator: " "
 emoji: "\U0001F1E8\U0001F1F1"
 languages:
   - es

--- a/db/data/regions/CO.yml
+++ b/db/data/regions/CO.yml
@@ -24,6 +24,7 @@ combined_address_format:
   address2:
     - key: line2
     - key: neighborhood
+      decorator: " "
 emoji: "\U0001F1E8\U0001F1F4"
 languages:
   - es

--- a/db/data/regions/CR.yml
+++ b/db/data/regions/CR.yml
@@ -23,7 +23,7 @@ combined_address_format:
   address2:
     - key: line2
     - key: neighborhood
-      decorator: ","
+      decorator: ", "
 emoji: "\U0001F1E8\U0001F1F7"
 languages:
   - es

--- a/db/data/regions/ES.yml
+++ b/db/data/regions/ES.yml
@@ -32,6 +32,7 @@ combined_address_format:
   address1:
     - key: streetName
     - key: streetNumber
+      decorator: " "
 emoji: "\U0001F1EA\U0001F1F8"
 zones:
 - name: A Coruña

--- a/db/data/regions/ID.yml
+++ b/db/data/regions/ID.yml
@@ -26,7 +26,7 @@ combined_address_format:
   address2:
     - key: line2
     - key: neighborhood
-      decorator: ","
+      decorator: ", "
 emoji: "\U0001F1EE\U0001F1E9"
 zones:
 - name: Aceh

--- a/db/data/regions/IL.yml
+++ b/db/data/regions/IL.yml
@@ -27,6 +27,7 @@ combined_address_format:
   address1:
     - key: streetNumber
     - key: streetName
+      decorator: " "
 emoji: "\U0001F1EE\U0001F1F1"
 languages:
   - ar

--- a/db/data/regions/KW.yml
+++ b/db/data/regions/KW.yml
@@ -23,6 +23,7 @@ combined_address_format:
   address2:
     - key: line2
     - key: neighborhood
+      decorator: " "
 emoji: "\U0001F1F0\U0001F1FC"
 languages:
   - ar

--- a/db/data/regions/MX.yml
+++ b/db/data/regions/MX.yml
@@ -28,9 +28,11 @@ combined_address_format:
   address1:
     - key: streetName
     - key: streetNumber
+      decorator: " "
   address2:
     - key: line2
     - key: neighborhood
+      decorator: " "
 emoji: "\U0001F1F2\U0001F1FD"
 languages:
   - es

--- a/db/data/regions/NL.yml
+++ b/db/data/regions/NL.yml
@@ -34,5 +34,6 @@ combined_address_format:
   address1:
     - key: streetName
     - key: streetNumber
+      decorator: " "
 emoji: "\U0001F1F3\U0001F1F1"
 timezone: Europe/Amsterdam

--- a/db/data/regions/PA.yml
+++ b/db/data/regions/PA.yml
@@ -27,7 +27,7 @@ combined_address_format:
   address2:
     - key: line2
     - key: neighborhood
-      decorator: ","
+      decorator: ", "
 emoji: "\U0001F1F5\U0001F1E6"
 languages:
   - es

--- a/db/data/regions/PE.yml
+++ b/db/data/regions/PE.yml
@@ -23,6 +23,7 @@ combined_address_format:
   address2:
     - key: line2
     - key: neighborhood
+      decorator: " "
 emoji: "\U0001F1F5\U0001F1EA"
 languages:
   - es

--- a/db/data/regions/PH.yml
+++ b/db/data/regions/PH.yml
@@ -25,6 +25,7 @@ combined_address_format:
   address2:
     - key: line2
     - key: neighborhood
+      decorator: " "
 emoji: "\U0001F1F5\U0001F1ED"
 languages:
   - en

--- a/db/data/regions/SA.yml
+++ b/db/data/regions/SA.yml
@@ -28,6 +28,6 @@ combined_address_format:
   address2:
     - key: line2
     - key: neighborhood
-      decorator: ","
+      decorator: ", "
 emoji: "\U0001F1F8\U0001F1E6"
 timezone: Asia/Riyadh

--- a/db/data/regions/TR.yml
+++ b/db/data/regions/TR.yml
@@ -26,6 +26,7 @@ combined_address_format:
   address2:
     - key: line2
     - key: neighborhood
+      decorator: " "
 emoji: "\U0001F1F9\U0001F1F7"
 languages:
   - tr

--- a/db/data/regions/TW.yml
+++ b/db/data/regions/TW.yml
@@ -27,6 +27,7 @@ combined_address_format:
   address2:
     - key: line2
     - key: neighborhood
+      decorator: ""
 emoji: "\U0001F1F9\U0001F1FC"
 languages:
   - "zh-TW"

--- a/db/data/regions/TW.yml
+++ b/db/data/regions/TW.yml
@@ -27,7 +27,6 @@ combined_address_format:
   address2:
     - key: line2
     - key: neighborhood
-      decorator: ""
 emoji: "\U0001F1F9\U0001F1FC"
 languages:
   - "zh-TW"

--- a/db/data/regions/VN.yml
+++ b/db/data/regions/VN.yml
@@ -23,7 +23,7 @@ combined_address_format:
   address2:
     - key: line2
     - key: neighborhood
-      decorator: ","
+      decorator: ", "
 emoji: "\U0001F1FB\U0001F1F3"
 languages:
   - fr

--- a/lang/typescript/.changeset/three-cars-kiss.md
+++ b/lang/typescript/.changeset/three-cars-kiss.md
@@ -1,0 +1,5 @@
+---
+'@shopify/worldwide': minor
+---
+
+Change reserved delimiter to word joiner

--- a/lang/typescript/src/extended-address/concatenateAddress1.test.ts
+++ b/lang/typescript/src/extended-address/concatenateAddress1.test.ts
@@ -35,7 +35,7 @@ describe('concatenateAddress1', () => {
         streetName: 'Main',
         streetNumber: '123',
       }),
-    ).toBe('Main,\u00A0123');
+    ).toBe('Main,\u2060123');
     expect(
       concatenateAddress1({
         countryCode: 'CL',
@@ -43,7 +43,7 @@ describe('concatenateAddress1', () => {
         streetName: 'Main',
         streetNumber: '123',
       }),
-    ).toBe('Main\u00A0123');
+    ).toBe('Main\u2060123');
   });
 
   test('returns address1 string if no additional address fields are found', () => {
@@ -83,7 +83,7 @@ describe('concatenateAddress1', () => {
         streetName: '',
         streetNumber: '123',
       }),
-    ).toBe('\u00A0123');
+    ).toBe('\u2060123');
     expect(
       concatenateAddress1({
         countryCode: 'BR',
@@ -101,14 +101,14 @@ describe('concatenateAddress1', () => {
         streetName: 'Main',
         streetNumber: '123',
       }),
-    ).toBe('Main,\u00A0123');
+    ).toBe('Main,\u2060123');
     expect(
       concatenateAddress1({
         countryCode: 'BR',
         streetNumber: '123',
         streetName: 'Main',
       }),
-    ).toBe('Main,\u00A0123');
+    ).toBe('Main,\u2060123');
   });
 
   test('returns concatenated address', () => {
@@ -118,7 +118,7 @@ describe('concatenateAddress1', () => {
         streetName: 'Main',
         streetNumber: '123',
       }),
-    ).toBe('Main\u00A0123');
+    ).toBe('Main\u2060123');
   });
 
   test('returns concatenated address with decorator', () => {
@@ -128,7 +128,7 @@ describe('concatenateAddress1', () => {
         streetName: 'Main',
         streetNumber: '123',
       }),
-    ).toBe('Main,\u00A0123');
+    ).toBe('Main,\u2060123');
   });
 
   test('returns street name with no delimiter or decorator if street number is missing', () => {
@@ -152,12 +152,12 @@ describe('concatenateAddress1', () => {
         countryCode: 'BR',
         streetNumber: '123',
       }),
-    ).toBe('\u00A0123');
+    ).toBe('\u2060123');
     expect(
       concatenateAddress1({
         countryCode: 'CL',
         streetNumber: '123',
       }),
-    ).toBe('\u00A0123');
+    ).toBe('\u2060123');
   });
 });

--- a/lang/typescript/src/extended-address/concatenateAddress1.test.ts
+++ b/lang/typescript/src/extended-address/concatenateAddress1.test.ts
@@ -35,7 +35,7 @@ describe('concatenateAddress1', () => {
         streetName: 'Main',
         streetNumber: '123',
       }),
-    ).toBe('Main,\u2060123');
+    ).toBe('Main, \u2060123');
     expect(
       concatenateAddress1({
         countryCode: 'CL',
@@ -43,7 +43,7 @@ describe('concatenateAddress1', () => {
         streetName: 'Main',
         streetNumber: '123',
       }),
-    ).toBe('Main\u2060123');
+    ).toBe('Main \u2060123');
   });
 
   test('returns address1 string if no additional address fields are found', () => {
@@ -101,14 +101,14 @@ describe('concatenateAddress1', () => {
         streetName: 'Main',
         streetNumber: '123',
       }),
-    ).toBe('Main,\u2060123');
+    ).toBe('Main, \u2060123');
     expect(
       concatenateAddress1({
         countryCode: 'BR',
         streetNumber: '123',
         streetName: 'Main',
       }),
-    ).toBe('Main,\u2060123');
+    ).toBe('Main, \u2060123');
   });
 
   test('returns concatenated address', () => {
@@ -118,7 +118,7 @@ describe('concatenateAddress1', () => {
         streetName: 'Main',
         streetNumber: '123',
       }),
-    ).toBe('Main\u2060123');
+    ).toBe('Main \u2060123');
   });
 
   test('returns concatenated address with decorator', () => {
@@ -128,7 +128,7 @@ describe('concatenateAddress1', () => {
         streetName: 'Main',
         streetNumber: '123',
       }),
-    ).toBe('Main,\u2060123');
+    ).toBe('Main, \u2060123');
   });
 
   test('returns street name with no delimiter or decorator if street number is missing', () => {

--- a/lang/typescript/src/extended-address/concatenateAddress2.test.ts
+++ b/lang/typescript/src/extended-address/concatenateAddress2.test.ts
@@ -43,7 +43,7 @@ describe('concatenateAddress2', () => {
         line2: 'dpto 4',
         neighborhood: 'Centro',
       }),
-    ).toBe('dpto 4,\u2060Centro');
+    ).toBe('dpto 4, \u2060Centro');
     expect(
       concatenateAddress2({
         countryCode: 'CL',
@@ -51,7 +51,7 @@ describe('concatenateAddress2', () => {
         line2: 'dpto 4',
         neighborhood: 'Centro',
       }),
-    ).toBe('dpto 4\u2060Centro');
+    ).toBe('dpto 4 \u2060Centro');
   });
 
   test('returns address2 string if no additional address fields are found', () => {
@@ -126,7 +126,7 @@ describe('concatenateAddress2', () => {
         line2: 'dpto 4',
         neighborhood: 'Centro',
       }),
-    ).toBe('dpto 4\u2060Centro');
+    ).toBe('dpto 4 \u2060Centro');
   });
 
   test('returns concatenated address with decorator', () => {
@@ -136,21 +136,21 @@ describe('concatenateAddress2', () => {
         line2: 'dpto 4',
         neighborhood: 'Centro',
       }),
-    ).toBe('dpto 4,\u2060Centro');
+    ).toBe('dpto 4, \u2060Centro');
     expect(
       concatenateAddress2({
         countryCode: 'PH',
         line2: 'apt 4',
         neighborhood: '294',
       }),
-    ).toBe('apt 4\u2060294');
+    ).toBe('apt 4 \u2060294');
     expect(
       concatenateAddress2({
         countryCode: 'VN',
         line2: 'apt 4',
         neighborhood: 'Cầu Giấy',
       }),
-    ).toBe('apt 4,\u2060Cầu Giấy');
+    ).toBe('apt 4, \u2060Cầu Giấy');
   });
 
   test('returns line2 with no delimiter or decorator if neighborhood is missing', () => {

--- a/lang/typescript/src/extended-address/concatenateAddress2.test.ts
+++ b/lang/typescript/src/extended-address/concatenateAddress2.test.ts
@@ -109,14 +109,14 @@ describe('concatenateAddress2', () => {
         line2: 'dpto 4',
         neighborhood: 'Centro',
       }),
-    ).toBe('dpto 4,\u2060Centro');
+    ).toBe('dpto 4, \u2060Centro');
     expect(
       concatenateAddress2({
         countryCode: 'BR',
         neighborhood: 'Centro',
         line2: 'dpto 4',
       }),
-    ).toBe('dpto 4,\u2060Centro');
+    ).toBe('dpto 4, \u2060Centro');
   });
 
   test('returns concatenated address', () => {

--- a/lang/typescript/src/extended-address/concatenateAddress2.test.ts
+++ b/lang/typescript/src/extended-address/concatenateAddress2.test.ts
@@ -43,7 +43,7 @@ describe('concatenateAddress2', () => {
         line2: 'dpto 4',
         neighborhood: 'Centro',
       }),
-    ).toBe('dpto 4,\u00A0Centro');
+    ).toBe('dpto 4,\u2060Centro');
     expect(
       concatenateAddress2({
         countryCode: 'CL',
@@ -51,7 +51,7 @@ describe('concatenateAddress2', () => {
         line2: 'dpto 4',
         neighborhood: 'Centro',
       }),
-    ).toBe('dpto 4\u00A0Centro');
+    ).toBe('dpto 4\u2060Centro');
   });
 
   test('returns address2 string if no additional address fields are found', () => {
@@ -91,7 +91,7 @@ describe('concatenateAddress2', () => {
         line2: '',
         neighborhood: 'Centro',
       }),
-    ).toBe('\u00A0Centro');
+    ).toBe('\u2060Centro');
     expect(
       concatenateAddress2({
         countryCode: 'BR',
@@ -109,14 +109,14 @@ describe('concatenateAddress2', () => {
         line2: 'dpto 4',
         neighborhood: 'Centro',
       }),
-    ).toBe('dpto 4,\u00A0Centro');
+    ).toBe('dpto 4,\u2060Centro');
     expect(
       concatenateAddress2({
         countryCode: 'BR',
         neighborhood: 'Centro',
         line2: 'dpto 4',
       }),
-    ).toBe('dpto 4,\u00A0Centro');
+    ).toBe('dpto 4,\u2060Centro');
   });
 
   test('returns concatenated address', () => {
@@ -126,7 +126,7 @@ describe('concatenateAddress2', () => {
         line2: 'dpto 4',
         neighborhood: 'Centro',
       }),
-    ).toBe('dpto 4\u00A0Centro');
+    ).toBe('dpto 4\u2060Centro');
   });
 
   test('returns concatenated address with decorator', () => {
@@ -136,21 +136,21 @@ describe('concatenateAddress2', () => {
         line2: 'dpto 4',
         neighborhood: 'Centro',
       }),
-    ).toBe('dpto 4,\u00A0Centro');
+    ).toBe('dpto 4,\u2060Centro');
     expect(
       concatenateAddress2({
         countryCode: 'PH',
         line2: 'apt 4',
         neighborhood: '294',
       }),
-    ).toBe('apt 4\u00A0294');
+    ).toBe('apt 4\u2060294');
     expect(
       concatenateAddress2({
         countryCode: 'VN',
         line2: 'apt 4',
         neighborhood: 'Cầu Giấy',
       }),
-    ).toBe('apt 4,\u00A0Cầu Giấy');
+    ).toBe('apt 4,\u2060Cầu Giấy');
   });
 
   test('returns line2 with no delimiter or decorator if neighborhood is missing', () => {
@@ -174,12 +174,12 @@ describe('concatenateAddress2', () => {
         countryCode: 'BR',
         neighborhood: 'Centro',
       }),
-    ).toBe('\u00A0Centro');
+    ).toBe('\u2060Centro');
     expect(
       concatenateAddress2({
         countryCode: 'CL',
         neighborhood: 'Centro',
       }),
-    ).toBe('\u00A0Centro');
+    ).toBe('\u2060Centro');
   });
 });

--- a/lang/typescript/src/extended-address/splitAddress1.test.ts
+++ b/lang/typescript/src/extended-address/splitAddress1.test.ts
@@ -21,14 +21,14 @@ describe('splitAddress1', () => {
   });
 
   test('returns full address object when separated by delimiter', () => {
-    expect(splitAddress1('CL', 'Main\u2060123')).toEqual({
+    expect(splitAddress1('CL', 'Main \u2060123')).toEqual({
       streetName: 'Main',
       streetNumber: '123',
     });
   });
 
   test('returns full address object when separated by delimiter and decorator', () => {
-    expect(splitAddress1('BR', 'Main,\u2060123')).toEqual({
+    expect(splitAddress1('BR', 'Main, \u2060123')).toEqual({
       streetName: 'Main',
       streetNumber: '123',
     });

--- a/lang/typescript/src/extended-address/splitAddress1.test.ts
+++ b/lang/typescript/src/extended-address/splitAddress1.test.ts
@@ -16,19 +16,19 @@ describe('splitAddress1', () => {
   });
 
   test('returns street number if string before delimiter is empty', () => {
-    expect(splitAddress1('CL', '\u00A0123')).toEqual({streetNumber: '123'});
-    expect(splitAddress1('BR', '\u00A0123')).toEqual({streetNumber: '123'});
+    expect(splitAddress1('CL', '\u2060123')).toEqual({streetNumber: '123'});
+    expect(splitAddress1('BR', '\u2060123')).toEqual({streetNumber: '123'});
   });
 
   test('returns full address object when separated by delimiter', () => {
-    expect(splitAddress1('CL', 'Main\u00A0123')).toEqual({
+    expect(splitAddress1('CL', 'Main\u2060123')).toEqual({
       streetName: 'Main',
       streetNumber: '123',
     });
   });
 
   test('returns full address object when separated by delimiter and decorator', () => {
-    expect(splitAddress1('BR', 'Main,\u00A0123')).toEqual({
+    expect(splitAddress1('BR', 'Main,\u2060123')).toEqual({
       streetName: 'Main',
       streetNumber: '123',
     });

--- a/lang/typescript/src/extended-address/splitAddress2.test.ts
+++ b/lang/typescript/src/extended-address/splitAddress2.test.ts
@@ -25,14 +25,14 @@ describe('splitAddress2', () => {
   });
 
   test('returns full address object when separated by delimiter', () => {
-    expect(splitAddress2('CL', 'dpto 4\u2060Centro')).toEqual({
+    expect(splitAddress2('CL', 'dpto 4 \u2060Centro')).toEqual({
       line2: 'dpto 4',
       neighborhood: 'Centro',
     });
   });
 
   test('returns full address object when separated by delimiter and decorator', () => {
-    expect(splitAddress2('BR', 'dpto 4,\u2060Centro')).toEqual({
+    expect(splitAddress2('BR', 'dpto 4, \u2060Centro')).toEqual({
       line2: 'dpto 4',
       neighborhood: 'Centro',
     });

--- a/lang/typescript/src/extended-address/splitAddress2.test.ts
+++ b/lang/typescript/src/extended-address/splitAddress2.test.ts
@@ -16,23 +16,23 @@ describe('splitAddress2', () => {
   });
 
   test('returns neighborhood if string before delimiter is empty', () => {
-    expect(splitAddress2('CL', '\u00A0Centro')).toEqual({
+    expect(splitAddress2('CL', '\u2060Centro')).toEqual({
       neighborhood: 'Centro',
     });
-    expect(splitAddress2('BR', '\u00A0Centro')).toEqual({
+    expect(splitAddress2('BR', '\u2060Centro')).toEqual({
       neighborhood: 'Centro',
     });
   });
 
   test('returns full address object when separated by delimiter', () => {
-    expect(splitAddress2('CL', 'dpto 4\u00A0Centro')).toEqual({
+    expect(splitAddress2('CL', 'dpto 4\u2060Centro')).toEqual({
       line2: 'dpto 4',
       neighborhood: 'Centro',
     });
   });
 
   test('returns full address object when separated by delimiter and decorator', () => {
-    expect(splitAddress2('BR', 'dpto 4,\u00A0Centro')).toEqual({
+    expect(splitAddress2('BR', 'dpto 4,\u2060Centro')).toEqual({
       line2: 'dpto 4',
       neighborhood: 'Centro',
     });

--- a/lang/typescript/src/utils/address-fields.test.ts
+++ b/lang/typescript/src/utils/address-fields.test.ts
@@ -97,6 +97,7 @@ describe('concatAddressField', () => {
         'Main,\u2060123',
       );
     });
+
     test("doesn't include decorator if previous field is empty", () => {
       const fieldDefinition: FieldConcatenationRule[] = [
         {key: 'streetName'},
@@ -109,6 +110,7 @@ describe('concatAddressField', () => {
         '\u2060123',
       );
     });
+
     test("doesn't include decorator or delimiter if field is empty", () => {
       const fieldDefinition: FieldConcatenationRule[] = [
         {key: 'streetName'},
@@ -186,7 +188,8 @@ describe('splitAddressField', () => {
         streetNumber: '123',
       });
     });
-    test('splits address without defined decorator', () => {
+
+    test('splits address without defined decorator if no delimiter is found', () => {
       const fieldDefinition: FieldConcatenationRule[] = [
         {key: 'streetName'},
         {key: 'streetNumber', decorator: ','},
@@ -197,7 +200,8 @@ describe('splitAddressField', () => {
         streetName: 'Main',
       });
     });
-    test('splits address without defined decorator 2', () => {
+
+    test('splits address without defined decorator if leading delimiter is found', () => {
       const fieldDefinition: FieldConcatenationRule[] = [
         {key: 'streetName'},
         {key: 'streetNumber', decorator: ','},

--- a/lang/typescript/src/utils/address-fields.test.ts
+++ b/lang/typescript/src/utils/address-fields.test.ts
@@ -7,9 +7,11 @@ import {
 
 describe('RESERVED_DELIMITER', () => {
   test('is a non-breaking space', () => {
-    expect(RESERVED_DELIMITER).toBe(' ');
-    expect(RESERVED_DELIMITER).toBe('\xA0');
-    expect(RESERVED_DELIMITER).toBe('\u00A0');
+    expect(RESERVED_DELIMITER).toBe('⁠');
+    expect(RESERVED_DELIMITER).not.toBe('\u2060');
+    expect(RESERVED_DELIMITER).not.toBe(' ');
+    expect(RESERVED_DELIMITER).not.toBe('\xA0');
+    expect(RESERVED_DELIMITER).not.toBe('\u00A0');
     expect(RESERVED_DELIMITER).not.toBe('\x20');
     expect(RESERVED_DELIMITER).not.toBe(' ');
   });
@@ -26,7 +28,7 @@ describe('concatAddressField', () => {
       streetName: 'Main',
     };
     expect(concatAddressField(fieldDefinition, fieldValues)).toBe(
-      '123\u00A0Main',
+      '123\u2060Main',
     );
   });
 
@@ -44,10 +46,10 @@ describe('concatAddressField', () => {
       streetName: 'Main',
     };
     expect(concatAddressField(fieldDefinitionNumberFirst, fieldValues)).toBe(
-      '123\u00A0Main',
+      '123\u2060Main',
     );
     expect(concatAddressField(fieldDefinitionNameFirst, fieldValues)).toBe(
-      'Main\u00A0123',
+      'Main\u2060123',
     );
   });
 
@@ -61,7 +63,7 @@ describe('concatAddressField', () => {
       streetName: 'Main',
     };
     expect(concatAddressField(fieldDefinition, fieldValues)).toBe(
-      '123\u00A0Main',
+      '123\u2060Main',
     );
     expect(
       concatAddressField(fieldDefinition, {
@@ -72,7 +74,7 @@ describe('concatAddressField', () => {
       concatAddressField(fieldDefinition, {
         streetName: fieldValues.streetName,
       }),
-    ).toBe('\u00A0Main');
+    ).toBe('\u2060Main');
     expect(concatAddressField(fieldDefinition, {})).toBe('');
   });
 
@@ -87,7 +89,7 @@ describe('concatAddressField', () => {
         streetName: 'Main',
       };
       expect(concatAddressField(fieldDefinition, fieldValues)).toBe(
-        'Main,\u00A0123',
+        'Main,\u2060123',
       );
     });
     test("doesn't include decorator if previous field is empty", () => {
@@ -99,7 +101,7 @@ describe('concatAddressField', () => {
         streetNumber: '123',
       };
       expect(concatAddressField(fieldDefinition, fieldValues)).toBe(
-        '\u00A0123',
+        '\u2060123',
       );
     });
     test("doesn't include decorator or delimiter if field is empty", () => {
@@ -121,7 +123,7 @@ describe('splitAddressField', () => {
       {key: 'streetNumber'},
       {key: 'streetName'},
     ];
-    const concatenatedAddress = '123\u00A0Main';
+    const concatenatedAddress = '123\u2060Main';
 
     expect(splitAddressField(fieldDefinition, concatenatedAddress)).toEqual({
       streetNumber: '123',
@@ -138,7 +140,7 @@ describe('splitAddressField', () => {
       {key: 'streetName'},
       {key: 'streetNumber'},
     ];
-    const concatenatedAddress = '123\u00A0Main';
+    const concatenatedAddress = '123\u2060Main';
     expect(
       splitAddressField(fieldDefinitionNumberFirst, concatenatedAddress),
     ).toEqual({
@@ -161,7 +163,7 @@ describe('splitAddressField', () => {
     expect(splitAddressField(fieldDefinition, '123')).toEqual({
       streetNumber: '123',
     });
-    expect(splitAddressField(fieldDefinition, '\u00A0Main')).toEqual({
+    expect(splitAddressField(fieldDefinition, '\u2060Main')).toEqual({
       streetName: 'Main',
     });
   });
@@ -172,7 +174,7 @@ describe('splitAddressField', () => {
         {key: 'streetName'},
         {key: 'streetNumber', decorator: ','},
       ];
-      const concatenatedAddress = 'Main,\u00A0123';
+      const concatenatedAddress = 'Main,\u2060123';
 
       expect(splitAddressField(fieldDefinition, concatenatedAddress)).toEqual({
         streetName: 'Main',
@@ -195,7 +197,7 @@ describe('splitAddressField', () => {
         {key: 'streetName'},
         {key: 'streetNumber', decorator: ','},
       ];
-      const concatenatedAddress = '\u00A0123';
+      const concatenatedAddress = '\u2060123';
 
       expect(splitAddressField(fieldDefinition, concatenatedAddress)).toEqual({
         streetNumber: '123',

--- a/lang/typescript/src/utils/address-fields.test.ts
+++ b/lang/typescript/src/utils/address-fields.test.ts
@@ -5,10 +5,10 @@ import {
   splitAddressField,
 } from './address-fields';
 
-describe('RESERVED_DELIMITER', () => {
-  test('is a non-breaking space', () => {
+describe.only('RESERVED_DELIMITER', () => {
+  test.only('is a non-breaking space', () => {
     expect(RESERVED_DELIMITER).toBe('⁠');
-    expect(RESERVED_DELIMITER).not.toBe('\u2060');
+    expect(RESERVED_DELIMITER).toBe('\u2060');
     expect(RESERVED_DELIMITER).not.toBe(' ');
     expect(RESERVED_DELIMITER).not.toBe('\xA0');
     expect(RESERVED_DELIMITER).not.toBe('\u00A0');

--- a/lang/typescript/src/utils/address-fields.test.ts
+++ b/lang/typescript/src/utils/address-fields.test.ts
@@ -5,15 +5,20 @@ import {
   splitAddressField,
 } from './address-fields';
 
-describe.only('RESERVED_DELIMITER', () => {
-  test.only('is a non-breaking space', () => {
+describe('RESERVED_DELIMITER', () => {
+  test('is a non-breaking space', () => {
+    // Word Joiner (U+2060)
     expect(RESERVED_DELIMITER).toBe('⁠');
     expect(RESERVED_DELIMITER).toBe('\u2060');
+
+    // Non-breaking space (U+00A0)
     expect(RESERVED_DELIMITER).not.toBe(' ');
     expect(RESERVED_DELIMITER).not.toBe('\xA0');
     expect(RESERVED_DELIMITER).not.toBe('\u00A0');
-    expect(RESERVED_DELIMITER).not.toBe('\x20');
+
+    // Regular space
     expect(RESERVED_DELIMITER).not.toBe(' ');
+    expect(RESERVED_DELIMITER).not.toBe('\x20');
   });
 });
 

--- a/lang/typescript/src/utils/address-fields.ts
+++ b/lang/typescript/src/utils/address-fields.ts
@@ -56,7 +56,9 @@ export function splitAddressField(
       // Ex: streetNumber decorator is ","; ["Main,", "123"] => ["Main", "123"]
       const nextFieldDecorator = fieldDefinition[index + 1]?.decorator;
       const fieldValue =
-        nextFieldDecorator && value.endsWith(nextFieldDecorator)
+        nextFieldDecorator &&
+        nextFieldDecorator.length > 0 &&
+        value.endsWith(nextFieldDecorator)
           ? value.substring(0, value.length - nextFieldDecorator.length)
           : value;
       return {

--- a/lang/typescript/src/utils/address-fields.ts
+++ b/lang/typescript/src/utils/address-fields.ts
@@ -2,7 +2,7 @@ import {Address} from '../types/address';
 
 import {FieldConcatenationRule} from './regions';
 
-export const RESERVED_DELIMITER = '\xA0';
+export const RESERVED_DELIMITER = '\u2060';
 
 /**
  * Utility function that concatenates address fields based on a provided field

--- a/lang/typescript/src/utils/regions.test.ts
+++ b/lang/typescript/src/utils/regions.test.ts
@@ -8,7 +8,16 @@ describe('region yaml loader', () => {
     expect(config!.combined_address_format).toBeUndefined();
   });
 
-  test('should load config with combined_address_format', () => {
+  test('should load config with combined_address_format and no decorator', () => {
+    const config = getRegionConfig('TW');
+    expect(config).not.toBeNull();
+    expect(config!.code).toEqual('TW');
+    expect(config!.combined_address_format).toEqual({
+      address2: [{key: 'line2'}, {key: 'neighborhood'}],
+    });
+  });
+
+  test('should load config with combined_address_format and decorator set', () => {
     const config = getRegionConfig('BR');
     expect(config).not.toBeNull();
     expect(config!.code).toEqual('BR');

--- a/lang/typescript/src/utils/regions.test.ts
+++ b/lang/typescript/src/utils/regions.test.ts
@@ -13,8 +13,8 @@ describe('region yaml loader', () => {
     expect(config).not.toBeNull();
     expect(config!.code).toEqual('BR');
     expect(config!.combined_address_format).toEqual({
-      address1: [{key: 'streetName'}, {key: 'streetNumber', decorator: ','}],
-      address2: [{key: 'line2'}, {key: 'neighborhood', decorator: ','}],
+      address1: [{key: 'streetName'}, {key: 'streetNumber', decorator: ', '}],
+      address2: [{key: 'line2'}, {key: 'neighborhood', decorator: ', '}],
     });
   });
 

--- a/lib/worldwide/address.rb
+++ b/lib/worldwide/address.rb
@@ -2,6 +2,8 @@
 
 module Worldwide
   class Address
+    RESERVED_DELIMITER = "\u2060"
+
     attr_reader :first_name,
       :last_name,
       :company,
@@ -145,7 +147,6 @@ module Worldwide
       Util.blank?(errors)
     end
 
-    RESERVED_DELIMITER = "\u00A0"
     def concatenate_address1
       additional_fields = region.combined_address_format["address1"] || []
       additional_field_keys = additional_fields.map { |field| field["key"] }

--- a/test/worldwide/address_test.rb
+++ b/test/worldwide/address_test.rb
@@ -94,20 +94,20 @@ module Worldwide
       cl_address = Address.new(street_number: "123", country_code: "CL")
       br_address = Address.new(street_number: "123", country_code: "BR")
 
-      assert_equal " 123", cl_address.concatenate_address1
-      assert_equal " 123", br_address.concatenate_address1
+      assert_equal "⁠123", cl_address.concatenate_address1
+      assert_equal "⁠123", br_address.concatenate_address1
     end
 
     test "concatenate_address1 returns street name concatenated with street number separated by delimiter" do
       address = Address.new(street_name: "Main Street", street_number: "123", country_code: "CL")
 
-      assert_equal "Main Street 123", address.concatenate_address1
+      assert_equal "Main Street ⁠123", address.concatenate_address1
     end
 
     test "concatenate_address1 returns street name concatenated with street number separated by delimiter and decorator" do
       address = Address.new(street_name: "Main Street", street_number: "123", country_code: "BR")
 
-      assert_equal "Main Street, 123", address.concatenate_address1
+      assert_equal "Main Street,⁠123", address.concatenate_address1
     end
 
     test "concatenate_address2 returns address2 when additional fields are unset" do
@@ -152,14 +152,14 @@ module Worldwide
       cl_address = Address.new(neighborhood: "Centro", country_code: "CL")
       br_address = Address.new(neighborhood: "Centro", country_code: "BR")
 
-      assert_equal " Centro", cl_address.concatenate_address2
-      assert_equal " Centro", br_address.concatenate_address2
+      assert_equal "⁠Centro", cl_address.concatenate_address2
+      assert_equal "⁠Centro", br_address.concatenate_address2
     end
 
     test "concatenate_address2 returns line2 concatenated with neighborhood separated by delimiter" do
       address = Address.new(line2: "dpto 4", neighborhood: "Centro", country_code: "CL")
 
-      assert_equal "dpto 4 Centro", address.concatenate_address2
+      assert_equal "dpto 4⁠Centro", address.concatenate_address2
     end
 
     test "concatenate_address2 returns line2 concatenated with neighborhood separated by delimiter and decorator" do
@@ -167,9 +167,9 @@ module Worldwide
       ph_address = Address.new(line2: "apt 4", neighborhood: "294", country_code: "PH")
       vn_address = Address.new(line2: "apt 4", neighborhood: "Cầu Giấy", country_code: "VN")
 
-      assert_equal "dpto 4, Centro", br_address.concatenate_address2
-      assert_equal "apt 4 294", ph_address.concatenate_address2
-      assert_equal "apt 4, Cầu Giấy", vn_address.concatenate_address2
+      assert_equal "dpto 4,⁠Centro", br_address.concatenate_address2
+      assert_equal "apt 4⁠294", ph_address.concatenate_address2
+      assert_equal "apt 4,⁠Cầu Giấy", vn_address.concatenate_address2
     end
 
     test "split_address1 returns nil when additional address fields are not defined for the country" do
@@ -196,8 +196,8 @@ module Worldwide
     end
 
     test "split_address1 returns only street number if no string is present before the delimiter" do
-      cl_address = Address.new(address1: " 123", country_code: "CL")
-      br_address = Address.new(address1: " 123", country_code: "BR")
+      cl_address = Address.new(address1: "⁠123", country_code: "CL")
+      br_address = Address.new(address1: "⁠123", country_code: "BR")
       expected_hash = { "street_number" => "123" }
 
       assert_equal expected_hash, cl_address.split_address1
@@ -205,14 +205,14 @@ module Worldwide
     end
 
     test "split_address1 returns street name and street number when both values are present and seperated by a delimiter" do
-      address = Address.new(address1: "Main Street 123", country_code: "CL")
+      address = Address.new(address1: "Main Street⁠123", country_code: "CL")
       expected_hash = { "street_name" => "Main Street", "street_number" => "123" }
 
       assert_equal expected_hash, address.split_address1
     end
 
     test "split_address1 returns street name and street number when both values are present and seperated by a delimiter and decorator" do
-      address = Address.new(address1: "Main Street, 123", country_code: "BR")
+      address = Address.new(address1: "Main Street,⁠123", country_code: "BR")
       expected_hash = { "street_name" => "Main Street", "street_number" => "123" }
 
       assert_equal expected_hash, address.split_address1
@@ -242,8 +242,8 @@ module Worldwide
     end
 
     test "split_address2 returns only neighborhood if no string is present before the delimiter" do
-      cl_address = Address.new(address2: " Centro", country_code: "CL")
-      br_address = Address.new(address2: " Centro", country_code: "BR")
+      cl_address = Address.new(address2: "⁠Centro", country_code: "CL")
+      br_address = Address.new(address2: "⁠Centro", country_code: "BR")
       expected_hash = { "neighborhood" => "Centro" }
 
       assert_equal expected_hash, cl_address.split_address2
@@ -251,15 +251,15 @@ module Worldwide
     end
 
     test "split_address2 returns line2 and neighborhood when both values are present and seperated by a delimiter" do
-      cl_address = Address.new(address2: "dpto 4 Centro", country_code: "CL")
+      cl_address = Address.new(address2: "dpto 4⁠Centro", country_code: "CL")
       expected_hash = { "line2" => "dpto 4", "neighborhood" => "Centro" }
 
       assert_equal expected_hash, cl_address.split_address2
     end
 
     test "split_address2 returns line2 and neighborhood when both values are present and seperated by a delimiter and a decorator" do
-      br_address = Address.new(address2: "dpto 4, Centro", country_code: "BR")
-      ph_address = Address.new(address2: "dpto 4 294", country_code: "PH")
+      br_address = Address.new(address2: "dpto 4,⁠Centro", country_code: "BR")
+      ph_address = Address.new(address2: "dpto 4⁠294", country_code: "PH")
       expected_hash_br = { "line2" => "dpto 4", "neighborhood" => "Centro" }
       expected_hash_ph = { "line2" => "dpto 4", "neighborhood" => "294" }
 

--- a/test/worldwide/address_test.rb
+++ b/test/worldwide/address_test.rb
@@ -99,15 +99,18 @@ module Worldwide
     end
 
     test "concatenate_address1 returns street name concatenated with street number separated by delimiter" do
-      address = Address.new(street_name: "Main Street", street_number: "123", country_code: "CL")
+      Worldwide::Region.any_instance.stubs(:combined_address_format).returns(
+        { "address1" => [{ "key" => "street_name" }, { "key" => "street_number" }] },
+      )
+      address = Address.new(street_name: "文林路", street_number: "88號", country_code: "TW")
 
-      assert_equal "Main Street ⁠123", address.concatenate_address1
+      assert_equal "文林路⁠88號", address.concatenate_address1
     end
 
     test "concatenate_address1 returns street name concatenated with street number separated by delimiter and decorator" do
       address = Address.new(street_name: "Main Street", street_number: "123", country_code: "BR")
 
-      assert_equal "Main Street,⁠123", address.concatenate_address1
+      assert_equal "Main Street, ⁠123", address.concatenate_address1
     end
 
     test "concatenate_address2 returns address2 when additional fields are unset" do
@@ -157,9 +160,9 @@ module Worldwide
     end
 
     test "concatenate_address2 returns line2 concatenated with neighborhood separated by delimiter" do
-      address = Address.new(line2: "dpto 4", neighborhood: "Centro", country_code: "CL")
+      address = Address.new(line2: "1樓", neighborhood: "士林區", country_code: "TW")
 
-      assert_equal "dpto 4⁠Centro", address.concatenate_address2
+      assert_equal "1樓⁠士林區", address.concatenate_address2
     end
 
     test "concatenate_address2 returns line2 concatenated with neighborhood separated by delimiter and decorator" do
@@ -167,9 +170,9 @@ module Worldwide
       ph_address = Address.new(line2: "apt 4", neighborhood: "294", country_code: "PH")
       vn_address = Address.new(line2: "apt 4", neighborhood: "Cầu Giấy", country_code: "VN")
 
-      assert_equal "dpto 4,⁠Centro", br_address.concatenate_address2
-      assert_equal "apt 4⁠294", ph_address.concatenate_address2
-      assert_equal "apt 4,⁠Cầu Giấy", vn_address.concatenate_address2
+      assert_equal "dpto 4, ⁠Centro", br_address.concatenate_address2
+      assert_equal "apt 4 ⁠294", ph_address.concatenate_address2
+      assert_equal "apt 4, ⁠Cầu Giấy", vn_address.concatenate_address2
     end
 
     test "split_address1 returns nil when additional address fields are not defined for the country" do
@@ -204,15 +207,25 @@ module Worldwide
       assert_equal expected_hash, br_address.split_address1
     end
 
-    test "split_address1 returns street name and street number when both values are present and seperated by a delimiter" do
-      address = Address.new(address1: "Main Street⁠123", country_code: "CL")
+    test "split_address1 returns street name and street number when both values are present and separated by a delimiter" do
+      Worldwide::Region.any_instance.stubs(:combined_address_format).returns(
+        { "address1" => [{ "key" => "street_name" }, { "key" => "street_number" }] },
+      )
+      address = Address.new(address1: "文林路⁠88號", country_code: "TW")
+      expected_hash = { "street_name" => "文林路", "street_number" => "88號" }
+
+      assert_equal expected_hash, address.split_address1
+    end
+
+    test "split_address1 returns street name and street number when both values are present and separated by a delimiter and decorator" do
+      address = Address.new(address1: "Main Street, ⁠123", country_code: "BR")
       expected_hash = { "street_name" => "Main Street", "street_number" => "123" }
 
       assert_equal expected_hash, address.split_address1
     end
 
-    test "split_address1 returns street name and street number when both values are present and seperated by a delimiter and decorator" do
-      address = Address.new(address1: "Main Street,⁠123", country_code: "BR")
+    test "split_address1 returns street name and street number when delimiter is present but decorator is missing" do
+      address = Address.new(address1: "Main Street⁠123", country_code: "BR")
       expected_hash = { "street_name" => "Main Street", "street_number" => "123" }
 
       assert_equal expected_hash, address.split_address1
@@ -250,21 +263,28 @@ module Worldwide
       assert_equal expected_hash, br_address.split_address2
     end
 
-    test "split_address2 returns line2 and neighborhood when both values are present and seperated by a delimiter" do
-      cl_address = Address.new(address2: "dpto 4⁠Centro", country_code: "CL")
-      expected_hash = { "line2" => "dpto 4", "neighborhood" => "Centro" }
+    test "split_address2 returns line2 and neighborhood when both values are present and separated by a delimiter" do
+      cl_address = Address.new(address2: "1樓⁠士林區", country_code: "TW")
+      expected_hash = { "line2" => "1樓", "neighborhood" => "士林區" }
 
       assert_equal expected_hash, cl_address.split_address2
     end
 
-    test "split_address2 returns line2 and neighborhood when both values are present and seperated by a delimiter and a decorator" do
-      br_address = Address.new(address2: "dpto 4,⁠Centro", country_code: "BR")
-      ph_address = Address.new(address2: "dpto 4⁠294", country_code: "PH")
+    test "split_address2 returns line2 and neighborhood when both values are present and separated by a delimiter and a decorator" do
+      br_address = Address.new(address2: "dpto 4, ⁠Centro", country_code: "BR")
+      ph_address = Address.new(address2: "dpto 4 ⁠294", country_code: "PH")
       expected_hash_br = { "line2" => "dpto 4", "neighborhood" => "Centro" }
       expected_hash_ph = { "line2" => "dpto 4", "neighborhood" => "294" }
 
       assert_equal expected_hash_br, br_address.split_address2
       assert_equal expected_hash_ph, ph_address.split_address2
+    end
+
+    test "split_address2 returns line2 and neighborhood when delimiter is present but decorator is missing" do
+      address = Address.new(address2: "dpto 4⁠Centro", country_code: "BR")
+      expected_hash = { "line2" => "dpto 4", "neighborhood" => "Centro" }
+
+      assert_equal expected_hash, address.split_address2
     end
   end
 end

--- a/test/worldwide/region_test.rb
+++ b/test/worldwide/region_test.rb
@@ -396,18 +396,18 @@ module Worldwide
       [
         [:us, {}],
         [:il, {
-          "address1" => [{ "key" => "streetNumber" }, { "key" => "streetName" }],
+          "address1" => [{ "key" => "streetNumber" }, { "key" => "streetName", "decorator" => " " }],
         },],
         [:br, {
-          "address1" => [{ "key" => "streetName" }, { "key" => "streetNumber", "decorator" => "," }],
-          "address2" => [{ "key" => "line2" }, { "key" => "neighborhood", "decorator" => "," }],
+          "address1" => [{ "key" => "streetName" }, { "key" => "streetNumber", "decorator" => ", " }],
+          "address2" => [{ "key" => "line2" }, { "key" => "neighborhood", "decorator" => ", " }],
         },],
         [:cl, {
-          "address1" => [{ "key" => "streetName" }, { "key" => "streetNumber" }],
-          "address2" => [{ "key" => "line2" }, { "key" => "neighborhood" }],
+          "address1" => [{ "key" => "streetName" }, { "key" => "streetNumber", "decorator" => " " }],
+          "address2" => [{ "key" => "line2" }, { "key" => "neighborhood", "decorator" => " " }],
         },],
         [:id, {
-          "address2" => [{ "key" => "line2" }, { "key" => "neighborhood", "decorator" => "," }],
+          "address2" => [{ "key" => "line2" }, { "key" => "neighborhood", "decorator" => ", " }],
         },],
       ].each do |region_code, expected_value|
         assert_equal expected_value, Worldwide.region(code: region_code).combined_address_format

--- a/test/worldwide/region_yml_consistency_test.rb
+++ b/test/worldwide/region_yml_consistency_test.rb
@@ -144,6 +144,26 @@ module Worldwide
       end
     end
 
+    test "combined_address_format decorators are non-empty strings when set" do
+      Regions.all.select(&:country?).each do |country|
+        next if country.combined_address_format.blank?
+
+        country.combined_address_format.each do |_combined_field, fields|
+          fields.each do |field|
+            decorator = field["decorator"]
+
+            next if decorator.nil?
+
+            refute_predicate(
+              decorator,
+              :empty?,
+              "#{country.iso_code} combined_address_format decorator for #{field["key"]} can't be an empty string",
+            )
+          end
+        end
+      end
+    end
+
     test "If zones key does not exists, should not have {province} in format key" do
       Regions.all.select do |region|
         region.country? && region.zones.blank?


### PR DESCRIPTION
### What are you trying to accomplish?
<!--
Link to an issue or provide enough context so that someone new can understand the 'why' behind this change.
-->

Resolves https://github.com/Shopify/address/issues/2630

Change the reserved delimiter from the Non-Breaking Space (`U+00A0`) to Word Joiner (`U+2060`) and updated region decorators to include a space explicitly where necessary.

### What approach did you choose and why?
<!--
There are many ways to solve a problem. How did you approach this problem and why?
-->

The Word Joiner character has a few benefits:
- Has zero-width so doesn't add spacing in languages that don't normally have spacing between characters (e.g. Mandarin Chinese)
- Does not introduce a leading spacing when optional address fields are blank
   - Example: Brazil address2 that includes neighborhood without line2 would render as `" Neighborhood"`, will now render as `"Neighborhood"`)

### What should reviewers focus on?
<!--
Outline anything you'd like reviewers to pay extra attention to. List open questions for discussion.
-->

The Ruby and Typescript implementations should handle this change the same way:
- Reserved delimiter updated to `U+2060`
- 2-character decorators need to work, so `", "` for Brazil
- Decorators should be inserted before the next fields delimiter, so `<line2><decorator><delimiter><neighborhood>` for Brazil will be `dpto 4, \u2060Centro`

### The impact of these changes
<!--
Are there any specific impacts from this change that you'd like to call out?
-->

No changes to the exposed functions or classes.

Internally:
- Decorators are now required on most regions to insert a space

Behavioral/UX change (out of scope of this package but a downstream impact on usage):
- Copy-paste behavior in browsers will change when rendering the concatenated string directly to HTML because Chrome will convert NBSP to a space but will not remove WordJoiner

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

### Typescript ✅ 

<img width="759" alt="Screenshot 2024-06-14 at 1 45 32 PM" src="https://github.com/Shopify/worldwide/assets/1051880/0a22acde-6e5c-442c-9b65-bbcec35e69d5">

### Ruby 💎 
- tests updated
- some tests added to cover decorator-less countries (TW)
- added a consistency check to ensure that all `decorator` entries in region ymls are either null or non-empty strings.

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
