### PR TITLE
release v1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Security in case of vulnerabilities.
 
 ## [Unreleased]
-- Adds Kosovo to Southern Europe [#216](https://github.com/Shopify/worldwide/pull/261)
+- Nil.
 
 ---
+
+## [1.7.2] - 2024-07-25
+- Associates Kosovo with Southern Europe [#216](https://github.com/Shopify/worldwide/pull/261)
 
 ## [1.7.1] - 2024-07-25
 - Update iana_to_rails_time_zone mappings for 11 tz's, add time zone data consistency tests[#259](https://github.com/Shopify/worldwide/pull/259)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (1.7.1)
+    worldwide (1.7.2)
       activesupport (>= 7.0)
       i18n
       phonelib (~> 0.8)

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "1.7.1"
+  VERSION = "1.7.2"
 end


### PR DESCRIPTION
### What are you trying to accomplish?

new patch.

Fixes bug where Kosovo has no associated continent.

## [1.7.2] - 2024-07-25
- Associates Kosovo with Southern Europe [#216](https://github.com/Shopify/worldwide/pull/261)

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
