### PR TITLE
Add mapping for deprecated timezones - Kolkata, Indianapolis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- Update legacy timezone mappings for America/Indianapolis and Asia/Calcutta [#267](https://github.com/Shopify/worldwide/pull/267)
+
 ---
 
 ## [1.7.3] - 2024-07-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-- Update legacy timezone mappings for America/Indianapolis and Asia/Calcutta [#267](https://github.com/Shopify/worldwide/pull/267)
-
 ---
+
+## [1.7.4] - 2024-08-01
+- Update legacy timezone mappings for America/Indianapolis and Asia/Calcutta [#267](https://github.com/Shopify/worldwide/pull/267)
 
 ## [1.7.3] - 2024-07-30
 - Update NZ postcode prefixes [#265](https://github.com/Shopify/worldwide/pull/265)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (1.7.3)
+    worldwide (1.7.4)
       activesupport (>= 7.0)
       i18n
       phonelib (~> 0.8)

--- a/lib/worldwide/deprecated_time_zone_mapper.rb
+++ b/lib/worldwide/deprecated_time_zone_mapper.rb
@@ -22,7 +22,9 @@ module Worldwide
 
     DEPRECATED_ZONES_MAP = {
       "America/Indiana": "America/Indiana/Indianapolis",
+      "America/Indianapolis": "America/Indiana/Indianapolis",
       "America/Argentina": "America/Argentina/Buenos_Aires",
+      "Asia/Calcutta": "Asia/Kolkata",
       "Asia/Chongqing": "Asia/Shanghai",
       "Asia/Istanbul": "Europe/Istanbul",
       "Australia/ACT": "Australia/Sydney",

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "1.7.3"
+  VERSION = "1.7.4"
 end


### PR DESCRIPTION
### What are you trying to accomplish?

`America/Indianapolis` and `Asia/Calcutta` timezones are deprecated, map to the correct replacement timezones

### The impact of these changes

These timezones are still present in our systems and need to be mapped to the correct values.

### Testing

...

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
