### PR TITLE
Release version 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,12 +27,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+---
+
+## [1.8.0] - 2024-08-09
 - Bump Ruby to 3.3.1; drop support for 3.0.x [#264](https://github.com/Shopify/worldwide/pull/264)
 - Add support for partial zip matching for SG [#271](https://github.com/Shopify/worldwide/pull/271)
 
----
-
-## [1.7.5] = 2024-08-01
+## [1.7.5] - 2024-08-01
 - Update legacy timezone mappings for America/Indianapolis and Asia/Calcutta [#267](https://github.com/Shopify/worldwide/pull/267)
 
 ## [1.7.4] - 2024-08-01

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (1.7.5)
+    worldwide (1.8.0)
       activesupport (>= 7.0)
       i18n
       phonelib (~> 0.8)

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "1.7.5"
+  VERSION = "1.8.0"
 end


### PR DESCRIPTION
### What are you trying to accomplish?
This minor version drops support for Ruby 3.0.x (hence the minor) and adds partial postal code validation for Singapore.

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
