### PR TITLE
Street number is optional in Chile, release v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 --
 
+## [1.5.0] - 2024-06-17
+- Make street number optional in CL [#228](https://github.com/Shopify/worldwide/pull/228)
+
 ## [1.4.1] - 2024-06-17
 - Add translations for neighborhood error strings in AE, CR, KW, PA, PE, SA [#220](https://github.com/Shopify/worldwide/pull/220)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (1.4.1)
+    worldwide (1.5.0)
       activesupport (>= 7.0)
       i18n
       phonelib (~> 0.8)

--- a/db/data/regions/CL.yml
+++ b/db/data/regions/CL.yml
@@ -20,7 +20,6 @@ additional_address_fields:
   - name: streetName
     required: true
   - name: streetNumber
-    required: true
   - name: line2
   - name: neighborhood
 combined_address_format:

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "1.4.1"
+  VERSION = "1.5.0"
 end

--- a/test/worldwide/region_test.rb
+++ b/test/worldwide/region_test.rb
@@ -296,8 +296,8 @@ module Worldwide
     end
 
     test "street_number_required? returns values as expected" do
-      street_number_not_required_countries = [:ca, :us, :id]
-      street_number_required_countries = [:be, :br, :cl, :es]
+      street_number_not_required_countries = [:ca, :cl, :us, :id]
+      street_number_required_countries = [:be, :br, :il, :mx, :nl, :es]
 
       street_number_not_required_countries.each do |country_code|
         assert_equal false, Worldwide.region(code: country_code).street_number_required?


### PR DESCRIPTION
### What are you trying to accomplish?
Street number should be optional. 

part of https://github.com/Shopify/address/issues/2638

### What approach did you choose and why?
Make street number optional

Release new version of worldwide 

### What should reviewers focus on?
<!--
Outline anything you'd like reviewers to pay extra attention to. List open questions for discussion.
-->

...

### The impact of these changes
Street number is no longer required in Chile 

### Testing
Updated tests

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
