### PR TITLE
Improve tests related to building number requiredness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- Improve tests related to building number requiredness [#249](https://github.com/Shopify/worldwide/pull/249)
+
 ---
 
 ## [1.6.1] - 2024-07-03

--- a/test/worldwide/region_test.rb
+++ b/test/worldwide/region_test.rb
@@ -380,7 +380,7 @@ module Worldwide
       end
     end
 
-    test "building_number_requrired returns values as expected" do
+    test "building_number_required returns values as expected" do
       [
         [:ca, true],
         [:in, false],
@@ -389,6 +389,17 @@ module Worldwide
         [:us, true],
       ].each do |region_code, expected_value|
         assert_equal expected_value, Worldwide.region(code: region_code).building_number_required
+      end
+    end
+
+    test "building_number_may_be_in_address2 returns values as expected" do
+      [
+        [:ca, false],
+        [:de, true],
+        [:jp, true],
+        [:us, false],
+      ].each do |region_code, expected_value|
+        assert_equal expected_value, Worldwide.region(code: region_code).building_number_may_be_in_address2
       end
     end
 

--- a/test/worldwide/region_yml_consistency_test.rb
+++ b/test/worldwide/region_yml_consistency_test.rb
@@ -59,6 +59,16 @@ module Worldwide
       end
     end
 
+    test "all regions that allow a building number on address2 set building_number_required to true" do
+      Regions.all.select(&:country?).each do |country|
+        next unless country.building_number_may_be_in_address2
+
+        assert_predicate country,
+          :building_number_required,
+          "#{country.iso_code} allows building number in address2 but building_number_required is not true"
+      end
+    end
+
     test "format keys must belong to a limited set of required and allowed keys" do
       allowed_keys = ["edit", "show"]
       required_format_keys = ["{firstName}", "{lastName}", "{company}", "{address1}", "{address2}", "{country}", "{phone}"]


### PR DESCRIPTION
### What are you trying to accomplish?
Follow up to a change in Shopify's legacy internal library, which now delegates to worldwide.

Worldwide should shore up its tests and consistency checks around `building_number_required` and `building_number_may_be_in_address2`

### What should reviewers focus on?
<!--
Outline anything you'd like reviewers to pay extra attention to. List open questions for discussion.
-->

...

### The impact of these changes
<!--
Are there any specific impacts from this change that you'd like to call out?
-->

...

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

...

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
