### PR TITLE
Respect `available_locales` if already set in application.

### DIFF
--- a/lib/worldwide/config.rb
+++ b/lib/worldwide/config.rb
@@ -39,8 +39,7 @@ module Worldwide
 
         set_unless_explicitly_set(i18n_config, :default_locale, :en)
         set_unless_explicitly_set(i18n_config, :exception_handler, exception_handler)
-
-        i18n_config.available_locales = expanded_locales_from_configuration(i18n_config)
+        set_unless_explicitly_set(i18n_config, :available_locales, expanded_locales_from_configuration(i18n_config))
 
         add_cldr_data(i18n_config, additional_components: additional_components)
         add_other_data(i18n_config)


### PR DESCRIPTION
Currently, this gem overrides if `config.i18n.available_locales` is manually set in an initializer or environment file. This PR respects if that config is already set.

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
