### PR TITLE
Improve Copy-on-Write friendliness

### DIFF
--- a/lib/worldwide.rb
+++ b/lib/worldwide.rb
@@ -17,8 +17,8 @@ require "worldwide/address_validator"
 require "worldwide/calendar"
 require "worldwide/cldr"
 require "worldwide/cldr/context_transforms"
-require "worldwide/currencies"
 require "worldwide/currency"
+require "worldwide/currencies"
 require "worldwide/deprecated_time_zone_mapper"
 require "worldwide/discounts"
 require "worldwide/fields"
@@ -109,4 +109,6 @@ module Worldwide
       Units
     end
   end
+
+  Regions.instance # eagerload
 end

--- a/lib/worldwide/calendar.rb
+++ b/lib/worldwide/calendar.rb
@@ -4,32 +4,27 @@ require "worldwide/calendar/gregorian"
 
 module Worldwide
   module Calendar
+    data = YAML.load_file(File.join(Worldwide::Paths::CLDR_ROOT, "week_data.yml"))["first_day"]
+    weekday_numbers = {
+      sun: 0,
+      mon: 1,
+      tue: 2,
+      wed: 3,
+      thu: 4,
+      fri: 5,
+      sat: 6,
+    }
+    FIRST_DAY_DATA = data.each_with_object({}) do |(day, territories), memo|
+      territories.each do |territory|
+        memo[territory.to_sym] = weekday_numbers.fetch(day.to_sym)
+      end
+    end
+    FIRST_DAY_DATA.freeze
+    private_constant :FIRST_DAY_DATA
+
     class << self
       def first_week_day(territory_code)
-        first_day_data[territory_code.to_sym] || first_day_data.fetch(:"001")
-      end
-
-      private
-
-      def first_day_data
-        return @first_day_data if defined?(@first_day_data)
-
-        weekday_numbers = {
-          sun: 0,
-          mon: 1,
-          tue: 2,
-          wed: 3,
-          thu: 4,
-          fri: 5,
-          sat: 6,
-        }
-
-        data = YAML.load_file(File.join(Worldwide::Paths::CLDR_ROOT, "week_data.yml"))["first_day"]
-        @first_day_data = data.each_with_object({}) do |(day, territories), memo|
-          territories.each do |territory|
-            memo[territory.to_sym] = weekday_numbers.fetch(day.to_sym)
-          end
-        end
+        FIRST_DAY_DATA[territory_code.to_sym] || FIRST_DAY_DATA.fetch(:"001")
       end
     end
   end

--- a/lib/worldwide/cldr/fallbacks.rb
+++ b/lib/worldwide/cldr/fallbacks.rb
@@ -26,7 +26,10 @@ module Worldwide
       private
 
       def cldr_defined_parents
-        @cldr_defined_parents ||= YAML.load_file(File.join(Worldwide::Paths::CLDR_ROOT, "parent_locales.yml")).to_h { |k, v| [k.to_sym, v.to_sym] }
+        @cldr_defined_parents ||= YAML.load_file(
+          File.join(Worldwide::Paths::CLDR_ROOT, "parent_locales.yml"),
+          symbolize_names: true,
+        ).transform_values(&:to_sym)
       end
 
       def ancestry(locale)

--- a/lib/worldwide/locale.rb
+++ b/lib/worldwide/locale.rb
@@ -2,13 +2,6 @@
 
 module Worldwide
   class Locale
-    class << self
-      def unknown
-        # Special CLDR value
-        @unknown = Locale.new("und")
-      end
-    end
-
     attr_reader :code
 
     def initialize(code)
@@ -19,6 +12,10 @@ module Worldwide
       @code = code.to_sym
       @name_cache = {}
     end
+
+    # Special CLDR value
+    @unknown = new("und")
+    singleton_class.attr_reader(:unknown)
 
     def language_subtag
       code.to_s.split("-", 2).first

--- a/lib/worldwide/regions_loader.rb
+++ b/lib/worldwide/regions_loader.rb
@@ -287,7 +287,7 @@ module Worldwide
     end
 
     def world_yml
-      @world_yml ||= YAML.load_file(File.join(Worldwide::Paths::DB_DATA_ROOT, "world.yml"))
+      @world_yml ||= YAML.load_file(File.join(Worldwide::Paths::DB_DATA_ROOT, "world.yml"), freeze: true)
     end
   end
 end


### PR DESCRIPTION
Lazily loading data files is an anti-pattern:

```ruby
module Currencies
  extend self

  def currency_codes
    @currency_codes ||= YAML.safe_load_file(CURRENCY_CODES_FILE_PATH)
  end
end
```

Here if `currency_codes` is never called during boot, it means that it will be loaded by the first request that needs it, meaning:

  - A slower first call, responsible for "shark fin" looking latency graph around deploys.
  - The same data being loaded up to 32 times instead of once per pod (in core).
  - The same data using 32 times as much memory because it's not in CoW regions.
  - Will cause unecessary work for the GC because it won't immediately be in the old generation.
  - Will cause the memory of pods to grow over time looking like a leak.

If such data will be loaded anyway, it's much better to load it upfront and essentially make it a boot defined constant.

Additionally, for this kind of data, it's best to pass `freeze: true`, to `YAML.load_file` so it can deduplicate strings.

Here I fixed the most obvious occurences of that problem, but there are a few left, like `@currencies_cache` and `@locales_cache`.
