### PR TITLE
Remove lookbehind from BR address1_regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Nil.
 ---
 
+## [1.12.1] - 2024-10-15
+- Update BR address1_regex to remove lookbehinds [#](https://github.com/Shopify/worldwide/pull/)
+
 ## [1.12.0] - 2024-10-11
 - Update Address splitting methods to split on the first delimiter [#291](https://github.com/Shopify/worldwide/pull/291)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (1.12.0)
+    worldwide (1.12.1)
       activesupport (>= 7.0)
       i18n
       phonelib (~> 0.8)

--- a/db/data/regions/BR.yml
+++ b/db/data/regions/BR.yml
@@ -29,7 +29,7 @@ format:
 format_extended:
   edit: "{country}_{firstName}{lastName}_{company}_{zip}_{streetName}{streetNumber}_{line2}{neighborhood}_{city}{province}_{phone}"
 address1_regex:
-  - "^(?<streetName>(?!.*\\bnúmero\\b)[^\\d,]+(?<!\\s))(?:,? ?)(?<streetNumber>\\d+(?: ?[a-z])?)$"
+  - "^(?<streetName>(?:[^\\d,\\s]+\\s)*[^\\d,\\s]+)(?:,? ?)(?<streetNumber>\\d+(?: ?[a-z])?)$"
 additional_address_fields:
   - name: streetName
     required: true

--- a/lang/typescript/.changeset/popular-suits-perform.md
+++ b/lang/typescript/.changeset/popular-suits-perform.md
@@ -1,0 +1,5 @@
+---
+'@shopify/worldwide': patch
+---
+
+Update BR address1_regex to remove lookbehinds

--- a/lang/typescript/src/extended-address/splitAddress1.test.ts
+++ b/lang/typescript/src/extended-address/splitAddress1.test.ts
@@ -379,7 +379,10 @@ describe('splitAddress1', () => {
     },
     {
       address: 'Rua Nair Costa Baldoino - número: 449',
-      expected: {streetName: 'Rua Nair Costa Baldoino - número: 449'},
+      expected: {
+        streetName: 'Rua Nair Costa Baldoino - número:',
+        streetNumber: '449',
+      },
     },
   ])(
     'returns full address object when not separated by delimiter, tryRegexFallback is true and address matches regex for BR',

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "1.12.0"
+  VERSION = "1.12.1"
 end

--- a/test/worldwide/region_data_consistency_test.rb
+++ b/test/worldwide/region_data_consistency_test.rb
@@ -213,5 +213,17 @@ module Worldwide
         )
       end
     end
+
+    # lookbehinds are not supported by all browsers, https://caniuse.com/js-regexp-lookbehind
+    test "address1_regex does not contain positive or negative lookbehinds" do
+      Regions.all.select(&:country?).each do |country|
+        next if country.address1_regex.blank?
+
+        country.address1_regex.each do |regex|
+          assert_no_match("?>=", regex, "Positive lookbehind found in #{country.iso_code}")
+          assert_no_match("?>!", regex, "Negative lookbehind found in #{country.iso_code}")
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?
The regex lookbehind is not supported by all browsers, https://caniuse.com/js-regexp-lookbehind

BR's address1_regex contained a negative lookbehind `?<!`, which resulted in browser errors. 

part of https://github.com/Shopify/shopify/issues/545512
### What approach did you choose and why?
Replace address1_regex.

Added a consistency test to ensure positive and negative lookbehinds are not added to `address1_regex`. 

Before: https://rubular.com/r/wtB2VwRpbMQUpo
- 316 matches 
After:  https://rubular.com/r/0Nfxcmpc2Hc3Sk
- 317 matches 

Notably, the new regex has one additional match. 
- Input: `Rua Nair Costa Baldoino - número: 449` 
- streetName: Rua Nair Costa Baldoino - número:
- streetNumber: 449


### What should reviewers focus on?
<!--
Outline anything you'd like reviewers to pay extra attention to. List open questions for discussion.
-->

...

### The impact of these changes
Resolves browser errors when run on Safari <16.4

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

...

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
