### PR TITLE
Add address1 Regex for remaining countries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 - Add address1_regex to regions [#281](https://github.com/Shopify/worldwide/pull/281)
+- Add address1_regex for BE, CL, MX, ES, IL [#282](https://github.com/Shopify/worldwide/pull/282)
 
 ---
 

--- a/db/data/regions/BE.yml
+++ b/db/data/regions/BE.yml
@@ -31,6 +31,9 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 format_extended:
   edit: "{country}_{firstName}{lastName}_{company}_{streetName}{streetNumber}_{address2}_{zip}{city}_{phone}"
+address1_regex:
+  - "^(?<streetName>[^\\d,]+),? (?<streetNumber>\\d+(?: ?[a-z])?)$"
+  - "^(?<streetNumber>\\d+(?: ?[a-z])?),? (?<streetName>[^\\d,]+)$"
 additional_address_fields:
   - name: streetName
     required: true

--- a/db/data/regions/BR.yml
+++ b/db/data/regions/BR.yml
@@ -28,6 +28,8 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city} {province}_{country}_{phone}"
 format_extended:
   edit: "{country}_{firstName}{lastName}_{company}_{zip}_{streetName}{streetNumber}_{line2}{neighborhood}_{city}{province}_{phone}"
+address1_regex:
+  - "^(?<streetName>(?!.*\\bnúmero\\b)[^\\d,]+(?<!\\s))(?:,? ?)(?<streetNumber>\\d+(?: ?[a-z])?)$"
 additional_address_fields:
   - name: streetName
     required: true

--- a/db/data/regions/CL.yml
+++ b/db/data/regions/CL.yml
@@ -16,6 +16,8 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{province}_{country}_{phone}"
 format_extended:
   edit: "{country}_{firstName}{lastName}_{company}_{streetName}{streetNumber}_{line2}{neighborhood}_{zip}{city}_{province}_{phone}"
+address1_regex:
+  - "^(?<streetName>[^\\d,]+?),? (?<streetNumber>(?:n|n\\.|nº|número|no\\.|no|#)? ?\\d+(?: ?[a-z])?)$"
 additional_address_fields:
   - name: streetName
     required: true

--- a/db/data/regions/ES.yml
+++ b/db/data/regions/ES.yml
@@ -29,6 +29,8 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{province}_{country}_{phone}"
 format_extended:
   edit: "{country}_{firstName}{lastName}_{company}_{streetName}{streetNumber}_{address2}_{zip}{city}{province}_{phone}"
+address1_regex:
+  - "^(?<streetName>[^\\d,]+?),? (?<streetNumber>(?:n|n\\.|nº|número|no\\.|no|#)? ?\\d+(?: ?[a-z])?)$"
 additional_address_fields:
   - name: streetName
     required: true

--- a/db/data/regions/IL.yml
+++ b/db/data/regions/IL.yml
@@ -18,6 +18,9 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
 format_extended:
   edit: "{country}_{firstName}{lastName}_{company}_{streetName}{streetNumber}_{address2}_{zip}{city}_{phone}"
+address1_regex:
+  - "^(?<streetName>[^\\d,]+),? (?<streetNumber>\\d+(?:\/\\d+)?)$"
+  - "^(?<streetNumber>\\d+(?:\/\\d+)?),? (?<streetName>[^\\d,]+)$"
 additional_address_fields:
   - name: streetName
     required: true

--- a/db/data/regions/MX.yml
+++ b/db/data/regions/MX.yml
@@ -17,6 +17,8 @@ format:
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city} {province}_{country}_{phone}"
 format_extended:
   edit: "{country}_{firstName}{lastName}_{company}_{streetName}{streetNumber}_{line2}{neighborhood}_{zip}{city}{province}_{phone}"
+address1_regex:
+  - "^(?<streetName>[^\\d,]+?),? (?<streetNumber>(?:n|n\\.|nº|número|no\\.|no|#)? ?\\d+(?: ?[a-z])?)$"
 additional_address_fields:
   - name: streetName
     required: true

--- a/db/data/regions/NL.yml
+++ b/db/data/regions/NL.yml
@@ -31,7 +31,7 @@ format:
 format_extended:
   edit: "{country}_{firstName}{lastName}_{company}_{streetName}{streetNumber}_{address2}_{zip}{city}_{phone}"
 address1_regex:
-  - "^(?<streetName>[^\\d]+) (?<streetNumber>\\d+(?:\\s?[A-za-z])?)$"
+  - "^(?<streetName>[^\\d]+) (?<streetNumber>\\d+(?: ?[a-z])?)$"
 additional_address_fields:
   - name: streetName
     required: true

--- a/lang/typescript/src/extended-address/splitAddress1.test.ts
+++ b/lang/typescript/src/extended-address/splitAddress1.test.ts
@@ -95,29 +95,249 @@ describe('splitAddress1', () => {
 
   test.each([
     {
-      country: 'NL',
       address: 'Mercuriusstraat 26',
       expected: {streetName: 'Mercuriusstraat', streetNumber: '26'},
     },
     {
-      country: 'NL',
       address: 'Bloemgracht 41B',
       expected: {streetName: 'Bloemgracht', streetNumber: '41B'},
     },
     {
-      country: 'NL',
       address: 'Bloemgracht 41b',
       expected: {streetName: 'Bloemgracht', streetNumber: '41b'},
     },
     {
-      country: 'NL',
       address: 'Meester Arendstraat 48 B',
       expected: {streetName: 'Meester Arendstraat', streetNumber: '48 B'},
     },
   ])(
-    'returns full address object when not separated by delimiter, tryRegexFallback is true and address matches regex',
-    ({country, address, expected}) => {
-      expect(splitAddress1(country, address, true)).toEqual(expected);
+    'returns full address object when not separated by delimiter, tryRegexFallback is true and address matches regex for NL',
+    ({address, expected}) => {
+      expect(splitAddress1('NL', address, true)).toEqual(expected);
+    },
+  );
+
+  test.each([
+    {
+      address: 'Doornbergstraat 30',
+      expected: {streetName: 'Doornbergstraat', streetNumber: '30'},
+    },
+    {
+      address: 'Moeskouterlaan, 29',
+      expected: {streetName: 'Moeskouterlaan', streetNumber: '29'},
+    },
+    {
+      address: 'Rue le Marais 6A',
+      expected: {streetName: 'Rue le Marais', streetNumber: '6A'},
+    },
+    {
+      address: 'Kiezelstraat 4a',
+      expected: {streetName: 'Kiezelstraat', streetNumber: '4a'},
+    },
+    {
+      address: 'Rue Grand Peine 12 C',
+      expected: {streetName: 'Rue Grand Peine', streetNumber: '12 C'},
+    },
+    {
+      address: '85 Rue des Floralies',
+      expected: {streetName: 'Rue des Floralies', streetNumber: '85'},
+    },
+    {
+      address: '39, rue de Grass',
+      expected: {streetName: 'rue de Grass', streetNumber: '39'},
+    },
+    {
+      address: '84 a Rue du merlo',
+      expected: {streetName: 'Rue du merlo', streetNumber: '84 a'},
+    },
+    {
+      address: '84A Rue du merlo',
+      expected: {streetName: 'Rue du merlo', streetNumber: '84A'},
+    },
+  ])(
+    'returns full address object when not separated by delimiter, tryRegexFallback is true and address matches regex for BE',
+    ({address, expected}) => {
+      expect(splitAddress1('BE', address, true)).toEqual(expected);
+    },
+  );
+
+  test.each([
+    {
+      address: 'Alberto Risopatrón 2714',
+      expected: {streetName: 'Alberto Risopatrón', streetNumber: '2714'},
+    },
+    {
+      address: 'avenida nelson pereira, 1741',
+      expected: {streetName: 'avenida nelson pereira', streetNumber: '1741'},
+    },
+    {
+      address: 'Rancho las Cabras 9A',
+      expected: {streetName: 'Rancho las Cabras', streetNumber: '9A'},
+    },
+    {
+      address: 'Callejón Torreblanca 355 B',
+      expected: {streetName: 'Callejón Torreblanca', streetNumber: '355 B'},
+    },
+    {
+      address: 'Quebrada de Vitor #1234',
+      expected: {streetName: 'Quebrada de Vitor', streetNumber: '#1234'},
+    },
+    {
+      address: 'Barros Arana # 1298',
+      expected: {streetName: 'Barros Arana', streetNumber: '# 1298'},
+    },
+    {
+      address: 'Calle Amalia Errazuriz Nº956',
+      expected: {streetName: 'Calle Amalia Errazuriz', streetNumber: 'Nº956'},
+    },
+    {
+      address: 'Calle Amalia Errazuriz Nº 956',
+      expected: {streetName: 'Calle Amalia Errazuriz', streetNumber: 'Nº 956'},
+    },
+    {
+      address: 'Calle Amalia Errazuriz nº956',
+      expected: {streetName: 'Calle Amalia Errazuriz', streetNumber: 'nº956'},
+    },
+    {
+      address: 'Calle Amalia Errazuriz nº 956',
+      expected: {streetName: 'Calle Amalia Errazuriz', streetNumber: 'nº 956'},
+    },
+    {
+      address: 'Calle Amalia Errazuriz no956',
+      expected: {streetName: 'Calle Amalia Errazuriz', streetNumber: 'no956'},
+    },
+    {
+      address: 'Calle Amalia Errazuriz no 956',
+      expected: {streetName: 'Calle Amalia Errazuriz', streetNumber: 'no 956'},
+    },
+    {
+      address: 'Calle Amalia Errazuriz No956',
+      expected: {streetName: 'Calle Amalia Errazuriz', streetNumber: 'No956'},
+    },
+    {
+      address: 'Calle Amalia Errazuriz No 956',
+      expected: {streetName: 'Calle Amalia Errazuriz', streetNumber: 'No 956'},
+    },
+    {
+      address: 'Calle Amalia Errazuriz no.956',
+      expected: {streetName: 'Calle Amalia Errazuriz', streetNumber: 'no.956'},
+    },
+    {
+      address: 'Calle Amalia Errazuriz no. 956',
+      expected: {streetName: 'Calle Amalia Errazuriz', streetNumber: 'no. 956'},
+    },
+    {
+      address: 'Calle Amalia Errazuriz No.956',
+      expected: {streetName: 'Calle Amalia Errazuriz', streetNumber: 'No.956'},
+    },
+    {
+      address: 'Calle Amalia Errazuriz No. 956',
+      expected: {streetName: 'Calle Amalia Errazuriz', streetNumber: 'No. 956'},
+    },
+    {
+      address: 'Calle Amalia Errazuriz número 956',
+      expected: {
+        streetName: 'Calle Amalia Errazuriz',
+        streetNumber: 'número 956',
+      },
+    },
+    {
+      address: 'Calle Amalia Errazuriz Número 956',
+      expected: {
+        streetName: 'Calle Amalia Errazuriz',
+        streetNumber: 'Número 956',
+      },
+    },
+  ])(
+    'returns full address object when not separated by delimiter, tryRegexFallback is true and address matches regex for CL, MX, ES',
+    ({address, expected}) => {
+      expect(splitAddress1('CL', address, true)).toEqual(expected);
+      expect(splitAddress1('MX', address, true)).toEqual(expected);
+      expect(splitAddress1('ES', address, true)).toEqual(expected);
+    },
+  );
+
+  test.each([
+    {
+      address: 'פטישן 22',
+      expected: {streetName: 'פטישן', streetNumber: '22'},
+    },
+    {
+      address: 'שבזי שלום 9',
+      expected: {streetName: 'שבזי שלום', streetNumber: '9'},
+    },
+    {
+      address: 'חרצית, 5',
+      expected: {streetName: 'חרצית', streetNumber: '5'},
+    },
+    {
+      address: 'חרצית, 500',
+      expected: {streetName: 'חרצית', streetNumber: '500'},
+    },
+    {
+      address: '21, הדקל',
+      expected: {streetName: 'הדקל', streetNumber: '21'},
+    },
+    {
+      address: '1, קיבוץ גבים',
+      expected: {streetName: 'קיבוץ גבים', streetNumber: '1'},
+    },
+    {
+      address: '47/2, המגינים',
+      expected: {streetName: 'המגינים', streetNumber: '47/2'},
+    },
+    {
+      address: 'רבי יהודה הנשיא 30/16',
+      expected: {streetName: 'רבי יהודה הנשיא', streetNumber: '30/16'},
+    },
+    {
+      address: 'St. Ben Ami 24',
+      expected: {streetName: 'St. Ben Ami', streetNumber: '24'},
+    },
+    {
+      address: 'Shevet Zvulun, 2',
+      expected: {streetName: 'Shevet Zvulun', streetNumber: '2'},
+    },
+  ])(
+    'returns full address object when not separated by delimiter, tryRegexFallback is true and address matches regex for IL',
+    ({address, expected}) => {
+      expect(splitAddress1('IL', address, true)).toEqual(expected);
+    },
+  );
+
+  test.each([
+    {
+      address: 'Rua Santo Antônio 722',
+      expected: {streetName: 'Rua Santo Antônio', streetNumber: '722'},
+    },
+    {
+      address: 'Rua Santo Antônio, 722',
+      expected: {streetName: 'Rua Santo Antônio', streetNumber: '722'},
+    },
+    {
+      address: 'Rua Santo Antônio,722',
+      expected: {streetName: 'Rua Santo Antônio', streetNumber: '722'},
+    },
+    {
+      address: 'Rua Corumbá 47 A',
+      expected: {streetName: 'Rua Corumbá', streetNumber: '47 A'},
+    },
+    {
+      address: 'Rua Corumbá 47A',
+      expected: {streetName: 'Rua Corumbá', streetNumber: '47A'},
+    },
+    {
+      address: 'Rua Corumbá 47A',
+      expected: {streetName: 'Rua Corumbá', streetNumber: '47A'},
+    },
+    {
+      address: 'Rua Nair Costa Baldoino - número: 449',
+      expected: {streetName: 'Rua Nair Costa Baldoino - número: 449'},
+    },
+  ])(
+    'returns full address object when not separated by delimiter, tryRegexFallback is true and address matches regex for BR',
+    ({address, expected}) => {
+      expect(splitAddress1('BR', address, true)).toEqual(expected);
     },
   );
 });

--- a/lang/typescript/src/utils/regions.ts
+++ b/lang/typescript/src/utils/regions.ts
@@ -110,5 +110,5 @@ export function getAddress1Regex(config: RegionYamlConfig): RegExp[] {
     return [];
   }
 
-  return config.address1_regex.map((pattern) => new RegExp(pattern));
+  return config.address1_regex.map((pattern) => new RegExp(pattern, 'i'));
 }

--- a/test/worldwide/region_test.rb
+++ b/test/worldwide/region_test.rb
@@ -456,7 +456,8 @@ module Worldwide
     test "address1_regex returns values as expected" do
       [
         [:us, []],
-        [:nl, ["^(?<streetName>[^\\d]+) (?<streetNumber>\\d+(?:\\s?[A-za-z])?)$"]],
+        [:nl, ["^(?<streetName>[^\\d]+) (?<streetNumber>\\d+(?: ?[a-z])?)$"]],
+        [:be, ["^(?<streetName>[^\\d,]+),? (?<streetNumber>\\d+(?: ?[a-z])?)$", "^(?<streetNumber>\\d+(?: ?[a-z])?),? (?<streetName>[^\\d,]+)$"]],
       ].each do |region_code, expected_value|
         assert_equal expected_value, Worldwide.region(code: region_code).address1_regex
       end


### PR DESCRIPTION
### What are you trying to accomplish?

Follow up to https://github.com/Shopify/worldwide/pull/281

Adds address1 regex for remaining countries with additional address fields in address1: Belgium, Chile, Mexico, Spain, Brazil, Israel

### What approach did you choose and why?

The regexes are as conservative as possible to avoid false matches.

Across the board, we don't match:
- street names that have numbers in them
- street names that have commas in them
- address lines with unit/extra information

| Country | Match %  |  Examples |  Limitations |
|---|---|---|---|
| Netherlands | 79% | https://rubular.com/r/iDIl0pimmKzdcD|  |
| Belgium  | 78%  |  https://rubular.com/r/Lpl5UoG5DAe2KO, https://rubular.com/r/VVQ2TgIeIOUcov |  |
|  Israel | 62% | https://rubular.com/r/G0T4Rtdxvyi1Sr, https://rubular.com/r/09zrJoLuHaDEdn | We should confirm that the RTL parsing behaves as expected with addresses coming from checkout  |   |
|  Chile | 59%  | https://rubular.com/r/qshIYvKnvE07lk  | Many addresses contain unit/extra info  |   |
|  Spain | 44%  | https://rubular.com/r/7GHfi7Iuz7o2XN | Many addresses contain unit/extra info |
|  Mexico | 40%  | https://rubular.com/r/tZ5Cg2MtmL2B00  | Many addresses contain unit/extra info  |
|  Brazil | 32% | https://rubular.com/r/kIIieK5nTAn1FP | Neighbourhood often in address1 |

### What should reviewers focus on?

Can the regex be simplified? Have I overlooked any false/incorrect matches that could occur?

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
