### PR TITLE
Migrate example_address to Worldwide::Region, cut v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ---
 
+## [1.7.0] - 2024-07-17
+- Introduce example_address to the worldwide region, update country ymls [#257](https://github.com/Shopify/worldwide/pull/257)
+
 ## [1.6.2] - 2024-07-10
 
 - Improve tests related to building number requiredness [#249](https://github.com/Shopify/worldwide/pull/249)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (1.6.2)
+    worldwide (1.7.0)
       activesupport (>= 7.0)
       i18n
       phonelib (~> 0.8)

--- a/db/data/regions/AC.yml
+++ b/db/data/regions/AC.yml
@@ -18,5 +18,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}"
 emoji: 🇦🇨
 languages:
-  - en
+- en
+example_address:
+  address1: Two Boats School
+  city: Two Boats
+  zip: ASCN 1ZZ
+  phone: "+290 64431"
 timezone: Atlantic/St_Helena

--- a/db/data/regions/AD.yml
+++ b/db/data/regions/AD.yml
@@ -17,7 +17,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1E6\U0001F1E9"
 languages:
-  - ca
-  - es
-  - fr
+- ca
+- es
+- fr
+example_address:
+  address1: Av. Meritxell, 73
+  city: Andorra la Vella
+  zip: AD500
+  phone: "+376 750 100"
 timezone: Europe/Andorra

--- a/db/data/regions/AE.yml
+++ b/db/data/regions/AE.yml
@@ -27,8 +27,14 @@ combined_address_format:
         decorator: ", "
 emoji: "\U0001F1E6\U0001F1EA"
 languages:
-  - ar
-  - en
+- ar
+- en
+example_address:
+  address1: Qasr Al Watan
+  address2: "⁠Al Ras Al Akhdar"
+  city: Abu Dhabi
+  province_code: AZ
+  phone: "+971 600 544442"
 zones:
 - name: Abu Dhabi
   code: AZ

--- a/db/data/regions/AF.yml
+++ b/db/data/regions/AF.yml
@@ -17,5 +17,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1E6\U0001F1EB"
 languages:
-  - ps
+- ps
+example_address:
+  address1: The Arg
+  address2: Wazir Akbar Khan Rd
+  city: Kabul
+  zip: '1003'
+  phone: "+93 20 210 1312"
 timezone: Asia/Kabul

--- a/db/data/regions/AG.yml
+++ b/db/data/regions/AG.yml
@@ -14,5 +14,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: "\U0001F1E6\U0001F1EC"
 languages:
-  - en
+- en
+example_address:
+  address1: Government House
+  address2: Church Street
+  city: St. John's
+  zip: '16500'
+  phone: "+1 (268) 462-0005"
 timezone: America/Puerto_Rico

--- a/db/data/regions/AI.yml
+++ b/db/data/regions/AI.yml
@@ -16,5 +16,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country} {zip}_{phone}"
 emoji: 🇦🇮
 languages:
-  - en
+- en
+example_address:
+  address1: Governor's Office
+  address2: Old Ta
+  city: The Valley
+  zip: AI-2640
+  phone: "+1 264-497-2621"
 timezone: America/Anguilla

--- a/db/data/regions/AL.yml
+++ b/db/data/regions/AL.yml
@@ -18,8 +18,14 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1E6\U0001F1F1"
 languages:
-  - el
-  - fr
-  - mk
-  - sq
+- el
+- fr
+- mk
+- sq
+example_address:
+  address1: Rruga Aleksandër Moisiu 76
+  address2: Ish - Kinostudio
+  city: Tirana
+  zip: '1007'
+  phone: "+355 698 757 912"
 timezone: Europe/Tirane

--- a/db/data/regions/AM.yml
+++ b/db/data/regions/AM.yml
@@ -18,7 +18,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1E6\U0001F1F2"
 languages:
-  - fr
-  - hy
-  - ru
+- fr
+- hy
+- ru
+example_address:
+  address1: 26 Marshal Baghramyan Ave
+  city: Yerevan
+  zip: '0077'
+  phone: "+374 11 59 75 34"
 timezone: Asia/Yerevan

--- a/db/data/regions/AO.yml
+++ b/db/data/regions/AO.yml
@@ -13,5 +13,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: "\U0001F1E6\U0001F1F4"
 languages:
-  - "pt-PT"
+- pt-PT
+example_address:
+  address1: Rua do MAT, Complexo Administrativo Clássicos do Talatona
+  address2: Edifício 4, 6.º andar
+  city: Luanda
+  phone: "+244 946 214 949"
 timezone: Africa/Lagos

--- a/db/data/regions/AR.yml
+++ b/db/data/regions/AR.yml
@@ -17,7 +17,13 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city} {province}_{country}_{phone}"
 emoji: "\U0001F1E6\U0001F1F7"
 languages:
-  - es
+- es
+example_address:
+  address1: Balcarce 78
+  city: Buenos Aires
+  province_code: C
+  zip: C1064
+  phone: "+54 11 4344-3600"
 zones:
 - tax: 0.0
   name: Buenos Aires

--- a/db/data/regions/AT.yml
+++ b/db/data/regions/AT.yml
@@ -16,8 +16,13 @@ phone_number_prefix: 43
 building_number_required: true
 building_number_may_be_in_address2: true
 languages:
-  - de
-  - en
+- de
+- en
+example_address:
+  address1: Josefsplatz 1
+  city: Wien
+  zip: '1015'
+  phone: "+43 1 53410"
 format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"

--- a/db/data/regions/AU.yml
+++ b/db/data/regions/AU.yml
@@ -24,7 +24,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city} {province} {zip}_{country}_{phone}"
 emoji: "\U0001F1E6\U0001F1FA"
 languages:
-  - en
+- en
+example_address:
+  address1: 109 Kirribilli Ave
+  city: Kiribilli
+  province_code: NSW
+  phone: "+61 2 6283 3533"
 use_zone_code_as_short_name: true
 zones:
 - tax: 0.0

--- a/db/data/regions/AW.yml
+++ b/db/data/regions/AW.yml
@@ -17,5 +17,9 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: "\U0001F1E6\U0001F1FC"
 languages:
-  - nl
+- nl
+example_address:
+  address1: L.G. Smith Boulevard 76
+  city: Oranjestad
+  phone: "+297 528 4900"
 timezone: America/Puerto_Rico

--- a/db/data/regions/AX.yml
+++ b/db/data/regions/AX.yml
@@ -21,6 +21,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: 🇦🇽
 languages:
-  - fi
-  - sv
+- fi
+- sv
+example_address:
+  address1: Strandgatan 37
+  city: Mariehamn
+  zip: '22100'
+  phone: "+358 18 25000"
 timezone: Europe/Mariehamn

--- a/db/data/regions/AZ.yml
+++ b/db/data/regions/AZ.yml
@@ -17,7 +17,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1E6\U0001F1FF"
 languages:
-  - av
-  - az
-  - ru
+- av
+- az
+- ru
+example_address:
+  address1: 19 Istiqlaliyyat Street
+  city: Baku
+  zip: AZ1066
+  phone: "+99412 492 35 43"
 timezone: Asia/Baku

--- a/db/data/regions/BA.yml
+++ b/db/data/regions/BA.yml
@@ -16,7 +16,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1E7\U0001F1E6"
 languages:
-  - bs
-  - hr
-  - sr
+- bs
+- hr
+- sr
+example_address:
+  address1: Kneza Domagoja bb.
+  city: Mostar
+  zip: '88000'
+  phone: "+387 (36) 33 43 82"
 timezone: Europe/Belgrade

--- a/db/data/regions/BB.yml
+++ b/db/data/regions/BB.yml
@@ -16,5 +16,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1E7\U0001F1E7"
 languages:
-  - en
+- en
+example_address:
+  address1: Ground Floor Baobab Tower
+  address2: Highway 2
+  city: Warrens, St. Michael
+  phone: "+1 (246) 535-2401"
 timezone: America/Barbados

--- a/db/data/regions/BD.yml
+++ b/db/data/regions/BD.yml
@@ -16,6 +16,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}"
 emoji: "\U0001F1E7\U0001F1E9"
 languages:
-  - bn
-  - en
+- bn
+- en
+example_address:
+  address1: Bangabhaban
+  city: Dhaka
+  zip: '1222'
+  phone: "+88 02 9550311"
 timezone: Asia/Dhaka

--- a/db/data/regions/BE.yml
+++ b/db/data/regions/BE.yml
@@ -17,10 +17,15 @@ building_number_required: true
 building_number_may_be_in_address2: true
 week_start_day: monday
 languages:
-  - de
-  - en
-  - fr
-  - nl
+- de
+- en
+- fr
+- nl
+example_address:
+  address1: Rue Brederode ⁠16
+  city: Bruxelles
+  zip: '1000'
+  phone: "+32 (0)2-551.20.20"
 format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"

--- a/db/data/regions/BF.yml
+++ b/db/data/regions/BF.yml
@@ -16,5 +16,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: 🇧🇫
 languages:
-  - fr
+- fr
+example_address:
+  address1: Palais présidentiel de Kossyam
+  address2: Bd Muammar Kaddafi, Ouaga 2000
+  city: Ouagadougou
+  zip: '10010'
+  phone: "+226 25 49 83 00"
 timezone: Africa/Abidjan

--- a/db/data/regions/BG.yml
+++ b/db/data/regions/BG.yml
@@ -19,6 +19,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1E7\U0001F1EC"
 languages:
-  - bg
-  - fr
+- bg
+- fr
+example_address:
+  address1: Knyaz Alexander Dondukov Blvd 2А
+  city: Sofia Center
+  zip: '1000'
+  phone: "+359 2 921 7799"
 timezone: Europe/Sofia

--- a/db/data/regions/BH.yml
+++ b/db/data/regions/BH.yml
@@ -17,6 +17,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}"
 emoji: "\U0001F1E7\U0001F1ED"
 languages:
-  - ar
-  - en
+- ar
+- en
+example_address:
+  address1: Road 2904 Building 293
+  city: Manama
+  zip: '329'
+  phone: "+973 1723 9999"
 timezone: Asia/Qatar

--- a/db/data/regions/BI.yml
+++ b/db/data/regions/BI.yml
@@ -13,7 +13,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: 🇧🇮
 languages:
-  - en
-  - fr
-  - rn
+- en
+- fr
+- rn
+example_address:
+  address1: 34 Ave. Murembwe
+  city: Bujumbura
+  phone: "+257 22 20 70 00"
 timezone: Africa/Maputo

--- a/db/data/regions/BJ.yml
+++ b/db/data/regions/BJ.yml
@@ -13,7 +13,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: "\U0001F1E7\U0001F1EF"
 languages:
-  - ar
-  - en
-  - fr
+- ar
+- en
+- fr
+example_address:
+  address1: Carré 784 P Bd du Canada
+  address2: B.P. 06-2650
+  city: Cottonou
+  phone: "+229 21 30 60 35"
 timezone: Africa/Lagos

--- a/db/data/regions/BL.yml
+++ b/db/data/regions/BL.yml
@@ -23,5 +23,11 @@ format:
 # That unofficial flag is what you get when using the emoji codepoints BL; we'll go with that here.
 emoji: 🇧🇱
 languages:
-  - fr
+- fr
+example_address:
+  address1: Musée de Wall House
+  address2: La Pointe
+  city: Gustavia
+  zip: '97133'
+  phone: "+590 690 77 63 55"
 timezone: America/Puerto_Rico

--- a/db/data/regions/BM.yml
+++ b/db/data/regions/BM.yml
@@ -15,5 +15,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}"
 emoji: "\U0001F1E7\U0001F1F2"
 languages:
-  - en
+- en
+example_address:
+  address1: 11 Langton Hill
+  city: Pembroke
+  zip: HM 13
+  phone: "(441) 292 3600"
 timezone: Atlantic/Bermuda

--- a/db/data/regions/BN.yml
+++ b/db/data/regions/BN.yml
@@ -16,6 +16,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1E7\U0001F1F3"
 languages:
-  - en
-  - ms
+- en
+- ms
+example_address:
+  address1: Ministry of Finance and Economy
+  address2: Commonwealth Drive
+  city: Bandar Seri Begawan
+  zip: BB3910
+  phone: "+673 238 0999"
 timezone: Asia/Kuching

--- a/db/data/regions/BO.yml
+++ b/db/data/regions/BO.yml
@@ -14,5 +14,9 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: "\U0001F1E7\U0001F1F4"
 languages:
-  - es
+- es
+example_address:
+  address1: C. Lucas Jaimes 76
+  city: La Paz
+  phone: "+591 2 2245518"
 timezone: America/La_Paz

--- a/db/data/regions/BQ.yml
+++ b/db/data/regions/BQ.yml
@@ -28,5 +28,9 @@ format:
 # BQ-SA and BQ-SE.  So let's stay official and use the flag for NL.
 emoji: 🇳🇱
 languages:
-  - nl
+- nl
+example_address:
+  address1: Plasa Medardo SV Thielman 1
+  city: Kralendijk
+  phone: "+599 717 5600"
 timezone: America/Puerto_Rico

--- a/db/data/regions/BR.yml
+++ b/db/data/regions/BR.yml
@@ -15,7 +15,14 @@ phone_number_prefix: 55
 building_number_required: true
 week_start_day: sunday
 languages:
-  - pt-BR
+- pt-BR
+example_address:
+  address1: Esplanada dos Ministérios, ⁠12
+  address2: "⁠Zona Cívico-Administrativa"
+  city: Brasília
+  province_code: DF
+  zip: 70050-000
+  phone: "+55 61 3224-4073"
 format:
   edit: "{country}_{firstName}{lastName}_{company}_{zip}_{address1}_{address2}_{city}{province}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city} {province}_{country}_{phone}"

--- a/db/data/regions/BS.yml
+++ b/db/data/regions/BS.yml
@@ -13,5 +13,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: "\U0001F1E7\U0001F1F8"
 languages:
-  - en
+- en
+example_address:
+  address1: Government House
+  address2: Duke St
+  city: Nassau
+  phone: "+1 (242) 322-1875"
 timezone: America/Toronto

--- a/db/data/regions/BT.yml
+++ b/db/data/regions/BT.yml
@@ -16,5 +16,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1E7\U0001F1F9"
 languages:
-  - dz
+- dz
+example_address:
+  address1: P.O. Box 168
+  address2: Chhogyal Lam
+  city: Thimphu
+  zip: '11001'
+  phone: "+975-2-334997"
 timezone: Asia/Thimphu

--- a/db/data/regions/BW.yml
+++ b/db/data/regions/BW.yml
@@ -13,5 +13,9 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: "\U0001F1E7\U0001F1FC"
 languages:
-  - en
+- en
+example_address:
+  address1: 4775 Notwane Rd
+  city: Gabarone
+  phone: "+267 355 0000"
 timezone: Africa/Maputo

--- a/db/data/regions/BY.yml
+++ b/db/data/regions/BY.yml
@@ -18,6 +18,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: 🇧🇾
 languages:
-  - be
-  - ru
+- be
+- ru
+example_address:
+  address1: вуліца Леніна 20
+  city: Мінск
+  zip: '220030'
+  phone: "+375 17 397-01-63"
 timezone: Europe/Minsk

--- a/db/data/regions/BZ.yml
+++ b/db/data/regions/BZ.yml
@@ -14,6 +14,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: "\U0001F1E7\U0001F1FF"
 languages:
-  - en
-  - es
+- en
+- es
+example_address:
+  address1: 23 Garbutt Creek Street
+  address2: P.O. Box 592
+  city: Belmopan
+  phone: "+1 (501) 822 1381"
 timezone: America/Belize

--- a/db/data/regions/CA.yml
+++ b/db/data/regions/CA.yml
@@ -20,8 +20,14 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city} {province} {zip}_{country}_{phone}"
 emoji: "\U0001F1E8\U0001F1E6"
 languages:
-  - en
-  - fr
+- en
+- fr
+example_address:
+  address1: 1 Sussex Drive
+  city: Ottawa
+  province_code: 'ON'
+  zip: K1A 0A1
+  phone: "+1 (866) 842-4422"
 use_zone_code_as_short_name: true
 zones:
 - tax: 0.0

--- a/db/data/regions/CC.yml
+++ b/db/data/regions/CC.yml
@@ -15,6 +15,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: 🇨🇨
 languages:
-  - en
-  - ms
+- en
+- ms
+example_address:
+  address1: Lot 41 Jalan Kipas
+  city: Bantam
+  zip: '6799'
+  phone: '08 9162 7592'
 timezone: Indian/Cocos

--- a/db/data/regions/CD.yml
+++ b/db/data/regions/CD.yml
@@ -13,8 +13,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: 🇨🇩
 languages:
-  - fr
-  - sw
-# The DRC uses two time zones (Africa/Kinshasa, UTC+1) and (Africa/Lubumbashi, UTC+2).
-# But the DRC does not use postal codes, so we cannot determine the time zone based on the postal code.
-# For now, we don't encode timezone information for DRC for this reason.
+- fr
+- sw
+example_address:
+  address1: Palais de la Nation
+  address2: Av. de Lemera
+  city: Kinshasa
+  phone: "+243 990 819 824"

--- a/db/data/regions/CF.yml
+++ b/db/data/regions/CF.yml
@@ -12,6 +12,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: 🇨🇫
 languages:
-  - fr
-  - sg
+- fr
+- sg
+example_address:
+  address1: Ministère des Arts, de la Culture et du Tourisme
+  address2: B.P. 655
+  city: Bangui
+  phone: "+236 724 210 24"
 timezone: Africa/Lagos

--- a/db/data/regions/CG.yml
+++ b/db/data/regions/CG.yml
@@ -12,5 +12,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: "\U0001F1E8\U0001F1EC"
 languages:
-  - fr
+- fr
+example_address:
+  address1: U.S. Embassy
+  address2: Blvd Denis Sassou Nguesso
+  city: Brazzaville
+  phone: "+242 06-612-2000"
 timezone: Africa/Brazzaville

--- a/db/data/regions/CH.yml
+++ b/db/data/regions/CH.yml
@@ -17,11 +17,16 @@ building_number_required: true
 building_number_may_be_in_address2: true
 week_start_day: monday
 languages:
-  - de
-  - en
-  - fr
-  - it
-  - rm
+- de
+- en
+- fr
+- it
+- rm
+example_address:
+  address1: Stauffacherstrasse 65/59g
+  city: Berne
+  zip: '3003'
+  phone: "+41 31 377 77 77"
 format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"

--- a/db/data/regions/CI.yml
+++ b/db/data/regions/CI.yml
@@ -13,5 +13,9 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: "\U0001F1E8\U0001F1EE"
 languages:
-  - fr
+- fr
+example_address:
+  address1: B.P. V258
+  city: Abidjan
+  phone: "+225 27 22 416 884"
 timezone: Africa/Abidjan

--- a/db/data/regions/CK.yml
+++ b/db/data/regions/CK.yml
@@ -14,6 +14,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: 🇨🇰
 languages:
-  - en
-  - mi
+- en
+- mi
+example_address:
+  address1: P.O. Box 8
+  city: Rarotonga
+  phone: "+682 55546"
 timezone: Pacific/Rarotonga

--- a/db/data/regions/CL.yml
+++ b/db/data/regions/CL.yml
@@ -34,7 +34,14 @@ combined_address_format:
         decorator: " "
 emoji: "\U0001F1E8\U0001F1F1"
 languages:
-  - es
+- es
+example_address:
+  address1: Herrera ⁠360
+  address2: "⁠Santiago"
+  city: Santiago
+  province_code: RM
+  zip: '8350493'
+  phone: "+56 (2) 2726 18 29"
 zones:
 - tax: 0.0
   name: Arica and Parinacota

--- a/db/data/regions/CM.yml
+++ b/db/data/regions/CM.yml
@@ -13,7 +13,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: "\U0001F1E8\U0001F1F2"
 languages:
-  - ar
-  - en
-  - fr
+- ar
+- en
+- fr
+example_address:
+  address1: Ancien palais presidentiel
+  address2: BP 12 798
+  city: Yaoundé
+  phone: "+237 2 22 22 85 83"
 timezone: Africa/Lagos

--- a/db/data/regions/CN.yml
+++ b/db/data/regions/CN.yml
@@ -25,7 +25,14 @@ localized_data:
   - MachineReadablePassport
   required: true
 languages:
-  - "zh-CN"
+- zh-CN
+example_address:
+  address1: No.2 Dongkoudai Hutong
+  address2: Xicheng District
+  city: Beijing
+  province_code: BJ
+  zip: '100009'
+  phone: "+86 10 83 22 02 38"
 zones:
 - name: Anhui
   name_alternates:

--- a/db/data/regions/CO.yml
+++ b/db/data/regions/CO.yml
@@ -28,7 +28,14 @@ combined_address_format:
         decorator: " "
 emoji: "\U0001F1E8\U0001F1F4"
 languages:
-  - es
+- es
+example_address:
+  address1: Calle 28 No. 13A-15
+  address2: Piso 17, Edificio Centro de Comercio Internacional ⁠Teusaquillo
+  city: Bogotá
+  province_code: DC
+  zip: '110321'
+  phone: "+57 317 331 9655"
 zones:
 - name: Amazonas
   code: AMA

--- a/db/data/regions/CR.yml
+++ b/db/data/regions/CR.yml
@@ -27,7 +27,15 @@ combined_address_format:
         decorator: ", "
 emoji: "\U0001F1E8\U0001F1F7"
 languages:
-  - es
+- es
+example_address:
+  company: Universidad de Ciencias Médicas
+  address1: 400m Oeste de la Heladería POPS
+  address2: Carr. Vieja a Escazú, ⁠Mata Redonda
+  city: San José
+  province_code: CR-SJ
+  zip: '10108'
+  phone: "+506 2549 0000"
 zones:
   - name: Alajuela
     code: CR-A

--- a/db/data/regions/CU.yml
+++ b/db/data/regions/CU.yml
@@ -13,5 +13,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: 🇨🇺
 languages:
-  - es
+- es
+example_address:
+  address1: 66 Cienfuegos
+  city: La Habana
+  zip: '10201'
+  phone: "+53 7 8603411"
 timezone: America/Havana

--- a/db/data/regions/CV.yml
+++ b/db/data/regions/CV.yml
@@ -14,6 +14,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1E8\U0001F1FB"
 languages:
-  - fr
-  - "pt-PT"
+- fr
+- pt-PT
+example_address:
+  address1: Av. Amílcar Cabral
+  address2: No. 27 R/C, Plateau
+  city: Praia
+  zip: '7600'
+  phone: "+238 260 4340"
 timezone: Atlantic/Cape_Verde

--- a/db/data/regions/CW.yml
+++ b/db/data/regions/CW.yml
@@ -17,6 +17,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: "\U0001F1E8\U0001F1FC"
 languages:
-  - en
-  - nl
+- en
+- nl
+example_address:
+  address1: Wilhelminaplein 4
+  city: Willemstad
+  phone: "+5999 4346000"
 timezone: America/Puerto_Rico

--- a/db/data/regions/CX.yml
+++ b/db/data/regions/CX.yml
@@ -15,7 +15,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: 🇨🇽
 languages:
-  - en
-  - ms
-  - "zh-CN"
+- en
+- ms
+- zh-CN
+example_address:
+  address1: 1 Gaze Rd
+  city: Flying Fish Cove
+  zip: '6798'
+  phone: "+61 8 9164 8382"
 timezone: Indian/Christmas

--- a/db/data/regions/CY.yml
+++ b/db/data/regions/CY.yml
@@ -18,7 +18,13 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1E8\U0001F1FE"
 languages:
-  - el
-  - en
-  - tr
+- el
+- en
+- tr
+example_address:
+  company: Ministry of Energy, Commerce and Industry
+  address1: Corner Makarios Av. & Karpenisiou Str.
+  city: Nicosia
+  zip: '1427'
+  phone: "+357 (22) 404 301"
 timezone: Asia/Nicosia

--- a/db/data/regions/CZ.yml
+++ b/db/data/regions/CZ.yml
@@ -22,5 +22,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1E8\U0001F1FF"
 languages:
-  - cs
+- cs
+example_address:
+  address1: V Pevnosti 159/5b
+  city: Praha
+  zip: 128 00
+  phone: "+420 241 410 348"
 timezone: Europe/Prague

--- a/db/data/regions/DE.yml
+++ b/db/data/regions/DE.yml
@@ -17,8 +17,13 @@ zip_example: '56068'
 phone_number_prefix: 49
 week_start_day: monday
 languages:
-  - de
-  - en
+- de
+- en
+example_address:
+  address1: Willy-Brandt-Straße 1
+  city: Berlin
+  zip: '10557'
+  phone: "+49 30 182722720"
 format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"

--- a/db/data/regions/DJ.yml
+++ b/db/data/regions/DJ.yml
@@ -21,8 +21,13 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: 🇩🇯
 languages:
-  - aa
-  - ar
-  - fr
-  - so
+- aa
+- ar
+- fr
+- so
+example_address:
+  address1: Bâtiment la plaine
+  address2: BP. 2512
+  city: Djibouti Ville
+  phone: "+253 21 33 05 00"
 timezone: Africa/Nairobi

--- a/db/data/regions/DK.yml
+++ b/db/data/regions/DK.yml
@@ -21,8 +21,13 @@ building_number_required: true
 building_number_may_be_in_address2: true
 week_start_day: monday
 languages:
-  - da
-  - en
+- da
+- en
+example_address:
+  address1: Amalienborg Slotsplads 5
+  city: København K
+  zip: '1257'
+  phone: "+45 33 12 21 86"
 format:
   address1: "{street} {building_num}"
   address1_with_unit: "{street} {building_num}, {unit}"

--- a/db/data/regions/DM.yml
+++ b/db/data/regions/DM.yml
@@ -12,6 +12,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: "\U0001F1E9\U0001F1F2"
 languages:
-  - en
-  - fr
+- en
+- fr
+example_address:
+  company: Companies and Intellectual Property Office
+  address1: Ministry of Tourism and Legal Affairs (CIPO)
+  address2: Corner of Turkey Lane & Independence Street
+  city: Roseau
+  phone: "+1 (767) 266 3359"
 timezone: America/Puerto_Rico

--- a/db/data/regions/DO.yml
+++ b/db/data/regions/DO.yml
@@ -15,5 +15,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1E9\U0001F1F4"
 languages:
-  - es
+- es
+example_address:
+  address1: C/ Paseo de los Locutores
+  address2: 
+  city: Santo Domingo
+  phone: "+1 (809) 685 2886"
 timezone: America/Santo_Domingo

--- a/db/data/regions/DZ.yml
+++ b/db/data/regions/DZ.yml
@@ -16,6 +16,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1E9\U0001F1FF"
 languages:
-  - ar
-  - fr
+- ar
+- fr
+example_address:
+  address1: 121 Rue Didouche Mourad
+  city: Alger
+  zip: '16000'
+  phone: "+213 (21) 73 59 39"
 timezone: Africa/Algiers

--- a/db/data/regions/EC.yml
+++ b/db/data/regions/EC.yml
@@ -16,7 +16,13 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip}_{city}_{country}_{phone}"
 emoji: "\U0001F1EA\U0001F1E8"
 languages:
-  - es
+- es
+example_address:
+  address1: Av. República E7-197 y Diego de Almagro
+  address2: Edificio Forum 300 primer piso
+  city: Quito
+  zip: '170518'
+  phone: "+593 2 3 940 000 Ext. 1136"
 timezones:
   America/Guayaquil:
   - '0'

--- a/db/data/regions/EE.yml
+++ b/db/data/regions/EE.yml
@@ -20,5 +20,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1EA\U0001F1EA"
 languages:
-  - et
+- et
+example_address:
+  address1: Suur-Ameerika 1
+  city: Tallinn
+  zip: '10122'
+  phone: "+372 6 208 100"
 timezone: Europe/Tallinn

--- a/db/data/regions/EG.yml
+++ b/db/data/regions/EG.yml
@@ -15,9 +15,17 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{city}_{zip}_{country}_{phone}"
 emoji: "\U0001F1EA\U0001F1EC"
 languages:
-  - ar
-  - en
-  - fr
+- ar
+- en
+- fr
+example_address:
+  company: Abdeen Palace Museum
+  address1: El-Gomhoreya Square
+  address2: Rahbet Abdin
+  city: Abdeen
+  province_code: C
+  zip: '11613'
+  phone: "+20 2 23916909"
 zones:
 - tax: 0.0
   name_alternates:

--- a/db/data/regions/EH.yml
+++ b/db/data/regions/EH.yml
@@ -13,6 +13,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: 🇪🇭
 languages:
-  - ar
-  - es
+- ar
+- es
+example_address:
+  address1: Villa 04 - Quartier Moulay Rachid
+  address2: 165, Rue Al Zaraktouni, BP-755
+  city: Laayoune
+  phone: "+212 52 88 92 369"
 timezone: Africa/El_Aaiun

--- a/db/data/regions/ER.yml
+++ b/db/data/regions/ER.yml
@@ -12,7 +12,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: 🇪🇷
 languages:
-  - ar
-  - en
-  - ti
+- ar
+- en
+- ti
+example_address:
+  address1: P.O. Box 5610
+  city: Asmara
+  phone: "+291 (1) 113 044"
 timezone: Africa/Nairobi

--- a/db/data/regions/ES.yml
+++ b/db/data/regions/ES.yml
@@ -17,7 +17,13 @@ building_number_required: true
 building_number_may_be_in_address2: true
 week_start_day: monday
 languages:
-  - es
+- es
+example_address:
+  address1: Plaza del Rey ⁠1
+  city: Madrid
+  province_code: M
+  zip: '28004'
+  phone: "+34 91 701 72 67"
 format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}{province}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{province}_{country}_{phone}"

--- a/db/data/regions/ET.yml
+++ b/db/data/regions/ET.yml
@@ -16,9 +16,16 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1EA\U0001F1F9"
 languages:
-  - aa
-  - am
-  - om
-  - so
-  - ti
+- aa
+- am
+- om
+- so
+- ti
+example_address:
+  company: St. Mary's University
+  address1: Roosevelt St, down the road from
+  address2: Federal Police Building, behind Oil Libya
+  city: Addis Ababa
+  zip: '1211'
+  phone: "+251 11 553 8017"
 timezone: Africa/Nairobi

--- a/db/data/regions/FI.yml
+++ b/db/data/regions/FI.yml
@@ -21,5 +21,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1EB\U0001F1EE"
 languages:
-  - fi
+- fi
+example_address:
+  address1: Korkeavuorenkatu 23
+  city: Helsinki
+  zip: '00130'
+  phone: "+358 9 6220540"
 timezone: Europe/Helsinki

--- a/db/data/regions/FJ.yml
+++ b/db/data/regions/FJ.yml
@@ -13,7 +13,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: "\U0001F1EB\U0001F1EF"
 languages:
-  - en
-  - fj
-  - hi
+- en
+- fj
+- hi
+example_address:
+  company: Fiji Museum
+  address1: Cakobau Road
+  city: Suva
+  phone: "+679 331 5944"
 timezone: Pacific/Fiji

--- a/db/data/regions/FK.yml
+++ b/db/data/regions/FK.yml
@@ -16,5 +16,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}"
 emoji: 🇫🇰
 languages:
-  - en
+- en
+example_address:
+  address1: Government House
+  address2: Government House Dr., Balcarce
+  city: Stanley
+  zip: FIQQ 1ZZ
+  phone: "+500 28200"
 timezone: Atlantic/Stanley

--- a/db/data/regions/FO.yml
+++ b/db/data/regions/FO.yml
@@ -16,6 +16,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1EB\U0001F1F4"
 languages:
-  - da
-  - fo
+- da
+- fo
+example_address:
+  address1: 9 Gundadalsvegur
+  city: Tórshavn
+  zip: '100'
+  phone: "+298 223579"
 timezone: Atlantic/Faroe

--- a/db/data/regions/FR.yml
+++ b/db/data/regions/FR.yml
@@ -21,7 +21,12 @@ phone_number_prefix: 33
 building_number_required: true
 week_start_day: monday
 languages:
-  - fr
+- fr
+example_address:
+  address1: 6 Parvis Notre-Dame
+  city: Paris
+  zip: '75004'
+  phone: "+33 1 42 34 56 10"
 format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"

--- a/db/data/regions/GA.yml
+++ b/db/data/regions/GA.yml
@@ -13,6 +13,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: "\U0001F1EC\U0001F1E6"
 languages:
-  - en
-  - fr
+- en
+- fr
+example_address:
+  address1: 1007 Louis, Place Raponda Walker
+  address2: 'B.P.: 15944'
+  city: Libreville
+  phone: "+241 01 76 36 49"
 timezone: Africa/Lagos

--- a/db/data/regions/GB.yml
+++ b/db/data/regions/GB.yml
@@ -25,8 +25,14 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}"
 emoji: "\U0001F1EC\U0001F1E7"
 languages:
-  - cy
-  - en
+- cy
+- en
+example_address:
+  address1: 96 Euston Road
+  city: London
+  province_code: ENG
+  zip: NW1 2DB
+  phone: "+44 330 333 1144"
 zones:
 - name: British Forces
   code: BFP

--- a/db/data/regions/GD.yml
+++ b/db/data/regions/GD.yml
@@ -13,6 +13,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: "\U0001F1EC\U0001F1E9"
 languages:
-  - en
-  - fr
+- en
+- fr
+example_address:
+  company: Corporate Affairs and Intellectual Property Office (CAIPO)
+  address1: Mt Wheldale Gap
+  address2: Upper Lucas Street
+  city: St. George's
+  phone: "+1 (473) 440 2030"
 timezone: America/Puerto_Rico

--- a/db/data/regions/GE.yml
+++ b/db/data/regions/GE.yml
@@ -17,7 +17,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1EC\U0001F1EA"
 languages:
-  - ab
-  - ka
-  - ru
+- ab
+- ka
+- ru
+example_address:
+  address1: Antioch st. 5
+  city: Mtskheta
+  zip: '3300'
+  phone: "+995 32 225 25 33"
 timezone: Asia/Tbilisi

--- a/db/data/regions/GF.yml
+++ b/db/data/regions/GF.yml
@@ -23,5 +23,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: 🇬🇫
 languages:
-  - fr
+- fr
+example_address:
+  address1: 966 Rte de Baduel
+  city: Cayenne
+  zip: '97300'
+  phone: "+594 594 25 28 18"
 timezone: America/Cayenne

--- a/db/data/regions/GG.yml
+++ b/db/data/regions/GG.yml
@@ -17,6 +17,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}"
 emoji: "\U0001F1EC\U0001F1EC"
 languages:
-  - en
-  - fr
+- en
+- fr
+example_address:
+  address1: Guernsey Museum & Art Gallery
+  address2: Candle Road
+  city: St. Peter Port
+  zip: GY1 1UG
+  phone: "+44 1481 226518"
 timezone: Europe/Guernsey

--- a/db/data/regions/GH.yml
+++ b/db/data/regions/GH.yml
@@ -16,8 +16,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}"
 emoji: "\U0001F1EC\U0001F1ED"
 languages:
-  - ee
-  - en
-  - fat
-  - tw
+- ee
+- en
+- fat
+- tw
+example_address:
+  address1: 33 Prof. Atta Mills High Street
+  city: Accra
+  phone: "+233 302 229190"
 timezone: Africa/Abidjan

--- a/db/data/regions/GI.yml
+++ b/db/data/regions/GI.yml
@@ -18,6 +18,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip}_{country}_{phone}"
 emoji: "\U0001F1EC\U0001F1EE"
 languages:
-  - en
-  - es
+- en
+- es
+example_address:
+  company: The Gibraltar Parliament
+  address1: John Mackintosh Square
+  city: Gibraltar
+  zip: GX11 1AA
+  phone: "+350 200 78420"
 timezone: Europe/Gibraltar

--- a/db/data/regions/GL.yml
+++ b/db/data/regions/GL.yml
@@ -18,9 +18,14 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1EC\U0001F1F1"
 languages:
-  - da
-  - en
-  - kl
+- da
+- en
+- kl
+example_address:
+  address1: Hans Egedesvej 8
+  city: Nuuk
+  zip: '3900'
+  phone: "+299 32 26 11"
 timezones:
   America/Danmarkshavn:
   - '3984'

--- a/db/data/regions/GM.yml
+++ b/db/data/regions/GM.yml
@@ -14,5 +14,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: "\U0001F1EC\U0001F1F2"
 languages:
-  - en
+- en
+example_address:
+  address1: The Gambia National Museum Premises
+  address2: Independence Drive PMB 151
+  city: Banjul
+  phone: "+220 778 1963"
 timezone: Africa/Abidjan

--- a/db/data/regions/GN.yml
+++ b/db/data/regions/GN.yml
@@ -17,8 +17,13 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}"
 emoji: 🇬🇳
 languages:
-  - ar
-  - en
-  - ff
-  - fr
+- ar
+- en
+- ff
+- fr
+example_address:
+  address1: 4ème étage Palais du peuple côté Ouest
+  address2: Commune de Kaloum, B.P. 4904
+  city: Conakry
+  phone: "+224 620 983 921"
 timezone: Africa/Abidjan

--- a/db/data/regions/GP.yml
+++ b/db/data/regions/GP.yml
@@ -22,5 +22,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1EC\U0001F1F5"
 languages:
-  - fr
+- fr
+example_address:
+  address1: 43 Pointe de la Verdure
+  city: Le Gosier
+  zip: '97190'
+  phone: "+590 690 54 30 50"
 timezone: America/Guadeloupe

--- a/db/data/regions/GQ.yml
+++ b/db/data/regions/GQ.yml
@@ -13,7 +13,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: 🇬🇶
 languages:
-  - es
-  - fr
-  - "pt-PT"
+- es
+- fr
+- pt-PT
+example_address:
+  company: Scientific and Technological Research Council (CICTE)
+  address1: Cocoteros s/n
+  city: Malabo
+  phone: "+240 222 273 444"
 timezone: Africa/Lagos

--- a/db/data/regions/GR.yml
+++ b/db/data/regions/GR.yml
@@ -19,6 +19,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1EC\U0001F1F7"
 languages:
-  - el
-  - en
+- el
+- en
+example_address:
+  address1: 28is Oktovriou 44
+  city: Athina
+  zip: 106 82
+  phone: "+30 21 3214 4800"
 timezone: Europe/Athens

--- a/db/data/regions/GS.yml
+++ b/db/data/regions/GS.yml
@@ -16,5 +16,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip}_{country}_{phone}"
 emoji: 🇬🇸
 languages:
-  - en
+- en
+example_address:
+  address1: South Georgia Museum
+  city: Grytviken
+  zip: SIQQ 1ZZ
+  phone: "+500 28200"
 timezone: Atlantic/South_Georgia

--- a/db/data/regions/GT.yml
+++ b/db/data/regions/GT.yml
@@ -15,7 +15,14 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city} {province}_{zip}_{country}_{phone}"
 emoji: "\U0001F1EC\U0001F1F9"
 languages:
-  - es
+- es
+example_address:
+  address1: 7a. Avenida 7-61 zona 4
+  address2: Primer Nivel
+  city: Guatemala Cuidad
+  province_code: GUA
+  zip: '01004'
+  phone: "+502 232 470 70 ext. 105"
 zones:
 - name: Alta Verapaz
   code: AVE

--- a/db/data/regions/GW.yml
+++ b/db/data/regions/GW.yml
@@ -16,8 +16,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: 🇬🇼
 languages:
-  - ar
-  - en
-  - fr
-  - "pt-PT"
+- ar
+- en
+- fr
+- pt-PT
+example_address:
+  address1: Caixa Postal 338
+  city: Bissau
+  phone: "+245 96 665 42 16"
 timezone: Africa/Bissau

--- a/db/data/regions/GY.yml
+++ b/db/data/regions/GY.yml
@@ -13,5 +13,9 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: "\U0001F1EC\U0001F1FE"
 languages:
-  - en
+- en
+example_address:
+  address1: Lot 1 High and Commerce Streets
+  city: Georgetown
+  phone: "+592 225 4374"
 timezone: America/Guyana

--- a/db/data/regions/HK.yml
+++ b/db/data/regions/HK.yml
@@ -14,8 +14,14 @@ phone_number_prefix: 852
 building_number_required: true
 week_start_day: sunday
 languages:
-  - en
-  - zh-HK
+- en
+- zh-HK
+example_address:
+  company: The Peninsula Hotel
+  address1: Salisbury Rd
+  city: Tsim Sha Tsui
+  province_code: KL
+  phone: "+852 2920 2888"
 format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{city}{province}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{province} {country}_{phone}"

--- a/db/data/regions/HN.yml
+++ b/db/data/regions/HN.yml
@@ -15,5 +15,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1ED\U0001F1F3"
 languages:
-  - es
+- es
+example_address:
+  company: Directorate General of Intellectual Property (DIGEPIH)
+  address1: Boulevard Juan Pablo Segundo
+  address2: Centro Cívico Gubernamental
+  city: Tegucigalpa
+  zip: '11101'
+  phone: "+504 223 55297"
 timezone: America/Tegucigalpa

--- a/db/data/regions/HR.yml
+++ b/db/data/regions/HR.yml
@@ -19,5 +19,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1ED\U0001F1F7"
 languages:
-  - hr
+- hr
+example_address:
+  address1: Savska cesta 18
+  zip: '10000'
+  city: Zagreb
+  phone: "+385 1 4844 050"
 timezone: Europe/Belgrade

--- a/db/data/regions/HT.yml
+++ b/db/data/regions/HT.yml
@@ -16,5 +16,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1ED\U0001F1F9"
 languages:
-  - fr
+- fr
+example_address:
+  address1: 31, rue Cheriez
+  address2: Canape-Vert
+  city: Port-au-Prince
+  zip: HT6113
+  phone: "+509 2211 5626"
 timezone: America/Port-au-Prince

--- a/db/data/regions/HU.yml
+++ b/db/data/regions/HU.yml
@@ -20,5 +20,10 @@ tags:
 - EU-member
 emoji: "\U0001F1ED\U0001F1FA"
 languages:
-  - hu
+- hu
+example_address:
+  address1: Szent István tér 1
+  city: Budapest
+  zip: '1051'
+  phone: "+36 1 311 0839"
 timezone: Europe/Budapest

--- a/db/data/regions/ID.yml
+++ b/db/data/regions/ID.yml
@@ -12,8 +12,15 @@ zip_example: '40115'
 phone_number_prefix: 62
 week_start_day: monday
 languages:
-  - en
-  - id
+- en
+- id
+example_address:
+  address1: Jalan H.R. Rasuna Said, Kav. 8-9
+  address2: "⁠Setiabudi"
+  city: Jakarta Selatan
+  province_code: JK
+  zip: '12940'
+  phone: "+62 21 2902 7326"
 format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{province}{zip}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{province} {zip}_{country}_{phone}"

--- a/db/data/regions/IE.yml
+++ b/db/data/regions/IE.yml
@@ -21,8 +21,15 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{province}_{zip}_{country}_{phone}"
 emoji: "\U0001F1EE\U0001F1EA"
 languages:
-  - en
-  - ga
+- en
+- ga
+example_address:
+  address1: Bedford Hall
+  address2: 34 Castle Street
+  city: Dublin
+  province_code: D
+  zip: D02 TN97
+  phone: "+353 469422213"
 zones:
 - name: Carlow
   code: CW

--- a/db/data/regions/IL.yml
+++ b/db/data/regions/IL.yml
@@ -31,6 +31,12 @@ combined_address_format:
         decorator: " "
 emoji: "\U0001F1EE\U0001F1F1"
 languages:
-  - ar
-  - he
+- ar
+- he
+example_address:
+  address1: 1 ⁠The Golda Meir Cultural and Art Center
+  address2: Sderot Sha'ul HaMelech 27
+  city: Tel Aviv-Yafo
+  zip: '6423931'
+  phone: "+972 3-607-7020"
 timezone: Asia/Jerusalem

--- a/db/data/regions/IM.yml
+++ b/db/data/regions/IM.yml
@@ -17,5 +17,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}"
 emoji: "\U0001F1EE\U0001F1F2"
 languages:
-  - en
+- en
+example_address:
+  address1: 1 Kingswood Grove
+  city: Douglas
+  zip: IM1 3LY
+  phone: "+44 1624 648000"
 timezone: Europe/Isle_of_Man

--- a/db/data/regions/IN.yml
+++ b/db/data/regions/IN.yml
@@ -17,22 +17,29 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city} {province}_{country}_{phone}"
 emoji: "\U0001F1EE\U0001F1F3"
 languages:
-  - as
-  - bn
-  - en
-  - gu
-  - hi
-  - kn
-  - ml
-  - mr
-  - ne
-  - or
-  - pa
-  - sa
-  - sd
-  - ta
-  - te
-  - ur
+- as
+- bn
+- en
+- gu
+- hi
+- kn
+- ml
+- mr
+- ne
+- or
+- pa
+- sa
+- sd
+- ta
+- te
+- ur
+example_address:
+  address1: Netaji Subhash Marg
+  address2: Lal Qila, Chandni Chowk
+  city: New Delhi
+  province_code: DL
+  zip: '110006'
+  phone: "+91 11 2327 7705"
 zones:
 - name: Andaman and Nicobar Islands
   name_alternates:

--- a/db/data/regions/IQ.yml
+++ b/db/data/regions/IQ.yml
@@ -16,6 +16,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}"
 emoji: "\U0001F1EE\U0001F1F6"
 languages:
-  - ar
-  - ckb
+- ar
+- ckb
+example_address:
+  company: Directorate of Patents and Industrial Designs
+  address1: University of Baghdad St.
+  address2: Al-Jaderiya
+  city: Baghdad
+  phone: "+964 770 566 4897"
 timezone: Asia/Baghdad

--- a/db/data/regions/IR.yml
+++ b/db/data/regions/IR.yml
@@ -13,7 +13,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: 🇮🇷
 languages:
-  - ar
-  - az
-  - fa
+- ar
+- az
+- fa
+example_address:
+  address1: 200 N Villa Rd
+  city: Tehran
+  zip: 15979-33813
+  phone: "+98 21 33 90 3895"
 timezone: Asia/Tehran

--- a/db/data/regions/IS.yml
+++ b/db/data/regions/IS.yml
@@ -19,5 +19,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1EE\U0001F1F8"
 languages:
-  - is
+- is
+example_address:
+  address1: Suðurgata 41
+  city: Reykjavík
+  zip: '102'
+  phone: "+354 530 2200"
 timezone: Atlantic/Reykjavik

--- a/db/data/regions/IT.yml
+++ b/db/data/regions/IT.yml
@@ -17,7 +17,13 @@ building_number_required: true
 building_number_may_be_in_address2: true
 week_start_day: monday
 languages:
-  - it
+- it
+example_address:
+  address1: Piazza della Rotonda
+  city: Roma
+  province_code: RM
+  zip: '00186'
+  phone: "+39 06 6830 0230"
 format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}{province}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city} {province}_{country}_{phone}"

--- a/db/data/regions/JE.yml
+++ b/db/data/regions/JE.yml
@@ -17,6 +17,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}"
 emoji: "\U0001F1EF\U0001F1EA"
 languages:
-  - en
-  - fr
+- en
+- fr
+example_address:
+  address1: 6f Rue de Bechet
+  city: Trinity
+  zip: JE3 5BE
+  phone: "+44 1534 865307"
 timezone: Europe/Jersey

--- a/db/data/regions/JM.yml
+++ b/db/data/regions/JM.yml
@@ -14,5 +14,9 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: "\U0001F1EF\U0001F1F2"
 languages:
-  - en
+- en
+example_address:
+  address1: 18 Trafalgar Road
+  city: Kingston
+  phone: "+1 (876) 978-7755"
 timezone: America/Jamaica

--- a/db/data/regions/JO.yml
+++ b/db/data/regions/JO.yml
@@ -15,5 +15,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}"
 emoji: "\U0001F1EF\U0001F1F4"
 languages:
-  - ar
+- ar
+example_address:
+  address1: 9 Hroun Al-Rashid St., Arjan
+  address2: P.O. Box 6070
+  city: Amman
+  zip: '11118'
+  phone: "+962 6 566 27 85"
 timezone: Asia/Amman

--- a/db/data/regions/JP.yml
+++ b/db/data/regions/JP.yml
@@ -16,8 +16,14 @@ building_number_required: true
 building_number_may_be_in_address2: true
 week_start_day: sunday
 languages:
-  - en
-  - ja
+- en
+- ja
+example_address:
+  address1: 永田町２丁目３−１
+  city: 千代田区
+  province_code: JP-13
+  zip: 100-0014
+  phone: "+81 (3) 3581-0101"
 format:
   edit: "{country}_{lastName}{firstName}_{company}_{zip}{province}_{city}_{address1}_{address2}_{phone}"
   show: "{country} 〒{zip}_{province} {city}_{address1}_{address2}_{company}_{lastName} {firstName}様_{phone}"

--- a/db/data/regions/KE.yml
+++ b/db/data/regions/KE.yml
@@ -17,6 +17,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}"
 emoji: "\U0001F1F0\U0001F1EA"
 languages:
-  - en
-  - sw
+- en
+- sw
+example_address:
+  address1: 5th Floor NHIF Building, Ragati Road
+  address2: P.O Box 34670
+  city: Nairobi
+  zip: '00100'
+  phone: "+254 (20) 253 38 69"
 timezone: Africa/Nairobi

--- a/db/data/regions/KG.yml
+++ b/db/data/regions/KG.yml
@@ -15,6 +15,11 @@ format:
   show: "{zip} {city}_{address2}_{address1}_{company}_{firstName} {lastName}_{country}_{phone}"
 emoji: "\U0001F1F0\U0001F1EC"
 languages:
-  - ky
-  - ru
+- ky
+- ru
+example_address:
+  address1: 62 Moskovskaya Street
+  city: Bishkek
+  zip: '720021'
+  phone: "+996 312 68 08 19"
 timezone: Asia/Bishkek

--- a/db/data/regions/KH.yml
+++ b/db/data/regions/KH.yml
@@ -14,6 +14,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}"
 emoji: "\U0001F1F0\U0001F1ED"
 languages:
-  - fr
-  - km
+- fr
+- km
+example_address:
+  address1: 227 Norodom Blvd.
+  city: Phnom Penh
+  zip: '120203'
+  phone: "+855 16 830 323"
 timezone: Asia/Bangkok

--- a/db/data/regions/KI.yml
+++ b/db/data/regions/KI.yml
@@ -15,5 +15,10 @@ format:
 emoji: 🇰🇮
 zip_requirement: optional
 languages:
-  - en
+- en
+example_address:
+  address1: P.O. Box 510
+  address2: Betio
+  city: Tarawa
+  phone: "+686 75126 156"
 timezone: Pacific/Tarawa

--- a/db/data/regions/KM.yml
+++ b/db/data/regions/KM.yml
@@ -13,6 +13,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: 🇰🇲
 languages:
-  - ar
-  - fr
+- ar
+- fr
+example_address:
+  address1: BP 139
+  city: Moroni
+  phone: "+269 369 75 14"
 timezone: Africa/Nairobi

--- a/db/data/regions/KN.yml
+++ b/db/data/regions/KN.yml
@@ -16,5 +16,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: 🇰🇳
 languages:
-  - en
+- en
+example_address:
+  address1: 1st Floor of The Cable Building
+  address2: Cayon Street
+  city: Basseterre
+  zip: KN0107
+  phone: "+1 (869) 467 19 78"
 timezone: America/Puerto_Rico

--- a/db/data/regions/KP.yml
+++ b/db/data/regions/KP.yml
@@ -12,5 +12,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: 🇰🇵
 languages:
-  - ko
+- ko
+example_address:
+  address1: Kinmaul Dong No.1
+  address2: Bipa Street, Moranbong District
+  city: Pyongyang
+  phone: "+850 2 381 8433"
 timezone: Asia/Pyongyang

--- a/db/data/regions/KR.yml
+++ b/db/data/regions/KR.yml
@@ -23,7 +23,13 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{province}_{country}_{phone}"
 emoji: "\U0001F1F0\U0001F1F7"
 languages:
-  - ko
+- ko
+example_address:
+  address1: 388, Galmae-ro
+  city: Sejong
+  province_code: KR-50
+  zip: '30119'
+  phone: "+82 44 203 2488"
 zones:
 - name: Busan
   name_alternates:

--- a/db/data/regions/KW.yml
+++ b/db/data/regions/KW.yml
@@ -27,7 +27,14 @@ combined_address_format:
         decorator: " "
 emoji: "\U0001F1F0\U0001F1FC"
 languages:
-  - ar
+- ar
+example_address:
+  address1: Kuwait National Museum 1
+  address2: "⁠Block 15"
+  city: Kuwait City
+  province_code: KW-KU
+  zip: '13122'
+  phone: "+965 229 298 68"
 zones:
   - name: Al Ahmadi
     code: KW-AH

--- a/db/data/regions/KY.yml
+++ b/db/data/regions/KY.yml
@@ -13,5 +13,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1F0\U0001F1FE"
 languages:
-  - en
+- en
+example_address:
+  address1: 68 Edward St.
+  city: George Town
+  zip: KY1-9000
+  phone: "+1 (345) 946-1323"
 timezone: America/Cayman

--- a/db/data/regions/KZ.yml
+++ b/db/data/regions/KZ.yml
@@ -17,8 +17,14 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}"
 emoji: "\U0001F1F0\U0001F1FF"
 languages:
-  - kk
-  - ru
+- kk
+- ru
+example_address:
+  address1: 8 Mangilik Yel avenue
+  address2: House of Ministries, Entrance 13
+  city: Astana
+  zip: '010000'
+  phone: "+7 (7172) 74 02 21"
 timezones:
   Asia/Almaty:
   - A

--- a/db/data/regions/LA.yml
+++ b/db/data/regions/LA.yml
@@ -16,6 +16,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1F1\U0001F1E6"
 languages:
-  - fr
-  - lo
+- fr
+- lo
+example_address:
+  address1: Phon Xay Rd
+  address2: P.O. Box 4107
+  city: Vientiane
+  phone: "+856 21 213 470 ext 154"
 timezone: Asia/Bangkok

--- a/db/data/regions/LB.yml
+++ b/db/data/regions/LB.yml
@@ -15,6 +15,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}"
 emoji: "\U0001F1F1\U0001F1E7"
 languages:
-  - ar
-  - fr
+- ar
+- fr
+example_address:
+  company: Office of Intellectual Property
+  address1: Down Town, Lazarieh Building
+  address2: Ministry of Economy and Trade - 4th floor
+  city: Beirut
+  phone: "+961 (1) 982 295"
 timezone: Asia/Beirut

--- a/db/data/regions/LC.yml
+++ b/db/data/regions/LC.yml
@@ -16,6 +16,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1F1\U0001F1E8"
 languages:
-  - en
-  - fr
+- en
+- fr
+example_address:
+  address1: 2nd Floor Hewanorra House
+  address2: Pointe Seraphine
+  city: Castries
+  zip: LC04  203
+  phone: "+1 (758) 468-3231"
 timezone: America/Puerto_Rico

--- a/db/data/regions/LI.yml
+++ b/db/data/regions/LI.yml
@@ -18,5 +18,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1F1\U0001F1EE"
 languages:
-  - de
+- de
+example_address:
+  address1: Bergstrasse 2
+  city: Vaduz
+  zip: '9490'
+  phone: "+423 238 12 00"
 timezone: Europe/Zurich

--- a/db/data/regions/LK.yml
+++ b/db/data/regions/LK.yml
@@ -16,7 +16,13 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}"
 emoji: "\U0001F1F1\U0001F1F0"
 languages:
-  - en
-  - si
-  - ta
+- en
+- si
+- ta
+example_address:
+  address1: Dharmaloka Hall
+  address2: Faculty of Science Pathway
+  city: Peliyagoda
+  zip: '11300'
+  phone: "+94 112 903 903"
 timezone: Asia/Colombo

--- a/db/data/regions/LR.yml
+++ b/db/data/regions/LR.yml
@@ -16,5 +16,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1F1\U0001F1F7"
 languages:
-  - en
+- en
+example_address:
+  company: Liberia Intellectual Property Office (LIPO)
+  address1: Old Labor Ministry Building
+  address2: UN Drive
+  city: Monrovia
+  phone: "+231 775 53 35 95"
 timezone: Africa/Monrovia

--- a/db/data/regions/LS.yml
+++ b/db/data/regions/LS.yml
@@ -14,6 +14,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}"
 emoji: "\U0001F1F1\U0001F1F8"
 languages:
-  - en
-  - st
+- en
+- st
+example_address:
+  address1: 1st Floor Africa House, Government Complex, Phase II
+  address2: Old High Court Road, P.O Box 33
+  city: Maseru
+  zip: '100'
+  phone: "+266 (22) 312 856"
 timezone: Africa/Johannesburg

--- a/db/data/regions/LT.yml
+++ b/db/data/regions/LT.yml
@@ -19,5 +19,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1F1\U0001F1F9"
 languages:
-  - lt
+- lt
+example_address:
+  address1: Arsenalo g. 5
+  city: Vilnius
+  zip: '01143'
+  phone: "+370 5 261 7453"
 timezone: Europe/Vilnius

--- a/db/data/regions/LU.yml
+++ b/db/data/regions/LU.yml
@@ -15,9 +15,14 @@ zip_example: '4750'
 phone_number_prefix: 352
 week_start_day: monday
 languages:
-  - en
-  - fr
-  - lb
+- en
+- fr
+- lb
+example_address:
+  address1: 17 Rue du Marché-aux-Herbes
+  city: Ville-Haute
+  zip: '1728'
+  phone: "+352 22 28 09"
 format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"

--- a/db/data/regions/LV.yml
+++ b/db/data/regions/LV.yml
@@ -20,5 +20,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}"
 emoji: "\U0001F1F1\U0001F1FB"
 languages:
-  - lv
+- lv
+example_address:
+  address1: Rātslaukums 7
+  address2: Centra rajons
+  city: Rīga
+  zip: LV-1050
+  phone: "+371 66 956 225"
 timezone: Europe/Riga

--- a/db/data/regions/LY.yml
+++ b/db/data/regions/LY.yml
@@ -17,6 +17,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: 🇱🇾
 languages:
-  - ar
-  - it
+- ar
+- it
+example_address:
+  company: Ministry of Foreign Affairs and International Cooperation
+  address1: Ash Shatt St
+  city: Tripoli
+  phone: "+218 21-3402921"
 timezone: Africa/Tripoli

--- a/db/data/regions/MA.yml
+++ b/db/data/regions/MA.yml
@@ -18,6 +18,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1F2\U0001F1E6"
 languages:
-  - ar
-  - fr
+- ar
+- fr
+example_address:
+  address1: 19 rue de Rome
+  city: Casablanca
+  zip: '20250'
+  phone: "+212 5377-65400"
 timezone: Africa/Casablanca

--- a/db/data/regions/MC.yml
+++ b/db/data/regions/MC.yml
@@ -17,5 +17,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1F2\U0001F1E8"
 languages:
-  - fr
+- fr
+example_address:
+  address1: 62 Bd du Jardin Exotique
+  city: La Condamine
+  zip: '98000'
+  phone: "+377 93 15 29 80"
 timezone: Europe/Monaco

--- a/db/data/regions/MD.yml
+++ b/db/data/regions/MD.yml
@@ -17,8 +17,13 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1F2\U0001F1E9"
 languages:
-  - fr
-  - ro
-  - ru
-  - uk
+- fr
+- ro
+- ru
+- uk
+example_address:
+  address1: Stefan cel Mare si Sfant Boulevard 165
+  city: Chişinău
+  zip: '2004'
+  phone: "+373 22 243 408"
 timezone: Europe/Chisinau

--- a/db/data/regions/ME.yml
+++ b/db/data/regions/ME.yml
@@ -16,8 +16,13 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1F2\U0001F1EA"
 languages:
-  - al
-  - bs
-  - hr
-  - sr
+- al
+- bs
+- hr
+- sr
+example_address:
+  address1: Rimski trg 46
+  city: Podgorica
+  zip: '81000'
+  phone: "+382 20 234 591"
 timezone: Europe/Belgrade

--- a/db/data/regions/MF.yml
+++ b/db/data/regions/MF.yml
@@ -19,5 +19,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1EB\U0001F1F7"
 languages:
-  - fr
+- fr
+example_address:
+  address1: 15 Rue de Coralita
+  city: Quartier d'Orléans
+  zip: '97150'
+  phone: "+590 590 77 39 23"
 timezone: America/Marigot

--- a/db/data/regions/MG.yml
+++ b/db/data/regions/MG.yml
@@ -15,6 +15,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1F2\U0001F1EC"
 languages:
-  - fr
-  - mg
+- fr
+- mg
+example_address:
+  address1: Lot IIF 62, Antaninandro
+  address2: BP 17 Bis
+  city: Antananarivo
+  zip: '101'
+  phone: "+261 (34) 05 533 70"
 timezone: Africa/Nairobi

--- a/db/data/regions/MK.yml
+++ b/db/data/regions/MK.yml
@@ -20,6 +20,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1F2\U0001F1F0"
 languages:
-  - al
-  - mk
+- al
+- mk
+example_address:
+  address1: 61, Gjuro Gjakovik
+  city: Skopje
+  zip: '1000'
+  phone: "+389 72 255 824"
 timezone: Europe/Belgrade

--- a/db/data/regions/ML.yml
+++ b/db/data/regions/ML.yml
@@ -15,6 +15,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: 🇲🇱
 languages:
-  - ar
-  - fr
+- ar
+- fr
+example_address:
+  address1: Villa B5, Avenue de l’OUA, Cité des Coopérants
+  address2: Faladié Sokoro BP E. 2735
+  city: Bamako
+  phone: "+223 20 20 98 70"
 timezone: Africa/Abidjan

--- a/db/data/regions/MM.yml
+++ b/db/data/regions/MM.yml
@@ -14,5 +14,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}"
 emoji: "\U0001F1F2\U0001F1F2"
 languages:
-  - my
+- my
+example_address:
+  address1: Building No. 52
+  city: Nay Pyi Taw
+  zip: '1508203'
+  phone: "+95 (67) 343 0572"
 timezone: Asia/Yangon

--- a/db/data/regions/MN.yml
+++ b/db/data/regions/MN.yml
@@ -16,7 +16,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}"
 emoji: "\U0001F1F2\U0001F1F3"
 languages:
-  - mn
+- mn
+example_address:
+  address1: Жуулчны Гудамж 1
+  city: Улаанбаатар
+  zip: '15160'
+  phone: "+976 70110911"
 timezones:
   Asia/Hovd:
   - '83'

--- a/db/data/regions/MO.yml
+++ b/db/data/regions/MO.yml
@@ -16,6 +16,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: "\U0001F1F2\U0001F1F4"
 languages:
-  - "pt-PT"
-  - "zh-TW"
+- pt-PT
+- zh-TW
+example_address:
+  address1: 7 Estr. de Dom Maria II
+  city: Macao
+  phone: "+853 2871 8063"
 timezone: Asia/Macau

--- a/db/data/regions/MQ.yml
+++ b/db/data/regions/MQ.yml
@@ -26,5 +26,10 @@ format:
 # https://www.rci.fm/martinique/infos/Justice/La-justice-annule-lutilisation-du-drapeau-et-de-lhymne-choisis-en-2019-par-la-CTM#
 emoji: 🇫🇷
 languages:
-  - fr
+- fr
+example_address:
+  address1: 29 Rue Victor Hugo
+  city: Fort-de-France
+  zip: '97200'
+  phone: "+596 596 80 00 70"
 timezone: America/Martinique

--- a/db/data/regions/MR.yml
+++ b/db/data/regions/MR.yml
@@ -16,6 +16,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: 🇲🇷
 languages:
-  - ar
-  - fr
+- ar
+- fr
+example_address:
+  company: U.S. Embassy
+  address1: Nouadhibou Road, Avenue Al Quds
+  address2: NOT PRTZ.
+  city: Nouakchott
+  phone: "+222 4525 2660"
 timezone: Africa/Abidjan

--- a/db/data/regions/MS.yml
+++ b/db/data/regions/MS.yml
@@ -14,5 +14,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}"
 emoji: 🇲🇸
 languages:
-  - en
+- en
+example_address:
+  address1: Longwood Road
+  city: Old Town
+  zip: MSR1350
+  phone: "+1 (617) 877-8986"
 timezone: America/Puerto_Rico

--- a/db/data/regions/MT.yml
+++ b/db/data/regions/MT.yml
@@ -19,6 +19,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}"
 emoji: "\U0001F1F2\U0001F1F9"
 languages:
-  - en
-  - mt
+- en
+- mt
+example_address:
+  address1: Lascaris Bastions
+  address2: Daħlet Ġnien is-Sultan
+  city: Valletta
+  zip: VLT 1933
+  phone: "+356 25 69 01 00"
 timezone: Europe/Malta

--- a/db/data/regions/MU.yml
+++ b/db/data/regions/MU.yml
@@ -17,6 +17,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip}_{city}_{country}_{phone}"
 emoji: "\U0001F1F2\U0001F1FA"
 languages:
-  - en
-  - fr
+- en
+- fr
+example_address:
+  company: Ministry of Arts and Cultural Heritage
+  address1: 7th Floor, Renganaden Seeneevassen Building
+  address2: Cnr Pope Hennessy & Maillard Streets
+  city: Port Louis
+  phone: "+230 212 4390"
 timezone: Indian/Mauritius

--- a/db/data/regions/MV.yml
+++ b/db/data/regions/MV.yml
@@ -16,6 +16,13 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}"
 emoji: "\U0001F1F2\U0001F1FB"
 languages:
-  - dv
-  - en
+- dv
+- en
+example_address:
+  company: Intellectual Property Unit
+  address1: Ministry of Economic Development
+  address2: Boduthakurufaanu Magu
+  city: Malé
+  zip: '20125'
+  phone: "+960 332 3668"
 timezone: Indian/Maldives

--- a/db/data/regions/MW.yml
+++ b/db/data/regions/MW.yml
@@ -19,7 +19,14 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1F2\U0001F1FC"
 languages:
-  - en
-  - ny
-  - to
+- en
+- ny
+- to
+example_address:
+  company: Copyright Society of Malawi (COSOMA)
+  address1: Off Paul Kagame Highway, Next to the Malawi Rural Finance Company Head
+    Office
+  address2: P.O. Box 30784
+  city: Lilongwe
+  phone: "+265 (1) 751 148"
 timezone: Africa/Maputo

--- a/db/data/regions/MX.yml
+++ b/db/data/regions/MX.yml
@@ -36,7 +36,15 @@ combined_address_format:
         decorator: " "
 emoji: "\U0001F1F2\U0001F1FD"
 languages:
-  - es
+- es
+example_address:
+  company: Museo Nacional de Antropología
+  address1: Av. P.º de la Reforma ⁠1
+  address2: Miguel Hidalgo ⁠Bosque de Chapultepec I Secc
+  city: Ciudad de México
+  province_code: DF
+  zip: '11560'
+  phone: "+52 55 5553 6266"
 zones:
 - name: Aguascalientes
   code: AGS

--- a/db/data/regions/MY.yml
+++ b/db/data/regions/MY.yml
@@ -17,10 +17,17 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{province}_{country}_{phone}"
 emoji: "\U0001F1F2\U0001F1FE"
 languages:
-  - en
-  - ms
-  - ta
-  - "zh-CN"
+- en
+- ms
+- ta
+- zh-CN
+example_address:
+  address1: 14, Jln Pudu
+  address2: City Centre
+  city: Kuala Lumpur
+  province_code: KUL
+  zip: '55100'
+  phone: "+60 3-8000 8000"
 zones:
 - tax: 0.0
   name: Johor

--- a/db/data/regions/MZ.yml
+++ b/db/data/regions/MZ.yml
@@ -14,6 +14,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1F2\U0001F1FF"
 languages:
-  - en
-  - "pt-PT"
+- en
+- pt-PT
+example_address:
+  address1: Rua Consiglieri Pedroso no. 165
+  address2: Box 1072
+  city: Maputo
+  phone: "+258 8 430 062 15"
 timezone: Africa/Maputo

--- a/db/data/regions/NA.yml
+++ b/db/data/regions/NA.yml
@@ -16,8 +16,14 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1F3\U0001F1E6"
 languages:
-  - af
-  - de
-  - en
-  - hz
+- af
+- de
+- en
+- hz
+example_address:
+  address1: 3 Ruhr Street, PZN Holdings Building, Windhoek, Namibia
+  address2: P.O. Box 185
+  city: Windhoek
+  zip: '10007'
+  phone: "(264) 61 299 4400"
 timezone: Africa/Windhoek

--- a/db/data/regions/NC.yml
+++ b/db/data/regions/NC.yml
@@ -19,5 +19,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1F3\U0001F1E8"
 languages:
-  - fr
+- fr
+example_address:
+  address1: Office des Postes et Télécommunications
+  address2: Rue Marcellin-Lacabanne
+  city: Nouméa
+  zip: '98800'
+  phone: "+687 26.86.50"
 timezone: Pacific/Noumea

--- a/db/data/regions/NE.yml
+++ b/db/data/regions/NE.yml
@@ -16,5 +16,9 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: 🇳🇪
 languages:
-  - fr
+- fr
+example_address:
+  address1: B.P. 215
+  city: Niamey
+  phone: "+227 96 57 38 08"
 timezone: Africa/Lagos

--- a/db/data/regions/NF.yml
+++ b/db/data/regions/NF.yml
@@ -15,5 +15,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country} {zip}_{phone}"
 emoji: 🇳🇫
 languages:
-  - en
+- en
+example_address:
+  address1: Quality Row
+  city: Kingston
+  zip: '2899'
+  phone: "+672 3 23788"
 timezone: Pacific/Norfolk

--- a/db/data/regions/NG.yml
+++ b/db/data/regions/NG.yml
@@ -16,7 +16,14 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city} {province}_{country}_{phone}"
 emoji: "\U0001F1F3\U0001F1EC"
 languages:
-  - en
+- en
+example_address:
+  address1: Shehu Shagary Express Way
+  address2: 1002 First Ave
+  city: Central Business District
+  province_code: FC
+  zip: '900103'
+  phone: 01-2691439
 zones:
 - name: Abia
   code: AB

--- a/db/data/regions/NI.yml
+++ b/db/data/regions/NI.yml
@@ -15,5 +15,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip}_{city}_{country}_{phone}"
 emoji: "\U0001F1F3\U0001F1EE"
 languages:
-  - es
+- es
+example_address:
+  address1: Costado Este del Hotel Intercontinental Metrocentro
+  city: Managua
+  zip: '10000'
+  phone: "+505 2267 4551"
 timezone: America/Managua

--- a/db/data/regions/NL.yml
+++ b/db/data/regions/NL.yml
@@ -18,8 +18,13 @@ building_number_required: true
 building_number_may_be_in_address2: true
 week_start_day: monday
 languages:
-  - en
-  - nl
+- en
+- nl
+example_address:
+  address1: Museumplein ⁠6
+  city: Amsterdam
+  zip: 1071 DJ
+  phone: "+31 20 570 5200"
 format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"

--- a/db/data/regions/NO.yml
+++ b/db/data/regions/NO.yml
@@ -15,9 +15,14 @@ zip_regex: "^(NO?( |-)?)?(?!8099|917\\d)(\\d{4})$"
 phone_number_prefix: 47
 week_start_day: monday
 languages:
-  - en
-  - nb
-  - "no"
+- en
+- nb
+- 'no'
+example_address:
+  address1: Huk Aveny 35
+  city: Oslo
+  zip: '0287'
+  phone: "+47 22 13 52 80"
 format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"

--- a/db/data/regions/NP.yml
+++ b/db/data/regions/NP.yml
@@ -14,5 +14,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}"
 emoji: "\U0001F1F3\U0001F1F5"
 languages:
-  - ne
+- ne
+example_address:
+  address1: Kalikasthan, Dillibazar
+  address2: PO Box No. 430
+  city: Kathmandu
+  phone: "+977 (9) 841 405 475"
 timezone: Asia/Kathmandu

--- a/db/data/regions/NR.yml
+++ b/db/data/regions/NR.yml
@@ -15,6 +15,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: 🇳🇷
 languages:
-  - en
-  - na
+- en
+- na
+example_address:
+  company: Secretary for Justice and Border Control
+  address1: Nauru Post Office
+  city: Aiwo District
+  zip: NRU68
+  phone: "+674 557 35 05"
 timezone: Pacific/Nauru

--- a/db/data/regions/NU.yml
+++ b/db/data/regions/NU.yml
@@ -16,5 +16,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: 🇳🇺
 languages:
-  - en
+- en
+example_address:
+  address1: Crown Law Office
+  address2: PO Box 70
+  city: Alofi
+  zip: '9974'
+  phone: "+683 4228"
 timezone: Pacific/Niue

--- a/db/data/regions/NZ.yml
+++ b/db/data/regions/NZ.yml
@@ -20,8 +20,14 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{province}_{city} {zip}_{country}_{phone}"
 emoji: "\U0001F1F3\U0001F1FF"
 languages:
-  - en
-  - mi
+- en
+- mi
+example_address:
+  address1: 55 Wellesley Street East
+  city: Auckland CBD
+  province_code: AUK
+  zip: '1010'
+  phone: "+64 9 921 9999"
 zones:
 - name: Auckland
   code: AUK

--- a/db/data/regions/OM.yml
+++ b/db/data/regions/OM.yml
@@ -15,5 +15,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip}_{city}_{country}_{phone}"
 emoji: "\U0001F1F4\U0001F1F2"
 languages:
-  - ar
+- ar
+example_address:
+  address1: P.O. Box 1161
+  address2: Al Markazi, Building Number 44, CBD
+  city: Ruwi
+  zip: '112'
+  phone: "+968 24 777 777"
 timezone: Asia/Dubai

--- a/db/data/regions/PA.yml
+++ b/db/data/regions/PA.yml
@@ -31,7 +31,15 @@ combined_address_format:
         decorator: ", "
 emoji: "\U0001F1F5\U0001F1E6"
 languages:
-  - es
+- es
+example_address:
+  company: Municipio de Panamá
+  address1: Ave. Justo Arosemena y Cuba
+  address2: y entre calles 35 y, C. 36 Este, ⁠El Marañón
+  city: Panamá
+  province_code: PA-8
+  zip: '0815'
+  phone: "+507 524-8900"
 zones:
 - name: Bocas del Toro
   code: PA-1

--- a/db/data/regions/PE.yml
+++ b/db/data/regions/PE.yml
@@ -27,7 +27,15 @@ combined_address_format:
         decorator: " "
 emoji: "\U0001F1F5\U0001F1EA"
 languages:
-  - es
+- es
+example_address:
+  company: Huaca Pucllana
+  address1: s/n, Ca. Gral. Borgoño cuadra 8
+  address2: "⁠Miraflores"
+  city: Miraflores
+  province_code: PE-LMA
+  zip: '15074'
+  phone: "+51 1 6177148"
 zones:
 - name: Amazonas
   code: PE-AMA

--- a/db/data/regions/PF.yml
+++ b/db/data/regions/PF.yml
@@ -19,7 +19,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1F5\U0001F1EB"
 languages:
-  - fr
+- fr
+example_address:
+  address1: BP 51585
+  city: Pirae
+  zip: '98716'
+  phone: "+689 40 50 80 80"
 timezones:
   Pacific/Gambier:
   - '98755'

--- a/db/data/regions/PG.yml
+++ b/db/data/regions/PG.yml
@@ -14,6 +14,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}"
 emoji: "\U0001F1F5\U0001F1EC"
 languages:
-  - en
-  - ho
+- en
+- ho
+example_address:
+  address1: P.O Box 5053
+  address2: Boroko
+  city: Port Moresby
+  zip: '111'
+  phone: "+675 308 4431"
 timezone: Pacific/Port_Moresby

--- a/db/data/regions/PH.yml
+++ b/db/data/regions/PH.yml
@@ -29,8 +29,15 @@ combined_address_format:
         decorator: " "
 emoji: "\U0001F1F5\U0001F1ED"
 languages:
-  - en
-  - fil
+- en
+- fil
+example_address:
+  address1: 1 Rizal Park
+  address2: "⁠Ermita"
+  city: Manila
+  province_code: PH-00
+  zip: '0913'
+  phone: "+63 2 8527 0011"
 zones:
 - name: Abra
   code: PH-ABR

--- a/db/data/regions/PK.yml
+++ b/db/data/regions/PK.yml
@@ -16,8 +16,15 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}"
 emoji: "\U0001F1F5\U0001F1F0"
 languages:
-  - en
-  - pa
-  - ps
-  - sd
+- en
+- pa
+- ps
+- sd
+example_address:
+  company: Copyrights Office
+  address1: Plot
+  address2: Behind KDA Civic Center, Block -14, Gulshan-e-Iqbal
+  city: Karachi
+  zip: '75300'
+  phone: "+92 21 99 230 140"
 timezone: Asia/Karachi

--- a/db/data/regions/PL.yml
+++ b/db/data/regions/PL.yml
@@ -26,6 +26,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1F5\U0001F1F1"
 languages:
-  - pl
-  - ru
+- pl
+- ru
+example_address:
+  address1: plac Zamkowy 4
+  city: Warszawa
+  zip: 00-277
+  phone: "+48 22 355 51 70"
 timezone: Europe/Warsaw

--- a/db/data/regions/PM.yml
+++ b/db/data/regions/PM.yml
@@ -18,5 +18,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: 🇵🇲
 languages:
-  - fr
+- fr
+example_address:
+  address1: Rue Borda
+  city: Saint-Pierre
+  zip: '97500'
+  phone: "+508 41 02 40"
 timezone: America/Miquelon

--- a/db/data/regions/PN.yml
+++ b/db/data/regions/PN.yml
@@ -16,5 +16,9 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip}_{country}_{phone}"
 emoji: 🇵🇳
 languages:
-  - en
+- en
+example_address:
+  city: Adamstown
+  zip: PCRN 1ZZ
+  phone: "+64 9 366 0186"
 timezone: Pacific/Pitcairn

--- a/db/data/regions/PS.yml
+++ b/db/data/regions/PS.yml
@@ -13,5 +13,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1F5\U0001F1F8"
 languages:
-  - ar
+- ar
+example_address:
+  address1: Faculty of Science – Second Floor
+  address2: Main Campus, Al-Quds University
+  city: Abu Dis
+  phone: "+970 2 2790606"
 timezone: Asia/Gaza

--- a/db/data/regions/PT.yml
+++ b/db/data/regions/PT.yml
@@ -21,7 +21,13 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{province}_{country}_{phone}"
 emoji: "\U0001F1F5\U0001F1F9"
 languages:
-  - "pt-PT"
+- pt-PT
+example_address:
+  address1: Largo da Sé 1
+  city: Lisboa
+  province_code: PT-11
+  zip: 1100-585
+  phone: "+351 21 886 6752"
 zones:
 - name: Açores
   code: PT-20

--- a/db/data/regions/PY.yml
+++ b/db/data/regions/PY.yml
@@ -15,5 +15,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1F5\U0001F1FE"
 languages:
-  - es
+- es
+example_address:
+  address1: 14 De Mayo 462
+  city: Asunción
+  zip: '001015'
+  phone: "+595 21 371 371"
 timezone: America/Asuncion

--- a/db/data/regions/QA.yml
+++ b/db/data/regions/QA.yml
@@ -13,5 +13,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: "\U0001F1F6\U0001F1E6"
 languages:
-  - ar
+- ar
+example_address:
+  address1: Lussail City
+  address2: P.O. Box 1968
+  city: Doha
+  phone: "+974 4012 26 23"
 timezone: Asia/Qatar

--- a/db/data/regions/RE.yml
+++ b/db/data/regions/RE.yml
@@ -22,5 +22,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1F7\U0001F1EA"
 languages:
-  - fr
+- fr
+example_address:
+  address1: 28 Rue de Montpellier
+  city: Le Port
+  zip: '97420'
+  phone: "+262 800 00 36 31"
 timezone: Indian/Reunion

--- a/db/data/regions/RO.yml
+++ b/db/data/regions/RO.yml
@@ -21,8 +21,14 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city} {province}_{country}_{phone}"
 emoji: "\U0001F1F7\U0001F1F4"
 languages:
-  - ro
-  - ru
+- ro
+- ru
+example_address:
+  address1: Bulevardul Unirii 22
+  city: București
+  province_code: B
+  zip: '030823'
+  phone: "+40 21 314 2434"
 zones:
 - name: Alba
   code: AB

--- a/db/data/regions/RS.yml
+++ b/db/data/regions/RS.yml
@@ -17,5 +17,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1F7\U0001F1F8"
 languages:
-  - sr
+- sr
+example_address:
+  address1: Trg Nikole Pašića 13
+  city: Beograd
+  zip: '11000'
+  phone: "+381 11 3026100"
 timezone: Europe/Belgrade

--- a/db/data/regions/RU.yml
+++ b/db/data/regions/RU.yml
@@ -17,7 +17,13 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{province}_{zip}_{country}_{phone}"
 emoji: "\U0001F1F7\U0001F1FA"
 languages:
-  - ru
+- ru
+example_address:
+  address1: Red Square, 1
+  city: Moscow
+  province_code: MOW
+  zip: '109012'
+  phone: "+7 495 692-40-19"
 zones:
 - name: Republic of Adygeya
   code: AD

--- a/db/data/regions/RW.yml
+++ b/db/data/regions/RW.yml
@@ -13,8 +13,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: "\U0001F1F7\U0001F1FC"
 languages:
-  - en
-  - fr
-  - rw
-  - sw
+- en
+- fr
+- rw
+- sw
+example_address:
+  address1: P.O. Box 6239
+  city: Kigali
+  phone: "+250 788811718"
 timezone: Africa/Maputo

--- a/db/data/regions/SA.yml
+++ b/db/data/regions/SA.yml
@@ -13,8 +13,14 @@ zip_example: '11564'
 phone_number_prefix: 966
 week_start_day: saturday
 languages:
-  - ar
-  - en
+- ar
+- en
+example_address:
+  address1: شارع الأمير ناصر بن فرحان،
+  address2: ⁠حي الملك سلمان
+  city: الرياض
+  zip: '12435'
+  phone: "+966 11 494 8888"
 format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{city}{zip}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}"

--- a/db/data/regions/SB.yml
+++ b/db/data/regions/SB.yml
@@ -13,5 +13,9 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: 🇸🇧
 languages:
-  - en
+- en
+example_address:
+  address1: P. O. Box G15
+  city: Honiara
+  phone: "+677 23 002"
 timezone: Pacific/Guadalcanal

--- a/db/data/regions/SC.yml
+++ b/db/data/regions/SC.yml
@@ -13,6 +13,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: "\U0001F1F8\U0001F1E8"
 languages:
-  - en
-  - fr
+- en
+- fr
+example_address:
+  address1: 1st Floor, Independence House
+  address2: P.O. Box 142
+  city: Victoria, Mahe
+  phone: "+248 428 09 00"
 timezone: Asia/Dubai

--- a/db/data/regions/SD.yml
+++ b/db/data/regions/SD.yml
@@ -17,6 +17,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip}_{city}_{country}_{phone}"
 emoji: "\U0001F1F8\U0001F1E9"
 languages:
-  - ar
-  - en
+- ar
+- en
+example_address:
+  address1: Air Street
+  address2: AlRaqi District
+  city: Khartoum
+  phone: "+249 155772782"
 timezone: Africa/Khartoum

--- a/db/data/regions/SE.yml
+++ b/db/data/regions/SE.yml
@@ -16,8 +16,13 @@ phone_number_prefix: 46
 building_number_required: true
 week_start_day: monday
 languages:
-  - en
-  - sv
+- en
+- sv
+example_address:
+  address1: Stortorget 2
+  city: Stockholm
+  zip: 103 16
+  phone: "+46 8 534 818 00"
 format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"

--- a/db/data/regions/SG.yml
+++ b/db/data/regions/SG.yml
@@ -14,9 +14,15 @@ building_number_required: true
 week_start_day: sunday
 autofill_city_enabled: true
 languages:
-  - en
-  - ms
-  - zh-CN
+- en
+- ms
+- zh-CN
+example_address:
+  address1: The Istana
+  address2: Orchard Rd
+  city: Singapore
+  zip: '238823'
+  phone: "+65 8720 6021"
 format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{zip}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{country} {zip}_{phone}"

--- a/db/data/regions/SH.yml
+++ b/db/data/regions/SH.yml
@@ -15,5 +15,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}"
 emoji: 🇸🇭
 languages:
-  - en
+- en
+example_address:
+  address1: Museum of St Helena
+  address2: P O Box 115
+  city: Jamestown
+  zip: STHL 1ZZ
+  phone: "+290 22845"
 timezone: Atlantic/St_Helena

--- a/db/data/regions/SI.yml
+++ b/db/data/regions/SI.yml
@@ -18,7 +18,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1F8\U0001F1EE"
 languages:
-  - hu
-  - it
-  - sl
+- hu
+- it
+- sl
+example_address:
+  address1: Dolničarjeva ulica 1
+  city: Ljubljana
+  zip: '1000'
+  phone: "+386 1 234 26 90"
 timezone: Europe/Belgrade

--- a/db/data/regions/SJ.yml
+++ b/db/data/regions/SJ.yml
@@ -17,5 +17,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: 🇸🇯
 languages:
-  - "no"
+- 'no'
+example_address:
+  address1: P.O. Box 156
+  city: Longyearbyen
+  zip: '9171'
+  phone: "+47 79 02 33 00"
 timezone: Arctic/Longyearbyen

--- a/db/data/regions/SK.yml
+++ b/db/data/regions/SK.yml
@@ -19,6 +19,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1F8\U0001F1F0"
 languages:
-  - ru
-  - sk
+- ru
+- sk
+example_address:
+  address1: Michalská ulica 22 806/24
+  city: Staré Mesto
+  zip: 811 03
+  phone: "+421 2/544 330 44"
 timezone: Europe/Prague

--- a/db/data/regions/SL.yml
+++ b/db/data/regions/SL.yml
@@ -16,6 +16,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: 🇸🇱
 languages:
-  - en
-  - fr
+- en
+- fr
+example_address:
+  address1: 28 Walpole Street
+  city: Freetown
+  phone: "+232 76 612 437"
 timezone: Africa/Abidjan

--- a/db/data/regions/SM.yml
+++ b/db/data/regions/SM.yml
@@ -15,5 +15,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: 🇸🇲
 languages:
-  - it
+- it
+example_address:
+  address1: Via 28 Luglio, 212
+  city: Borgo Maggiore
+  zip: '47893'
+  phone: "+378 0549 88 29 82"
 timezone: Europe/Rome

--- a/db/data/regions/SN.yml
+++ b/db/data/regions/SN.yml
@@ -15,5 +15,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1F8\U0001F1F3"
 languages:
-  - fr
+- fr
+example_address:
+  address1: Immeuble Adja Fatou Nourou DIOP,
+  address2: 12ème Etage sis aux Allées Papa Guéye FALL
+  city: Dakar
+  phone: "+221 33 849 03 38"
 timezone: Africa/Abidjan

--- a/db/data/regions/SO.yml
+++ b/db/data/regions/SO.yml
@@ -22,8 +22,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}"
 emoji: 🇸🇴
 languages:
-  - ar
-  - en
-  - it
-  - so
+- ar
+- en
+- it
+- so
+example_address:
+  address1: P.O. Box 1182
+  city: Mogadishu
+  phone: "+252 (1) 80 204"
 timezone: Africa/Nairobi

--- a/db/data/regions/SR.yml
+++ b/db/data/regions/SR.yml
@@ -13,5 +13,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: "\U0001F1F8\U0001F1F7"
 languages:
-  - nl
+- nl
+example_address:
+  company: Ministry of Economic Affairs, Entrepreneurship and Technological Innovation
+  address1: Havenlaan 1
+  city: Paramaribo
+  phone: "+597 404 834"
 timezone: America/Paramaribo

--- a/db/data/regions/SS.yml
+++ b/db/data/regions/SS.yml
@@ -19,6 +19,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: 🇸🇸
 languages:
-  - ar
-  - en
+- ar
+- en
+example_address:
+  company: National Communications Authority (NCA)
+  address1: P.O. Box 531
+  address2: Ministry Gateway Complex, Gumbo
+  city: JUBA
+  phone: "+211 922232222"
 timezone: Africa/Juba

--- a/db/data/regions/ST.yml
+++ b/db/data/regions/ST.yml
@@ -13,6 +13,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: 🇸🇹
 languages:
-  - fr
-  - "pt-PT"
+- fr
+- pt-PT
+example_address:
+  address1: Rua Viriato da Cruz
+  address2: C.P. 198
+  city: Sao Tome
+  phone: "+239 (22) 22803"
 timezone: Africa/Sao_Tome

--- a/db/data/regions/SV.yml
+++ b/db/data/regions/SV.yml
@@ -15,7 +15,14 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{province}_{country}_{phone}"
 emoji: "\U0001F1F8\U0001F1FB"
 languages:
-  - es
+- es
+example_address:
+  company: Centro Nacional de Registros
+  address1: 1a Calle Pte., San Salvador, El Salvador
+  city: San Salvador
+  province_code: SV-SS
+  zip: CP 1101
+  phone: "+503 2593 5000"
 zones:
   - name: Ahuachapán
     code: SV-AH

--- a/db/data/regions/SX.yml
+++ b/db/data/regions/SX.yml
@@ -17,6 +17,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: "\U0001F1F8\U0001F1FD"
 languages:
-  - en
-  - nl
+- en
+- nl
+example_address:
+  address1: 60 Welfare Rd
+  city: Cole Bay
+  phone: "+1 (721) 520-0008"
 timezone: America/Puerto_Rico

--- a/db/data/regions/SY.yml
+++ b/db/data/regions/SY.yml
@@ -14,5 +14,9 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: 🇸🇾
 languages:
-  - ar
+- ar
+example_address:
+  address1: Ministry of Culture
+  city: Damascus
+  phone: "+963 (11) 333 1556"
 timezone: Asia/Damascus

--- a/db/data/regions/SZ.yml
+++ b/db/data/regions/SZ.yml
@@ -17,6 +17,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}"
 emoji: 🇸🇿
 languages:
-  - en
-  - ss
+- en
+- ss
+example_address:
+  address1: Corner of MR 103 and Cultural Center Drive
+  address2: Ezulwini, P.O. Box D202
+  city: The Gables
+  zip: H106
+  phone: "+268 2417 9000"
 timezone: Africa/Johannesburg

--- a/db/data/regions/TA.yml
+++ b/db/data/regions/TA.yml
@@ -18,5 +18,9 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip}_{country}_{phone}"
 emoji: 🇹🇦
 languages:
-  - en
+- en
+example_address:
+  city: Edinburgh of the Seven Seas
+  zip: TDCU 1ZZ
+  phone: "+44 20 3014 2034"
 timezone: Africa/Abidjan

--- a/db/data/regions/TC.yml
+++ b/db/data/regions/TC.yml
@@ -16,5 +16,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}"
 emoji: "\U0001F1F9\U0001F1E8"
 languages:
-  - en
+- en
+example_address:
+  address1: 250 Bay Road
+  city: Wheeland
+  zip: TKCA 1ZZ
+  phone: "+1 (649) 941-5632"
 timezone: America/Grand_Turk

--- a/db/data/regions/TD.yml
+++ b/db/data/regions/TD.yml
@@ -12,6 +12,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: 🇹🇩
 languages:
-  - ar
-  - fr
+- ar
+- fr
+example_address:
+  address1: Palais du Gouvernement
+  address2: P.O. Box 4546
+  city: N'Djaména
+  phone: "+235 66 33 13 36"
 timezone: Africa/Ndjamena

--- a/db/data/regions/TG.yml
+++ b/db/data/regions/TG.yml
@@ -13,9 +13,14 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: 🇹🇬
 languages:
-  - ar
-  - de
-  - ee
-  - en
-  - fr
+- ar
+- de
+- ee
+- en
+- fr
+example_address:
+  address1: angle rue de l'Eglise
+  address2: 25 Rue Koketi
+  city: Lomé
+  phone: "+228 22 23 30 60"
 timezone: Africa/Abidjan

--- a/db/data/regions/TH.yml
+++ b/db/data/regions/TH.yml
@@ -16,7 +16,15 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{province} {zip}_{country}_{phone}"
 emoji: "\U0001F1F9\U0001F1ED"
 languages:
-  - th
+- th
+example_address:
+  company: Bureau of the Royal Household
+  address1: Sanam Sungpha
+  address2: Dusit Palace
+  city: Bangkok
+  province_code: TH-10
+  zip: '10300'
+  phone: 02 281 7878
 zones:
 - name: Amnat Charoen
   code: TH-37

--- a/db/data/regions/TJ.yml
+++ b/db/data/regions/TJ.yml
@@ -19,6 +19,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: 🇹🇯
 languages:
-  - ru
-  - tg
+- ru
+- tg
+example_address:
+  address1: Academics Rajabov Street 7
+  city: Dushanbe
+  zip: '735101'
+  phone: "+992 372 27 1350"
 timezone: Asia/Dushanbe

--- a/db/data/regions/TK.yml
+++ b/db/data/regions/TK.yml
@@ -12,5 +12,9 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: 🇹🇰
 languages:
-  - en
+- en
+example_address:
+  address1: Taupulega Office
+  city: Nukunonu
+  phone: "+690 4227"
 timezone: Pacific/Fakaofo

--- a/db/data/regions/TL.yml
+++ b/db/data/regions/TL.yml
@@ -13,5 +13,9 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: 🇹🇱
 languages:
-  - "pt-PT"
+- pt-PT
+example_address:
+  address1: R. Formosa 4
+  city: Díli
+  phone: "+670 333 1159"
 timezone: Asia/Dili

--- a/db/data/regions/TM.yml
+++ b/db/data/regions/TM.yml
@@ -15,6 +15,11 @@ format:
   show: "{zip} {city}_{country}_{firstName} {lastName}_{company}_{address1}_{address2}_{phone}"
 emoji: "\U0001F1F9\U0001F1F2"
 languages:
-  - ru
-  - tk
+- ru
+- tk
+example_address:
+  address1: Galkynysh St 4
+  city: Ashgabat
+  zip: '744000'
+  phone: "+993 65 379162"
 timezone: Asia/Ashgabat

--- a/db/data/regions/TN.yml
+++ b/db/data/regions/TN.yml
@@ -17,6 +17,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1F9\U0001F1F3"
 languages:
-  - ar
-  - fr
+- ar
+- fr
+example_address:
+  address1: 94 Boulevard du 9 Avril 1938
+  city: Tunis
+  zip: '1007'
+  phone: "+216 71 560 840"
 timezone: Africa/Tunis

--- a/db/data/regions/TO.yml
+++ b/db/data/regions/TO.yml
@@ -16,6 +16,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: 🇹🇴
 languages:
-  - en
-  - to
+- en
+- to
+example_address:
+  company: Royal Palace of Tonga
+  address1: Vuna Rd
+  city: Nuku'alofa
+  phone: "+676 843 5051"
 timezone: Pacific/Tongatapu

--- a/db/data/regions/TR.yml
+++ b/db/data/regions/TR.yml
@@ -30,5 +30,11 @@ combined_address_format:
         decorator: " "
 emoji: "\U0001F1F9\U0001F1F7"
 languages:
-  - tr
+- tr
+example_address:
+  address1: Küçük Ayasofya Mahallesi
+  address2: Camii Sokagi No:20 ⁠Küçük Ayasofya
+  city: Fatih/İstanbul
+  zip: '34122'
+  phone: "+90 212 491 16 63"
 timezone: Europe/Istanbul

--- a/db/data/regions/TT.yml
+++ b/db/data/regions/TT.yml
@@ -16,5 +16,9 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}"
 emoji: "\U0001F1F9\U0001F1F9"
 languages:
-  - en
+- en
+example_address:
+  address1: 2 Carib Street
+  city: San Fernando
+  phone: "+1 (868) 652-2311"
 timezone: America/Puerto_Rico

--- a/db/data/regions/TV.yml
+++ b/db/data/regions/TV.yml
@@ -12,5 +12,11 @@ format:
 emoji: 🇹🇻
 currency: AUD
 languages:
-  - en
+- en
+example_address:
+  company: Government House
+  address1: Te Auala O Valaku
+  address2: Vaiaku
+  city: Funafuti
+  phone: "+688 7 102 050"
 timezone: Pacific/Tarawa

--- a/db/data/regions/TW.yml
+++ b/db/data/regions/TW.yml
@@ -35,5 +35,11 @@ combined_address_format:
         decorator: ", "
 emoji: "\U0001F1F9\U0001F1FC"
 languages:
-  - "zh-TW"
+- zh-TW
+example_address:
+  address1: No. 45 號, City Hall Rd
+  address2: "⁠Xinyi District"
+  city: Taipei City
+  zip: '110'
+  phone: "+886 2 8101 8800"
 timezone: Asia/Taipei

--- a/db/data/regions/TZ.yml
+++ b/db/data/regions/TZ.yml
@@ -14,6 +14,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1F9\U0001F1FF"
 languages:
-  - en
-  - sw
+- en
+- sw
+example_address:
+  address1: Utumishi Block-8 Kivukoni Road, Kivukoni
+  address2: P.O. Box 6388
+  city: Dar es Salaam
+  zip: '11404'
+  phone: "+255 738 015 013"
 timezone: Africa/Nairobi

--- a/db/data/regions/UA.yml
+++ b/db/data/regions/UA.yml
@@ -17,6 +17,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}"
 emoji: "\U0001F1FA\U0001F1E6"
 languages:
-  - ru
-  - uk
+- ru
+- uk
+example_address:
+  address1: Lavrska St, 15
+  city: Kyiv
+  zip: '01015'
+  phone: "+380 44 255 1105"
 timezone: Europe/Kyiv

--- a/db/data/regions/UG.yml
+++ b/db/data/regions/UG.yml
@@ -13,6 +13,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: "\U0001F1FA\U0001F1EC"
 languages:
-  - en
-  - sw
+- en
+- sw
+example_address:
+  address1: Plot 5, Gejorge Street
+  address2: Georgian House
+  city: Kampala
+  phone: "+256 414 233 219"
 timezone: Africa/Nairobi

--- a/db/data/regions/US.yml
+++ b/db/data/regions/US.yml
@@ -22,8 +22,14 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city} {province} {zip}_{country}_{phone}"
 emoji: "\U0001F1FA\U0001F1F8"
 languages:
-  - en
-  - es
+- en
+- es
+example_address:
+  address1: 1600 Pennsylvania Avenue NW
+  city: Washington
+  province_code: DC
+  zip: 20500-0005
+  phone: "+1 (202) 456-1414"
 use_zone_code_as_short_name: true
 zones:
 - tax: 0.04

--- a/db/data/regions/UY.yml
+++ b/db/data/regions/UY.yml
@@ -15,7 +15,13 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}, {province}_{country}_{phone}"
 emoji: "\U0001F1FA\U0001F1FE"
 languages:
-  - es
+- es
+example_address:
+  address1: Av. Gonzalo Ramírez 1926
+  city: Montevideo
+  province_code: UY-MO
+  zip: '11200'
+  phone: "+598 2411 8839"
 zones:
   - name: Artigas
     code: UY-AR

--- a/db/data/regions/UZ.yml
+++ b/db/data/regions/UZ.yml
@@ -17,6 +17,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}"
 emoji: "\U0001F1FA\U0001F1FF"
 languages:
-  - ru
-  - uz
+- ru
+- uz
+example_address:
+  address1: 9 Amir Temur St
+  city: Samarkand
+  zip: '140100'
+  phone: "+998 66 233 38 72"
 timezone: Asia/Samarkand

--- a/db/data/regions/VA.yml
+++ b/db/data/regions/VA.yml
@@ -19,6 +19,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {country}_{phone}"
 emoji: 🇻🇦
 languages:
-  - it
-  - la
+- it
+- la
+example_address:
+  address1: Cortile del Belvedere
+  city: Città del Vaticano
+  zip: '00120'
+  phone: "+39 06 6988 3314"
 timezone: Europe/Rome

--- a/db/data/regions/VC.yml
+++ b/db/data/regions/VC.yml
@@ -16,5 +16,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1FB\U0001F1E8"
 languages:
-  - en
+- en
+example_address:
+  address1: Box 750
+  address2: Richmond Hill
+  city: Kingstown
+  zip: VC0100
+  phone: "+1 (784) 457-1111"
 timezone: America/Puerto_Rico

--- a/db/data/regions/VE.yml
+++ b/db/data/regions/VE.yml
@@ -16,7 +16,13 @@ format:
 emoji: "\U0001F1FB\U0001F1EA"
 ignore_zones: false
 languages:
-  - es
+- es
+example_address:
+  address1: C. Real de La Cañada
+  city: Caracas
+  province_code: VE-A
+  zip: '1030'
+  phone: "+58 800-7246300"
 zones:
   - name: Amazonas
     code: VE-Z

--- a/db/data/regions/VG.yml
+++ b/db/data/regions/VG.yml
@@ -15,5 +15,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{zip}_{country}_{phone}"
 emoji: "\U0001F1FB\U0001F1EC"
 languages:
-  - en
+- en
+example_address:
+  company: Governor's Office
+  address1: Waterfront Drive
+  address2: Road Town
+  city: Tortola
+  zip: VG1110
+  phone: "+1 (284) 494-2345"
 timezone: America/Puerto_Rico

--- a/db/data/regions/VN.yml
+++ b/db/data/regions/VN.yml
@@ -27,6 +27,11 @@ combined_address_format:
         decorator: ", "
 emoji: "\U0001F1FB\U0001F1F3"
 languages:
-  - fr
-  - vn
+- fr
+- vn
+example_address:
+  address1: No. 33, 294/2, Kim Ma Street
+  address2: "⁠Ba Dinh District"
+  city: Hanoi
+  phone: "+84 (24) 382 36 908"
 timezone: Asia/Bangkok

--- a/db/data/regions/VU.yml
+++ b/db/data/regions/VU.yml
@@ -14,7 +14,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: "\U0001F1FB\U0001F1FA"
 languages:
-  - bi
-  - en
-  - fr
+- bi
+- en
+- fr
+example_address:
+  address1: PMB 9056
+  address2: 1st Floor, Pilioko Building
+  city: Port Vila
+  phone: "+678 33414"
 timezone: Pacific/Efate

--- a/db/data/regions/WF.yml
+++ b/db/data/regions/WF.yml
@@ -20,5 +20,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: 🇼🇫
 languages:
-  - fr
+- fr
+example_address:
+  company: Service des Poste et Télécommunications
+  address1: BP 00
+  address2: SIGAVE
+  city: Léava
+  zip: '98600'
+  phone: "+681 72 20 14"
 timezone: Pacific/Wallis

--- a/db/data/regions/WS.yml
+++ b/db/data/regions/WS.yml
@@ -16,6 +16,12 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1FC\U0001F1F8"
 languages:
-  - en
-  - sm
+- en
+- sm
+example_address:
+  company: National University of Samoa
+  address1: To'omatagi
+  city: Apia
+  zip: WS1322
+  phone: "+685 20072"
 timezone: Pacific/Apia

--- a/db/data/regions/XK.yml
+++ b/db/data/regions/XK.yml
@@ -20,6 +20,11 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: 🇽🇰
 languages:
-  - bs
-  - tr
+- bs
+- tr
+example_address:
+  address1: Ulica "Luan Haradinaj" b.b.
+  city: Pristina
+  zip: '10000'
+  phone: "+383 (0) 38 521 033"
 timezone: Europe/Belgrade

--- a/db/data/regions/YE.yml
+++ b/db/data/regions/YE.yml
@@ -14,5 +14,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: "\U0001F1FE\U0001F1EA"
 languages:
-  - ar
+- ar
+example_address:
+  company: Ministry of Culture
+  address1: Tahreer Square
+  city: Sana'a
+  phone: "+967 777 665 437"
 timezone: Asia/Riyadh

--- a/db/data/regions/YT.yml
+++ b/db/data/regions/YT.yml
@@ -22,5 +22,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1FE\U0001F1F9"
 languages:
-  - fr
+- fr
+example_address:
+  address1: 23 Rue du Commerce
+  city: Dzaoudzi
+  zip: '97615'
+  phone: "+262 800 00 36 31"
 timezone: Africa/Nairobi

--- a/db/data/regions/ZA.yml
+++ b/db/data/regions/ZA.yml
@@ -18,13 +18,20 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{province}_{zip}_{country}_{phone}"
 emoji: "\U0001F1FF\U0001F1E6"
 languages:
-  - af
-  - en
-  - nr
-  - ss
-  - st
-  - xh
-  - zu
+- af
+- en
+- nr
+- ss
+- st
+- xh
+- zu
+example_address:
+  address1: 71 Wale St
+  address2: Schotsche Kloof
+  city: Cape Town
+  province_code: WC
+  zip: '8001'
+  phone: "+27 21 481 3938"
 zones:
 - name: Eastern Cape
   code: EC

--- a/db/data/regions/ZM.yml
+++ b/db/data/regions/ZM.yml
@@ -14,5 +14,10 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 emoji: "\U0001F1FF\U0001F1F2"
 languages:
-  - en
+- en
+example_address:
+  address1: Plot No. 8471, PACRA House Haile Selassie Avenue
+  address2: P.O. Box 32020
+  city: Longacres
+  phone: "+260 (211) 255 127"
 timezone: Africa/Maputo

--- a/db/data/regions/ZW.yml
+++ b/db/data/regions/ZW.yml
@@ -14,10 +14,15 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}"
 emoji: "\U0001F1FF\U0001F1FC"
 languages:
-  - en
-  - nd
-  - sn
-  - tn
-  - ts
-  - xh
+- en
+- nd
+- sn
+- tn
+- ts
+- xh
+example_address:
+  address1: 38 Nelson Mandela Avenue
+  address2: P.O Box CY 177, Causeway
+  city: Harare
+  phone: "+263 (4) 775 544"
 timezone: Africa/Maputo

--- a/lib/worldwide/region.rb
+++ b/lib/worldwide/region.rb
@@ -17,6 +17,7 @@ module Worldwide
       :building_number_required,
       :currency,
       :example_city,
+      :example_address,
       :flag,
       :format,
       :format_extended,
@@ -64,6 +65,9 @@ module Worldwide
 
     # A major city in the given region that can be used as an example
     attr_accessor :example_city
+
+    # A full address in the given region that can be used as an example
+    attr_accessor :example_address
 
     # Unicode codepoints for this region's flag emoji
     attr_accessor :flag
@@ -262,6 +266,7 @@ module Worldwide
       @zip_example = nil
       @zip_prefixes = []
       @zip_regex = nil
+      @example_address = nil
 
       @parents = [].to_set
       @zones = []

--- a/lib/worldwide/regions_loader.rb
+++ b/lib/worldwide/regions_loader.rb
@@ -105,6 +105,7 @@ module Worldwide
       region.flag = spec["emoji"]
       region.format = spec["format"]
       region.format_extended = spec["format_extended"] || {}
+      region.example_address = spec["example_address"] || nil
       region.group = spec["group"]
       region.group_name = spec["group_name"]
       region.hide_provinces_from_addresses = spec["hide_provinces_from_addresses"] || false

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "1.6.2"
+  VERSION = "1.7.0"
 end

--- a/test/worldwide/region_yml_consistency_test.rb
+++ b/test/worldwide/region_yml_consistency_test.rb
@@ -30,6 +30,7 @@ module Worldwide
         "tags",
         "example_city",
         "example_city_zip",
+        "example_address",
       ]
 
       @raw_yml.each do |yml|
@@ -187,6 +188,24 @@ module Worldwide
               )
             end
           end
+        end
+      end
+    end
+
+    test "example_address contains the word joiner when additional_address_fields are present" do
+      word_joiner = "\u2060"
+
+      Regions.all.select(&:country?).each do |country|
+        next if country.additional_address_fields.blank?
+
+        example_address = country.example_address
+
+        next if example_address.blank?
+
+        country.combined_address_format["default"].keys.each do |key|
+          included = example_address[key].include?(word_joiner)
+
+          assert included, "#{country.iso_code} example_address #{key} should contain the unicode word joiner"
         end
       end
     end


### PR DESCRIPTION
### What are you trying to accomplish?
Migrate the `example_address` method into worldwide from country_db. 
Cut a new version with this feature, `v1.7.0`

Next, will update country_db to route to worldwide 

part of https://github.com/Shopify/address/issues/2663

### What approach did you choose and why?
- Copied the example_address yml data from country_db into worldwide. 
- Copied over the consistency tests
- Added a test for additional_address_fields consistency; checks that the word joiner is present in the example address 

### What should reviewers focus on?


### The impact of these changes
Allows us to write a consistency test that ensures the example address contains a word joiner character when the country supports additional fields. 

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

...

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
