### PR TITLE
Map deprecated timezone `Europe/Kiev` to `Europe/Kyiv`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add address1_regex to regions [#281](https://github.com/Shopify/worldwide/pull/281)
 - Add address1_regex for BE, CL, MX, ES, IL [#282](https://github.com/Shopify/worldwide/pull/282)
 - Add address1_regex for DE [#286](https://github.com/Shopify/worldwide/pull/286)
+- Update legacy timezone mappings for Europe/Kiev [#288](https://github.com/Shopify/worldwide/pull/288)
+
 
 ---
 

--- a/lib/worldwide/deprecated_time_zone_mapper.rb
+++ b/lib/worldwide/deprecated_time_zone_mapper.rb
@@ -57,6 +57,7 @@ module Worldwide
       "Etc/UCT": "UTC",
       "Etc/Universal": "UTC",
       "Etc/Zulu": "UTC",
+      "Europe/Kiev": "Europe/Kyiv",
       GB: "Europe/London",
       "GB-Eire": "Europe/London",
       "GMT+0": "Etc/GMT",


### PR DESCRIPTION
### What are you trying to accomplish?

Map deprecated timezone `Europe/Kiev` to `Europe/Kyiv`

similar - https://github.com/Shopify/worldwide/pull/267

### The impact of these changes

These timezones are still present in our systems and need to be mapped to the correct values.


### Testing

n/a

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
