### PR TITLE
Move Units constants under `Worldwide::Units`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Security in case of vulnerabilities.
 
 ## [Unreleased]
+- Move Units constants `SUPPORTED_HUMANIZATIONS` and `MEASUREMENT_KEYS` to `Worldwide.units.supported_humanizations` and `Worldwide.units.measurement_keys` [#240](https://github.com/Shopify/worldwide/pull/240)
 
 ---
 
@@ -38,7 +39,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [1.4.1] - 2024-06-17
 - Add translations for neighborhood error strings in AE, CR, KW, PA, PE, SA [#220](https://github.com/Shopify/worldwide/pull/220)
-
 
 ## [1.4.0] - 2024-06-14
 - Add localized error strings for neighborhood in AE, CR, KW, PA, PE, SA [#215](https://github.com/Shopify/worldwide/pull/215)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,6 +126,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/README.md
+++ b/README.md
@@ -74,10 +74,17 @@ I18n.enforce_available_locales = false
 
 Here the list of the features we currently support:
 
-- [🌏  Regions](#--regions-countries--territories--subdivisions--states--provinces--prefectures--etc)
+- [🌏  Regions (Countries / Territories / Subdivisions / States / Provinces / Prefectures / etc.)](#--regions-countries--territories--subdivisions--states--provinces--prefectures--etc)
+  - [Regional Validations](#regional-validations)
+  - [Phone Validations](#phone-validations)
 - [📫  Addresses](#--addresses)
+  - [Formatting](#formatting)
+  - [Validation](#validation)
+  - [Auto-correction](#auto-correction)
 - [🗓  / ⌚  Date and Time formats](#-----date-and-time-formats)
+  - [Calendar quarter formatting](#calendar-quarter-formatting)
 - [📅  Calendar Information](#--calendar-information)
+  - [Month and Weekday labels](#month-and-weekday-labels)
 - [🕰  Localized Timezone](#--localized-timezone)
   - [➡🕰  Map Deprecated Timezone Name to Modern Name](#--map-deprecated-timezone-name-to-modern-name)
 - [👥  Names](#--names)
@@ -898,7 +905,7 @@ This module provides localized measurement unit formatting.
 
 `Units.format` supports the following arguments:
 - `amount`: the amount associated with the unit. This parameter is used to apply the unique pluralization rules of the requested locale.
-- `unit`: the measurement unit. Currently, only the keys listed in [`Worldwide::MEASUREMENT_KEYS`](https://github.com/Shopify/worldwide/blob/main/lib/worldwide/units.rb#L9-L51) are supported.
+- `unit`: the measurement unit. The keys listed in [`Worldwide.Units.measurement_keys`](https://github.com/Shopify/worldwide/blob/main/lib/worldwide/units.rb#L23-L70) are supported.
 - `humanize`: can be `:long` or `:short`. `:long` returns the translated word of the unit. `:short` returns the localized abbreviation of the unit. The default value is `:short`.
 
 ```ruby

--- a/lib/worldwide/units.rb
+++ b/lib/worldwide/units.rb
@@ -1,68 +1,72 @@
 # frozen_string_literal: true
 
 module Worldwide
-  SUPPORTED_HUMANIZATIONS = {
-    short: :short,
-    long: :long,
-  }.freeze
-
-  MEASUREMENT_KEYS = {
-    millimeter: :length_millimeter,
-    millimeters: :length_millimeter,
-    centimeter: :length_centimeter,
-    centimeters: :length_centimeter,
-    foot: :length_foot,
-    feet: :length_foot,
-    inch: :length_inch,
-    inches: :length_inch,
-    meter: :length_meter,
-    meters: :length_meter,
-    gram: :mass_gram,
-    grams: :mass_gram,
-    kilogram: :mass_kilogram,
-    kilograms: :mass_kilogram,
-    ounce: :mass_ounce,
-    ounces: :mass_ounce,
-    pound: :mass_pound,
-    pounds: :mass_pound,
-    centiliter: :volume_centiliter,
-    centiliters: :volume_centiliter,
-    cubic_meter: :volume_cubic_meter,
-    cubic_meters: :volume_cubic_meter,
-    imperial_fluid_ounce: :volume_fluid_ounce_imperial,
-    imperial_fluid_ounces: :volume_fluid_ounce_imperial,
-    fluid_ounce: :volume_fluid_ounce,
-    fluid_ounces: :volume_fluid_ounce,
-    imperial_gallon: :volume_gallon_imperial,
-    imperial_gallons: :volume_gallon_imperial,
-    gallon: :volume_gallon,
-    gallons: :volume_gallon,
-    liter: :volume_liter,
-    liters: :volume_liter,
-    milliliter: :volume_milliliter,
-    milliliters: :volume_milliliter,
-    pint: :volume_pint,
-    pints: :volume_pint,
-    imperial_pint: :volume_pint_imperial,
-    imperial_pints: :volume_pint_imperial,
-    quart: :volume_quart,
-    quarts: :volume_quart,
-    imperial_quart: :volume_quart_imperial,
-    imperial_quarts: :volume_quart_imperial,
-    yard: :length_yard,
-    yards: :length_yard,
-  }.freeze
-
   class Units
     class << self
       def format(amount, unit, humanize: :short)
-        supported_humanization = SUPPORTED_HUMANIZATIONS[humanize.to_sym]
+        supported_humanization = supported_humanizations[humanize.to_sym]
         raise ArgumentError, "Unsupported value for `humanize`: #{humanize}." unless supported_humanization
 
-        measurement_key = MEASUREMENT_KEYS[unit.to_sym]
+        measurement_key = measurement_keys[unit.to_sym]
         raise ArgumentError, "Unsupported value for `unit`: #{unit}." unless measurement_key
 
         Cldr.t("units.unit_length.#{supported_humanization}.#{measurement_key}", count: amount)
+      end
+
+      def supported_humanizations
+        {
+          short: :short,
+          long: :long,
+        }.freeze
+      end
+
+      def measurement_keys
+        {
+          millimeter: :length_millimeter,
+          millimeters: :length_millimeter,
+          centimeter: :length_centimeter,
+          centimeters: :length_centimeter,
+          foot: :length_foot,
+          feet: :length_foot,
+          inch: :length_inch,
+          inches: :length_inch,
+          meter: :length_meter,
+          meters: :length_meter,
+          gram: :mass_gram,
+          grams: :mass_gram,
+          kilogram: :mass_kilogram,
+          kilograms: :mass_kilogram,
+          ounce: :mass_ounce,
+          ounces: :mass_ounce,
+          pound: :mass_pound,
+          pounds: :mass_pound,
+          centiliter: :volume_centiliter,
+          centiliters: :volume_centiliter,
+          cubic_meter: :volume_cubic_meter,
+          cubic_meters: :volume_cubic_meter,
+          imperial_fluid_ounce: :volume_fluid_ounce_imperial,
+          imperial_fluid_ounces: :volume_fluid_ounce_imperial,
+          fluid_ounce: :volume_fluid_ounce,
+          fluid_ounces: :volume_fluid_ounce,
+          imperial_gallon: :volume_gallon_imperial,
+          imperial_gallons: :volume_gallon_imperial,
+          gallon: :volume_gallon,
+          gallons: :volume_gallon,
+          liter: :volume_liter,
+          liters: :volume_liter,
+          milliliter: :volume_milliliter,
+          milliliters: :volume_milliliter,
+          pint: :volume_pint,
+          pints: :volume_pint,
+          imperial_pint: :volume_pint_imperial,
+          imperial_pints: :volume_pint_imperial,
+          quart: :volume_quart,
+          quarts: :volume_quart,
+          imperial_quart: :volume_quart_imperial,
+          imperial_quarts: :volume_quart_imperial,
+          yard: :length_yard,
+          yards: :length_yard,
+        }.freeze
       end
     end
   end

--- a/rake/cldr/patch.rb
+++ b/rake/cldr/patch.rb
@@ -1210,7 +1210,7 @@ module Worldwide
 
         def patch_units
           puts("📐 Patching the units.yml CLDR files")
-          measurement_keys = Worldwide::MEASUREMENT_KEYS.values.uniq.map(&:to_s)
+          measurement_keys = Worldwide.units.measurement_keys.values.uniq.map(&:to_s)
           units_filepaths = Dir.glob(File.join(["data", "cldr", "locales", "*", "units.yml"]))
           raise NotNeededError, "No CLDR units files found to patch." if units_filepaths.empty?
 

--- a/test/worldwide/units_test.rb
+++ b/test/worldwide/units_test.rb
@@ -79,5 +79,13 @@ module Worldwide
         assert_equal "5 cm", result
       end
     end
+
+    test "#supported_humanizations returns supported humanizations" do
+      assert_not Worldwide.units.supported_humanizations.empty?
+    end
+
+    test "#measurement_keys returns supported measurement keys" do
+      assert_not Worldwide.units.measurement_keys.empty?
+    end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?
<!--
Link to an issue or provide enough context so that someone new can understand the 'why' behind this change.
-->

Move Units constants `SUPPORTED_HUMANIZATIONS` and `MEASUREMENT_KEYS` to `Worldwide.units.supported_humanizations` and `Worldwide.units.measurement_keys`

### What approach did you choose and why?
<!--
There are many ways to solve a problem. How did you approach this problem and why?
-->

These constants belong to `Worldwide::Units`, not to the broader `Worldwide` module.
Followed the same pattern as [`Worldwide.plurals.all_cardinal_pluralization_keys`](https://github.com/Shopify/worldwide/blob/main/lib/worldwide/plurals.rb#L28)

### What should reviewers focus on?
<!--
Outline anything you'd like reviewers to pay extra attention to. List open questions for discussion.
-->

:shrug:

### The impact of these changes
<!--
Are there any specific impacts from this change that you'd like to call out?
-->

Better code organization

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

Unit tests pass

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
