### PR TITLE
Release v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+---
+
+## [1.6.0] - 2024-06-21
 - Support multiple script-based address concatenation rules for each country [#224](https://github.com/Shopify/worldwide/pull/224)
 - Fixed a typo in list of supported scripts from `Latn` to `Latin`
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (1.5.0)
+    worldwide (1.6.0)
       activesupport (>= 7.0)
       i18n
       phonelib (~> 0.8)

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "1.5.0"
+  VERSION = "1.6.0"
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Minor bump to 1.6.0

- Support multiple script-based address concatenation rules for each country [#224](https://github.com/Shopify/worldwide/pull/224)
- Fixed a typo in list of supported scripts from `Latn` to `Latin`
- https://github.com/Shopify/worldwide/pull/235