### PR TITLE
Fix npm release workflow

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -35,4 +35,4 @@ jobs:
           cwd: lang/typescript
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}

--- a/lang/typescript/.changeset/npm-package-homepage.md
+++ b/lang/typescript/.changeset/npm-package-homepage.md
@@ -1,0 +1,5 @@
+---
+'@shopify/worldwide': patch
+---
+
+Update npm package homepage to npm package readme, fix release workflow (no functional changes)

--- a/lang/typescript/package.json
+++ b/lang/typescript/package.json
@@ -4,6 +4,7 @@
   "version": "0.4.0",
   "repository": "git@github.com:Shopify/worldwide.git",
   "author": "Shopify Inc.",
+  "homepage": "https://github.com/Shopify/worldwide/tree/main/lang/typescript#readme",
   "license": "MIT",
   "private": false,
   "publishConfig": {


### PR DESCRIPTION
### What are you trying to accomplish?
<!--
Link to an issue or provide enough context so that someone new can understand the 'why' behind this change.
-->

https://github.com/Shopify/address/issues/2615

Uses new access token for the changesets action, which will make the [automated changesets PR](https://github.com/Shopify/worldwide/pull/197) be run by the GAAP bot instead of the standard GH actions bot. This should make the CLA automatically signed.

### What approach did you choose and why?
<!--
There are many ways to solve a problem. How did you approach this problem and why?
-->

Opted to use the GAAP bot instead of modifying the CLA verification flow, as the GAAP bot should pass signing verification. Alternatively if this doesn't work we can have the GAAP bot bypass CLA.

### What should reviewers focus on?
<!--
Outline anything you'd like reviewers to pay extra attention to. List open questions for discussion.
-->

...

### The impact of these changes
<!--
Are there any specific impacts from this change that you'd like to call out?
-->

...

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

...

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
