### PR TITLE
Handle multiple word joiners when splitting addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Nil.
 ---
 
+## [1.12.0] - 2024-10-11
+- Update Address splitting methods to split on the first delimiter [#291](https://github.com/Shopify/worldwide/pull/291)
+
 ## [1.11.1] - 2024-10-02
 - Configure regexp timeout in Worldwide#Phone [#290](https://github.com/Shopify/worldwide/pull/290)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (1.11.1)
+    worldwide (1.12.0)
       activesupport (>= 7.0)
       i18n
       phonelib (~> 0.8)

--- a/lang/typescript/.changeset/address-split-multi-word-joiners.md
+++ b/lang/typescript/.changeset/address-split-multi-word-joiners.md
@@ -1,0 +1,5 @@
+---
+'@shopify/worldwide': patch
+---
+
+Handle input having multiple word joiners in address-splitting functions

--- a/lang/typescript/src/extended-address/splitAddress1.test.ts
+++ b/lang/typescript/src/extended-address/splitAddress1.test.ts
@@ -82,6 +82,13 @@ describe('splitAddress1', () => {
     });
   });
 
+  test('splits the address on the first delimiter', () => {
+    expect(splitAddress1('CL', 'Main \u2060123\u2060abc', false)).toEqual({
+      streetName: 'Main',
+      streetNumber: '123\u2060abc',
+    });
+  });
+
   test('returns full address object when separated by delimiter and decorator', () => {
     expect(splitAddress1('BR', 'Main, \u2060123', false)).toEqual({
       streetName: 'Main',

--- a/lang/typescript/src/extended-address/splitAddress2.test.ts
+++ b/lang/typescript/src/extended-address/splitAddress2.test.ts
@@ -38,6 +38,13 @@ describe('splitAddress2', () => {
     });
   });
 
+  test('splits the address on the first delimiter', () => {
+    expect(splitAddress2('CL', 'dpto 4 \u2060Centro\u2060abc')).toEqual({
+      line2: 'dpto 4',
+      neighborhood: 'Centro\u2060abc',
+    });
+  });
+
   describe('language override', () => {
     test("returns default format if language override doesn't match", () => {
       expect(splitAddress2('TW', '30號\u2060大甲區')).toEqual({

--- a/lang/typescript/src/utils/address-fields.ts
+++ b/lang/typescript/src/utils/address-fields.ts
@@ -45,10 +45,12 @@ export function splitAddressField(
   fieldDefinition: FieldConcatenationRule[],
   concatenatedAddress: string,
 ): Partial<Address> {
-  const values = concatenatedAddress.split(RESERVED_DELIMITER);
+  const [firstField, ...rest] = concatenatedAddress.split(RESERVED_DELIMITER);
+  const secondField = rest.join(RESERVED_DELIMITER);
+  const values = [firstField, secondField];
 
-  const parsedAddressObject = values.reduce((obj, value, index) => {
-    if (value !== '') {
+  const parsedAddressObject = fieldDefinition.reduce((obj, field, index) => {
+    if (values[index]) {
       // Decorator is included as a suffix in the previous sub-field value,
       // so we need to strip it from the current field by looking ahead at the
       // next field's definition
@@ -57,12 +59,15 @@ export function splitAddressField(
       const fieldValue =
         nextFieldDecorator &&
         nextFieldDecorator.length > 0 &&
-        value.endsWith(nextFieldDecorator)
-          ? value.substring(0, value.length - nextFieldDecorator.length)
-          : value;
+        values[index].endsWith(nextFieldDecorator)
+          ? values[index].substring(
+              0,
+              values[index].length - nextFieldDecorator.length,
+            )
+          : values[index];
       return {
         ...obj,
-        [fieldDefinition[index].key]: fieldValue,
+        [field.key]: fieldValue,
       };
     }
 

--- a/lib/worldwide/address.rb
+++ b/lib/worldwide/address.rb
@@ -167,13 +167,15 @@ module Worldwide
 
     def split_address1
       additional_fields = region.combined_address_format.dig(script_from_string(address1), "address1") || []
-      split_fields_arr = address1&.split(RESERVED_DELIMITER) || []
+      number_of_fields = additional_fields.size
+      split_fields_arr = address1&.split(RESERVED_DELIMITER, number_of_fields) || []
       split_fields(additional_fields, split_fields_arr)
     end
 
     def split_address2
       additional_fields = region.combined_address_format.dig(script_from_string(address2), "address2") || []
-      split_fields_arr = address2&.split(RESERVED_DELIMITER) || []
+      number_of_fields = additional_fields.size
+      split_fields_arr = address2&.split(RESERVED_DELIMITER, number_of_fields) || []
       split_fields(additional_fields, split_fields_arr)
     end
 

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "1.11.1"
+  VERSION = "1.12.0"
 end

--- a/test/worldwide/address_test.rb
+++ b/test/worldwide/address_test.rb
@@ -251,6 +251,13 @@ module Worldwide
       assert_equal expected_hash, address.split_address1
     end
 
+    test "split_address1 splits on the first delimiter" do
+      address = Address.new(address1: "Main Street⁠123⁠ n° 145", country_code: "BR")
+      expected_hash = { "street_name" => "Main Street", "street_number" => "123⁠ n° 145" }
+
+      assert_equal expected_hash, address.split_address1
+    end
+
     test "split_address1 returns only street number if no string is present before the delimiter" do
       cl_address = Address.new(address1: "⁠123", country_code: "CL")
       br_address = Address.new(address1: "⁠123", country_code: "BR")
@@ -347,6 +354,13 @@ module Worldwide
 
       assert_equal expected_hash, cl_address.split_address2
       assert_equal expected_hash, br_address.split_address2
+    end
+
+    test "split_address2 splits on the first delimiter" do
+      address = Address.new(address2: "1樓⁠士林區⁠123", country_code: "TW")
+      expected_hash = { "line2" => "1樓", "neighborhood" => "士林區⁠123" }
+
+      assert_equal expected_hash, address.split_address2
     end
 
     test "split_address2 returns line2 and neighborhood when both values are present and separated by a delimiter" do


### PR DESCRIPTION
### What are you trying to accomplish?

Our `splitAddress1` & `splitAddress2` functions in the TS package do not handle cases where the input has multiple word joiners:

<img width="982" alt="Screenshot 2024-10-10 at 12 06 05 PM" src="https://github.com/user-attachments/assets/6b4ba1db-94e5-4fd9-9d43-b8ecee4c84f7">

<img width="725" alt="Screenshot 2024-10-10 at 9 23 43 AM" src="https://github.com/user-attachments/assets/9224afc8-1a78-440b-86c8-bba7b2f98c1c">

part of https://github.com/Shopify/address/issues/2783
### What approach did you choose and why?

Update the TS and ruby functions to split on the first delimiter. 
- everything before the first word joiner will go into streetName || line2
- everything after will go into streetNumber || neighborhood 

Previously, the ruby implementation would split on each occurrence of the delimiter, and keep only the first 2 results. 
example address1: `Museumstraat <wj>1 <wj> apt 4`

**Before:**
streetName: `Museumstraat`
streetNumber: `1`

**After:**
streetName: `Museumstraat`
streetNumber: `1 <wj> apt 4`

Cut new version of the ruby gem and [added a changeset](https://github.com/Shopify/worldwide/tree/main/lang/typescript#adding-a-changelog) for the typescript package update.

### Testing

[spin instance](https://shop1.shopify.oct11.dominique-flabbi.us.spin.dev/checkouts/cn/Z2NwLXVzLWNlbnRyYWwxOjAxSjlZMjlSSFQ4Vk1KSlhRUVFCV0dINVYy)

[checkout-web branch for testing
](https://github.com/Shopify/checkout-web/pull/39046)

✅ Verified a successful checkout with the new implementation 

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
