### PR TITLE
additional field support in DE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Security in case of vulnerabilities.
 
 ## [Unreleased]
+- add support for additional address fields streetName, streetNumber in DE [#273](https://github.com/Shopify/worldwide/pull/273)
 
 ---
 

--- a/db/data/regions/DE.yml
+++ b/db/data/regions/DE.yml
@@ -20,7 +20,7 @@ languages:
 - de
 - en
 example_address:
-  address1: Willy-Brandt-Straße 1
+  address1: Willy-Brandt-Straße ⁠1
   city: Berlin
   zip: '10557'
   phone: "+49 30 182722720"

--- a/db/data/regions/DE.yml
+++ b/db/data/regions/DE.yml
@@ -27,5 +27,18 @@ example_address:
 format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
+format_extended:
+  edit: "{country}_{firstName}{lastName}_{company}_{streetName}{streetNumber}_{address2}_{zip}{city}_{phone}"
+additional_address_fields:
+  - name: streetName
+    required: true
+  - name: streetNumber
+    required: true
+combined_address_format:
+  default:
+    address1:
+      - key: streetName
+      - key: streetNumber
+        decorator: " "
 emoji: "\U0001F1E9\U0001F1EA"
 timezone: Europe/Berlin


### PR DESCRIPTION
### What are you trying to accomplish?
It is common in Germany for the address form to separate the `streetName` and `streetNumber`, as well as enforce requirements on each field. 

This PR adds additional field configuration for Germany. 

part of the work to extend additional field support in Germany - https://github.com/Shopify/address/issues/574

### What approach did you choose and why?
Introduced to DE.yml
- format_extended
- additional_address_fields
  - streetName, required
  - streetNumber, required
- combined_address_format
  - result is `streetName[space]streetNumber` 

### What should reviewers focus on?
<!--
Outline anything you'd like reviewers to pay extra attention to. List open questions for discussion.
-->

...

### The impact of these changes


### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

...

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
