### PR TITLE
Update npm release workflow with new token and changsets message

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
@@ -33,6 +35,8 @@ jobs:
         with:
           publish: pnpm release
           cwd: lang/typescript
+          title: Version NPM Package
+          commit: Version NPM Package
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}


### PR DESCRIPTION
### What are you trying to accomplish?
<!--
Link to an issue or provide enough context so that someone new can understand the 'why' behind this change.
-->

https://github.com/Shopify/address/issues/2615

Followup to https://github.com/Shopify/worldwide/pull/241

This adds the GH action token to the checkout step as well which is what actually uses the right github bot user for the PR creation. See: https://github.com/actions/checkout?tab=readme-ov-file#usage

Also updated the commit message and PR title to "Version NPM Package" instead of the default "Version Packages" as this makes more sense in our mixed-language context.

### What approach did you choose and why?
<!--
There are many ways to solve a problem. How did you approach this problem and why?
-->

...

### What should reviewers focus on?
<!--
Outline anything you'd like reviewers to pay extra attention to. List open questions for discussion.
-->

...

### The impact of these changes
<!--
Are there any specific impacts from this change that you'd like to call out?
-->

...

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

Tested this on a [dummy branch and PR](https://github.com/Shopify/worldwide/pull/242).

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
