### PR TITLE
neighborhood required in BR, cut v1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Security in case of vulnerabilities.
 
 ## [Unreleased]
-- add support for additional address fields streetName, streetNumber in DE [#273](https://github.com/Shopify/worldwide/pull/273)
+- Nil.
 
 ---
+
+## [1.9.0] - 2024-08-12
+- add support for additional address fields streetName, streetNumber in DE [#273](https://github.com/Shopify/worldwide/pull/273)
+- set additional_field neighborhood as required in BR [#279](https://github.com/Shopify/worldwide/pull/279)
+
 
 ## [1.8.0] - 2024-08-09
 - Bump Ruby to 3.3.1; drop support for 3.0.x [#264](https://github.com/Shopify/worldwide/pull/264)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (1.8.0)
+    worldwide (1.9.0)
       activesupport (>= 7.0)
       i18n
       phonelib (~> 0.8)

--- a/db/data/regions/BR.yml
+++ b/db/data/regions/BR.yml
@@ -35,6 +35,7 @@ additional_address_fields:
     required: true
   - name: line2
   - name: neighborhood
+    required: true
 combined_address_format:
   default:
     address1:

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "1.8.0"
+  VERSION = "1.9.0"
 end

--- a/test/worldwide/region_test.rb
+++ b/test/worldwide/region_test.rb
@@ -444,7 +444,7 @@ module Worldwide
     test "additional_address_fields returns values as expected" do
       [
         [:us, []],
-        [:br, [{ "name" => "streetName", "required" => true }, { "name" => "streetNumber", "required" => true }, { "name" => "line2" }, { "name" => "neighborhood" }]],
+        [:br, [{ "name" => "streetName", "required" => true }, { "name" => "streetNumber", "required" => true }, { "name" => "line2" }, { "name" => "neighborhood", "required" => true }]],
         [:be, [{ "name" => "streetName", "required" => true }, { "name" => "streetNumber", "required" => true }]],
         [:id, [{ "name" => "line2" }, { "name" => "neighborhood" }]],
         [:tr, [{ "name" => "line2" }, { "name" => "neighborhood", "required" => true }]],


### PR DESCRIPTION
### What are you trying to accomplish?
Make neighborhood required in Brazil. 
Cut a new version of worldwide. 

part of https://github.com/Shopify/address/issues/2705

### What approach did you choose and why?
Configured the neighborhood field as required 

### What should reviewers focus on?


### The impact of these changes
None until the new version of WW is cut and released. 

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

...

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
