### PR TITLE
Move expensive resource initialization into an explicit `eager_load!` namespace method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 - Add `zip_prefixes` for Spain. [#295](https://github.com/Shopify/worldwide/pull/295)
+- Move expensive resource initialization into an explicit `eager_load!` namespace method
+[#297](https://github.com/Shopify/worldwide/pull/297)
 ---
 
 ## [1.12.1] - 2024-10-15

--- a/lib/worldwide.rb
+++ b/lib/worldwide.rb
@@ -39,11 +39,17 @@ require "worldwide/units"
 require "worldwide/util"
 require "worldwide/zip"
 
+require "worldwide/rails/railtie" if defined?(Rails::Railtie)
+
 module Worldwide
   @currencies_cache = {}
   @locales_cache = {}
 
   class << self
+    def eager_load!
+      Regions.instance
+    end
+
     def address(**kwargs)
       Address.new(**kwargs)
     end
@@ -109,6 +115,4 @@ module Worldwide
       Units
     end
   end
-
-  Regions.instance # eagerload
 end

--- a/lib/worldwide/rails/railtie.rb
+++ b/lib/worldwide/rails/railtie.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rails/railtie"
+
+module Worldwide
+  module Rails
+    class Railtie < ::Rails::Railtie
+      initializer "worldwide.setup" do |application|
+        application.config.eager_load_namespaces << Worldwide
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What are you trying to accomplish?
https://github.com/Shopify/worldwide/pull/276 (version 1.10.0) triggered the expensive parsing & instantiation of region yaml files as part of loading the `Worldwide` module. Even on fast machines, this represents a 100ms + operation. Most production-like environments benefit from this forced, early loading step (see original PR), but this should not be forced upon all applications/environments.

### What approach did you choose and why?
Move the `Regions.instance` singleton warmup out of `Worldwide`'s own definition and into a dedicated `Worldwide.eager_load!` class method. 

### The impact of these changes
Non-Rails applications can call `eager_load!` at an appropriate point in their boot sequence, or ignore it entirely.  The gem will lazily load its resources otherwise.

Rails applications will now benefit from a [Railtie](https://api.rubyonrails.org/classes/Rails/Railtie.html) that eagerly loads the `Worldwide` module if the host application's `config.eager_load` is true (default is true in Production and false in other environments).

### Testing
Opened a console in our Rails application in an environment where eager loading is disabled. The breakpoint in `Worldwide:eager_load!` was not reached. The breakpoint in `Worldwide::Regions#initialize` was hit on the first call to `Worldwide.region(code: xx)`.

Reconfigured the host application to eager load and opened a console. The breakpoint in `Worldwide:eager_load!` was reached before the console prompt, and all calls to `Worldwide.region(code: xx)` avoided the `Worldwide::Regions#initialize` breakpoint.

In a plain `irb` session, requiring `worldwide` no longer triggers the loading of all regions.`Worldwide::Regions#initialize` was only called after running `Worldwide.region(code: xx)`. In a second `irb` session, `Worldwide.eager_load!` tiggered the region loading and subsequent region lookups did not.

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
