### PR TITLE
Add Region#example_city_zip and #priority attrs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Security in case of vulnerabilities.
 
 ## [Unreleased]
-- Nil.
+- Add example_city_zip and priority accessors to Regions [#298](https://github.com/Shopify/worldwide/pull/298)
 
 ---
 

--- a/lib/worldwide/region.rb
+++ b/lib/worldwide/region.rb
@@ -17,6 +17,7 @@ module Worldwide
       :building_number_required,
       :currency,
       :example_city,
+      :example_city_zip,
       :example_address,
       :flag,
       :format,
@@ -28,6 +29,7 @@ module Worldwide
       :languages,
       :neighbours,
       :numeric_three,
+      :priority,
       :week_start_day,
       :unit_system,
       :zip_autofill_enabled,
@@ -66,6 +68,13 @@ module Worldwide
 
     # A major city in the given region that can be used as an example
     attr_accessor :example_city
+
+    # A zip code in the given region that can be used as an example; corresponds to example_city
+    attr_accessor :example_city_zip
+
+    # A value that can be used to order zones
+    # Some countries, Japan, for example, customarily order zones non-alphabetically.
+    attr_accessor :priority
 
     # A full address in the given region that can be used as an example
     attr_accessor :example_address

--- a/lib/worldwide/regions_loader.rb
+++ b/lib/worldwide/regions_loader.rb
@@ -132,6 +132,8 @@ module Worldwide
       region.code_alternates = zone["code_alternates"] || []
       region.name_alternates = zone["name_alternates"] || []
       region.example_city = zone["example_city"]
+      region.example_city_zip = zone["example_city_zip"]
+      region.priority = zone["priority"]
       region.neighbours = zone["neighboring_zones"]
       region.zip_prefixes = zone["zip_prefixes"] || []
     end

--- a/test/worldwide/region_test.rb
+++ b/test/worldwide/region_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 module Worldwide
   class RegionTest < ActiveSupport::TestCase
-    test "can initialize a Region with only iso_code" do
+    test "#initialize with only iso_code" do
       region = Region.new(iso_code: "ZZ")
 
       assert_nil region.alpha_three
@@ -26,7 +26,7 @@ module Worldwide
       assert_equal 0, (region.tax_rate * 100).floor
     end
 
-    test "can initialize a Region passing in various parameters" do
+    test "#initialize with various parameters" do
       region = Region.new(
         alpha_three: "AUT",
         continent: false,
@@ -57,7 +57,40 @@ module Worldwide
       assert_equal 20, (region.tax_rate * 100).floor
     end
 
-    test "zones have short names where expected" do
+    test "#initialize sets expected default attributes" do
+      region = Region.new(iso_code: "ZZ")
+
+      assert_empty region.additional_address_fields
+      assert_empty(region.combined_address_format)
+      refute region.building_number_required
+      refute region.building_number_may_be_in_address2
+      assert_nil region.currency
+      assert_nil region.flag
+      assert_empty(region.format)
+      assert_empty(region.format_extended)
+      assert_empty region.name_alternates
+      assert_nil region.group
+      assert_nil region.group_name
+      assert_empty region.languages
+      assert_empty region.neighbours
+      assert_nil region.partial_zip_regex
+      assert_nil region.phone_number_prefix
+      assert_nil region.priority
+      assert_empty region.tags
+      assert_nil region.timezone
+      assert_empty(region.timezones)
+      assert_nil region.unit_system
+      assert_nil region.week_start_day
+      refute region.zip_autofill_enabled
+      assert_nil region.zip_example
+      assert_empty region.zip_prefixes
+      assert_nil region.zip_regex
+      assert_nil region.example_address
+      assert_empty region.parents
+      assert_empty region.zones
+    end
+
+    test "#short_name returns values as expected" do
       data = {
         "AU-NSW": "NSW",
         "CA-ON": "ON",
@@ -73,7 +106,7 @@ module Worldwide
       end
     end
 
-    test "can add a child region (zone)" do
+    test "#add_zone adds a child region (zone)" do
       region = Region.new(iso_code: "XA")
       zone = Region.new(iso_code: "XB")
 
@@ -84,7 +117,7 @@ module Worldwide
       assert_equal zone, region.zone(code: "XB")
     end
 
-    test "can look up a zone by name" do
+    test "#zone can look up a zone by name" do
       legacy_name = "Prince Edward Island"
       scenarios = {
         en: "Prince Edward Island",
@@ -102,27 +135,27 @@ module Worldwide
       end
     end
 
-    test "can look up a zone by its alternate names" do
+    test "#zone can look up a zone by its alternate names" do
       ["Baleares", "Illes Balears", "Islas Baleares"].each do |name|
         assert_equal "ES-PM", Worldwide.region(code: "ES").zone(name: name).iso_code
       end
     end
 
-    test "can look up a zone by CLDR code" do
+    test "#zone can look up a zone by CLDR code" do
       zone = Worldwide.region(code: "MY").zone(code: "my14")
 
       assert_not_nil zone
       assert_equal "MY-14", zone.iso_code
     end
 
-    test "can look up a zone by zip" do
+    test "#zone can look up a zone by zip" do
       zone = Worldwide.region(code: "CA").zone(zip: "V6B 4A2")
 
       assert_not_nil zone
       assert_equal "CA-BC", zone.iso_code
     end
 
-    test "can look up zones that go by iso_code" do
+    test "#zone can look up zones that go by iso_code" do
       [
         ["MX", "AGU", "MXAGU", "MX-AGU", "Aguascalientes"],
         ["JP", "01", "JP01", "JP-01", "Hokkaidō"],
@@ -137,7 +170,7 @@ module Worldwide
       end
     end
 
-    test "look up with both code and name raises" do
+    test "#zone raises when both code and name are provided" do
       ca = Worldwide.region(code: "CA")
 
       assert_raises ArgumentError do
@@ -145,7 +178,7 @@ module Worldwide
       end
     end
 
-    test "zone lookup for territories using alternate code formats" do
+    test "#zone can look up territories using alternate code formats" do
       [
         ["US", "PR", "USPR", "US-PR", "Puerto Rico"],
         ["FR", "BL", "FRBL", "FR-BL", "Saint Barthélemy"],
@@ -158,12 +191,12 @@ module Worldwide
       end
     end
 
-    test "can look up a zone by alternate code" do
+    test "#zone can look up a zone by alternate code" do
       assert_equal "CA-QC", Worldwide.region(code: "CA").zone(code: "PQ").iso_code
       assert_equal "MX-CMX", Worldwide.region(code: "MX").zone(code: "CDMX").iso_code
     end
 
-    test "look up with both name and zip raises" do
+    test "#zone raises when both name and zip are provided" do
       ca = Worldwide.region(code: "CA")
 
       assert_raises ArgumentError do
@@ -171,7 +204,7 @@ module Worldwide
       end
     end
 
-    test "look up with both code and zip raises" do
+    test "#zone raises when both code and zip are provided" do
       ca = Worldwide.region(code: "CA")
 
       assert_raises ArgumentError do
@@ -179,7 +212,7 @@ module Worldwide
       end
     end
 
-    test "look up with all three of code, name and zip raises" do
+    test "#zone raises when all three of code, name and zip are provided" do
       ca = Worldwide.region(code: "CA")
 
       assert_raises ArgumentError do
@@ -187,7 +220,7 @@ module Worldwide
       end
     end
 
-    test "look up of zone with neither code nor name nor zip raises" do
+    test "#zone raises when neither code nor name nor zip is provided" do
       ca = Worldwide.region(code: "CA")
 
       assert_raises ArgumentError do
@@ -195,7 +228,7 @@ module Worldwide
       end
     end
 
-    test "can get a region via Worldwide.region(code: code)" do
+    test "#region can be constructed with various code formats" do
       ["CA", "ca", :ca, :CA, "124", 124].each do |code|
         region = Worldwide.region(code: code)
 
@@ -208,7 +241,7 @@ module Worldwide
       end
     end
 
-    test "when CLDR has no name available, full_name falls back to legacy_name" do
+    test "#full_name falls back to legacy_name when CLDR has no name available" do
       dummy = Worldwide::Region.new(
         legacy_name: "Legacy name",
         cldr_code: "x@",
@@ -218,7 +251,7 @@ module Worldwide
       assert_equal "Legacy name", dummy.full_name
     end
 
-    test "zip autofills where expected" do
+    test "#autofill_zip returns values as expected" do
       {
         ac: "ASCN 1ZZ",
         ai: "AI-2640",
@@ -240,13 +273,13 @@ module Worldwide
       end
     end
 
-    test "zip does not autofill where no autofill is expected" do
+    test "#autofill_zip returns nil when no autofill is expected" do
       [:ad, :ca, :de, :es, :fr, :it, :nl, :us, :ve].each do |country_code|
         assert_nil Worldwide.region(code: country_code).autofill_zip
       end
     end
 
-    test "city does not autofill where no autofill is expected" do
+    test "#autofill_city returns nil when no autofill is expected" do
       [:ca, :de, :es, :fr, :it, :nl, :us, :ve].each do |country_code|
         assert_nil Worldwide.region(code: country_code).autofill_city
       end
@@ -270,7 +303,7 @@ module Worldwide
       end
     end
 
-    test "city_required? returns values as expected" do
+    test "#city_required? returns values as expected" do
       city_not_required_countries = [:gi, :gs, :pn, :sg, :ta, :va]
       city_required_countries = [:ca, :us, :gb]
 
@@ -283,7 +316,7 @@ module Worldwide
       end
     end
 
-    test "street_name_required? returns values as expected" do
+    test "#street_name_required? returns values as expected" do
       street_name_not_required_countries = [:ca, :us, :id]
       street_name_required_countries = [:nl, :be, :br, :cl, :es]
 
@@ -296,7 +329,7 @@ module Worldwide
       end
     end
 
-    test "street_number_required? returns values as expected" do
+    test "#street_number_required? returns values as expected" do
       street_number_not_required_countries = [:ca, :cl, :us, :id]
       street_number_required_countries = [:be, :br, :il, :mx, :nl, :es]
 
@@ -309,7 +342,7 @@ module Worldwide
       end
     end
 
-    test "neighborhood_required? returns values as expected" do
+    test "#neighborhood_required? returns values as expected" do
       neighborhood_not_required_countries = [:ca, :cl, :mx, :id]
       neighborhood_required_countries = [:ph, :vn, :tr]
 
@@ -322,7 +355,7 @@ module Worldwide
       end
     end
 
-    test "associated_country returns the expected country" do
+    test "#associated_country returns the expected country" do
       {
         ca: "CA",
         gb: "GB",
@@ -335,7 +368,7 @@ module Worldwide
       end
     end
 
-    test "associated_continent returns the expected continent" do
+    test "#associated_continent returns the expected continent" do
       [
         # Canada
         [:ca, "North America"],
@@ -356,11 +389,11 @@ module Worldwide
       end
     end
 
-    test "associated_continent for world region returns nil" do
+    test "#associated_continent returns nil for world region" do
       assert_nil Worldwide.region(code: "001").associated_continent
     end
 
-    test "name alternates are returned as expected" do
+    test "#name_alternates returns values as expected" do
       {
         cz: ["Czechia"],
         sz: ["Swaziland"],
@@ -371,7 +404,7 @@ module Worldwide
       end
     end
 
-    test "name alternates are returned as expected on zones" do
+    test "#name_alternates returns values as expected on zones" do
       [
         [:th, "TH-10", ["Krung Thep Maha Nakhon"]],
         [:jp, "JP-01", ["Hokkaido Prefecture", "北海道"]],
@@ -381,7 +414,7 @@ module Worldwide
       end
     end
 
-    test "building_number_required returns values as expected" do
+    test "#building_number_required returns values as expected" do
       [
         [:ca, true],
         [:in, false],
@@ -393,7 +426,7 @@ module Worldwide
       end
     end
 
-    test "building_number_may_be_in_address2 returns values as expected" do
+    test "#building_number_may_be_in_address2 returns values as expected" do
       [
         [:ca, false],
         [:de, true],
@@ -404,7 +437,7 @@ module Worldwide
       end
     end
 
-    test "combined_address_format returns values as expected" do
+    test "#combined_address_format returns values as expected" do
       [
         [:us, {}],
         [:il, {
@@ -442,7 +475,7 @@ module Worldwide
       end
     end
 
-    test "additional_address_fields returns values as expected" do
+    test "#additional_address_fields returns values as expected" do
       [
         [:us, []],
         [:br, [{ "name" => "streetName", "required" => true }, { "name" => "streetNumber", "required" => true }, { "name" => "line2" }, { "name" => "neighborhood", "required" => true }]],
@@ -454,39 +487,7 @@ module Worldwide
       end
     end
 
-    test "initializer sets expected default attributes" do
-      region = Region.new(iso_code: "ZZ")
-
-      assert_empty region.additional_address_fields
-      assert_empty(region.combined_address_format)
-      refute region.building_number_required
-      refute region.building_number_may_be_in_address2
-      assert_nil region.currency
-      assert_nil region.flag
-      assert_empty(region.format)
-      assert_empty(region.format_extended)
-      assert_empty region.name_alternates
-      assert_nil region.group
-      assert_nil region.group_name
-      assert_empty region.languages
-      assert_empty region.neighbours
-      assert_nil region.partial_zip_regex
-      assert_nil region.phone_number_prefix
-      assert_empty region.tags
-      assert_nil region.timezone
-      assert_empty(region.timezones)
-      assert_nil region.unit_system
-      assert_nil region.week_start_day
-      refute region.zip_autofill_enabled
-      assert_nil region.zip_example
-      assert_empty region.zip_prefixes
-      assert_nil region.zip_regex
-      assert_nil region.example_address
-      assert_empty region.parents
-      assert_empty region.zones
-    end
-
-    test "address1_regex returns values as expected" do
+    test "#address1_regex returns values as expected" do
       [
         [:us, []],
         [:nl, ["^(?<streetName>[^\\d]+) (?<streetNumber>\\d+(?: ?[a-z])?)$"]],
@@ -494,6 +495,18 @@ module Worldwide
       ].each do |region_code, expected_value|
         assert_equal expected_value, Worldwide.region(code: region_code).address1_regex
       end
+    end
+
+    test "#example_city returns values as expected" do
+      assert_equal "Los Angeles", Worldwide.region(code: "US").zone(code: "CA").example_city
+    end
+
+    test "#example_city_zip returns values as expected" do
+      assert_equal "90011", Worldwide.region(code: "US").zone(code: "CA").example_city_zip
+    end
+
+    test "#priority returns values as expected" do
+      assert_equal 47, Worldwide.region(code: "JP").zone(code: "JP-01").priority
     end
   end
 end

--- a/test/worldwide/region_yml_consistency_test.rb
+++ b/test/worldwide/region_yml_consistency_test.rb
@@ -401,9 +401,23 @@ module Worldwide
       end
     end
 
+    test "priority is an Integer" do
+      Regions.all.select(&:province?).each do |province|
+        next unless province.priority
+
+        assert_kind_of Integer, province.priority, "Province priority should be an Integer for #{province.inspect}"
+      end
+    end
+
     test "example_city is available for each US state" do
       assert_predicate Worldwide.region(code: "US").zones, :all? do |state|
         !state.example_city&.empty?
+      end
+    end
+
+    test "example_city_zip is available for each US state" do
+      assert_predicate Worldwide.region(code: "US").zones, :all? do |state|
+        !state.example_city_zip&.empty?
       end
     end
 


### PR DESCRIPTION
### What are you trying to accomplish?
The US region yml includes zip examples under zone key `example_city_zip`,
https://github.com/Shopify/worldwide/blob/dc40ce83e34430a65feae255cbd6b045468ad6c2/db/data/regions/US.yml#L68-L69

In addition, countries like JP include zone priority data to help with dropdown ordering: 
https://github.com/Shopify/worldwide/blob/dc40ce83e34430a65feae255cbd6b045468ad6c2/db/data/regions/JP.yml#L39

This PR makes these fields available via the Region object. 

### What approach did you choose and why?
Added accessor for example_city_zip, priority 

Added tests, and updated the existing test names while I was there. 

### What should reviewers focus on?
<!--
Outline anything you'd like reviewers to pay extra attention to. List open questions for discussion.
-->

...

### The impact of these changes
```
❯ bin/console
irb(main):001> us = Worldwide.region(code: "US")
=> #<Worldwide::Region:37440 @alpha_three="USA", @building_number_required=true, @currency=#<Worldwide::Currency:0x000000011e85f6c8 @currency_code="USD", @numeric_code=840>, @example_city=nil, @example_city_zip=nil, @exampl...
irb(main):002> us.zone(code: "CA")
=> #<Worldwide::Region:60280 @alpha_three=nil, @building_number_required=false, @currency=nil, @example_city="Los Angeles", @example_city_zip="90011", @example_address=nil, @flag=nil, @format={}, @format_extended={}, @group=nil, @group_name=nil, @cldr_code="usca", @iso_code="US-CA", @languages=[], @neighbours=["AZ", "NV", "OR"], @numeric_three=nil, @week_start_day=nil, @unit_system=nil, @zip_autofill_enabled=false, @zip_example=nil, @zip_regex=nil, @zip_requirement=nil, @additional_address_fields=[], @combined_address_format={}, @address1_regex=[]>
irb(main):003> us.zone(code: "CA").example_city_zip
=> "90011"
```


```
❯ bin/console
irb(main):001> jp = Worldwide.region(code: "JP")
=> #<Worldwide::Region:34900 @alpha_three="JPN", @building_number_required=true, @currency=#<Worldwide::Currency:0x000000012b191d48 @currency_code="JPY", @numeric_code=392>, @example_city=nil, @example_city_zip=nil, @example_address={"address1"=>"永...
irb(main):002> jp.zone(code:"JP-02").priority
=> 46
```

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
