### PR TITLE
Release 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Security in case of vulnerabilities.
 
 ## [Unreleased]
-- Add localized error strings for neighborhood in AE, CR, KW, PA, PE, SA [#215](https://github.com/Shopify/worldwide/pull/215)
-- Change delimiter from Non-Breaking Space to Word Joiner [#221](https://github.com/Shopify/worldwide/pull/221)
 
 --
+
+## [1.4.0] - 2024-06-14
+- Add localized error strings for neighborhood in AE, CR, KW, PA, PE, SA [#215](https://github.com/Shopify/worldwide/pull/215)
+- Change delimiter from Non-Breaking Space to Word Joiner [#221](https://github.com/Shopify/worldwide/pull/221)
 
 ## [1.3.1] - 2024-06-11
 Patch release containing many non-english translation updates

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (1.3.1)
+    worldwide (1.4.0)
       activesupport (>= 7.0)
       i18n
       phonelib (~> 0.8)

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "1.3.1"
+  VERSION = "1.4.0"
 end


### PR DESCRIPTION
### What are you trying to accomplish?
Prepare a new minor version that changes the string concatenation/splitting reserved delimiter from a non-breaking space to a word joiner.

### The impact of these changes
Affected ruby and typescript clients will need to update closely to one another, otherwise no splitting/concatenation will occur.

...

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
