### PR TITLE
Add Kosovo to world.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Security in case of vulnerabilities.
 
 ## [Unreleased]
-- Nil.
+- Adds Kosovo to Southern Europe [#216](https://github.com/Shopify/worldwide/pull/261)
 
 ---
 

--- a/db/data/world.yml
+++ b/db/data/world.yml
@@ -240,6 +240,7 @@
       - RS # Serbia
       - SI # Slovenia
       - ES # Spain
+      - XK # Kosovo
     '155': # Western Europe
       - AT # Austria
       - BE # Belgium


### PR DESCRIPTION
### What are you trying to accomplish?

Atlas leverages worldwide but is unable to resolve the `associated_continent` for Kosovo. Because of this, we fallback to Europe which is not translated.

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
