### PR TITLE
Configure Regexp timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Security in case of vulnerabilities.
 
 ## [Unreleased]
-
+- Nil.
 ---
+
+## [1.11.1] - 2024-10-02
+- Configure regexp timeout in Worldwide#Phone [#290](https://github.com/Shopify/worldwide/pull/290)
 
 ## [1.11.0] - 2024-10-02
 - Add address1_regex to regions [#281](https://github.com/Shopify/worldwide/pull/281)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (1.11.0)
+    worldwide (1.11.1)
       activesupport (>= 7.0)
       i18n
       phonelib (~> 0.8)

--- a/lib/worldwide/phone.rb
+++ b/lib/worldwide/phone.rb
@@ -137,13 +137,18 @@ module Worldwide
       number = input.downcase
 
       ["ext", "x", ";"].each do |separator|
-        if number.include?(separator)
-          m = number.match(Regexp.new("(?<base>[0-9a-z +-]*)\\s*#{separator}\\.?\\s*(?<ext>.*)"))
-          return [m["base"], m["ext"]] unless m.nil?
-        end
+        next unless number.include?(separator)
+
+        m = number.match(Regexp.new(
+          "(?<base>[0-9a-z +-]*)\\s*#{separator}\\.?\\s*(?<ext>.*)",
+          timeout: 1,
+        ))
+        return [m["base"], m["ext"]] unless m.nil?
       end
 
       # If we get this far, then we have not found an extension, and assume that the full input is just a public number
+      [input, nil]
+    rescue Regexp::TimeoutError
       [input, nil]
     end
 

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "1.11.0"
+  VERSION = "1.11.1"
 end


### PR DESCRIPTION
### What are you trying to accomplish?
As raised [via bugbounty ](https://bugbounty.shopify.io/reports/2637251), the Phone parsing class is susceptible to ReDos attacks when running on Ruby 3.1. 

Note the Regexp class was reworked and this issue fixed in Ruby 3.2. 
Ruby 3.1 is in maintenance with an expected EOL in April 2025, [ref](https://www.ruby-lang.org/en/downloads/branches/). 

closes https://github.com/Shopify/address/issues/2703
closes servicesDb action item: https://services.shopify.io/action-items/instances/70533

### What approach did you choose and why?
This article [outlines several options](https://blog.kiprosh.com/ruby-3-2-0-introduce/). 

Decided to simply add a Regexp [timeout](https://ruby-doc.org/3.3.5/Regexp.html#class-Regexp-label-Timeouts)


### The impact of these changes
Regexp will timeout after 1 second, and the split_extension method will return the input, unspilt from any extension. 

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
