### PR TITLE
Add Region#tax_type accessor, cut v1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 - Add example_city_zip and priority accessors to Regions [#298](https://github.com/Shopify/worldwide/pull/298)
+- Add tax_type accessor to Regions [#299](https://github.com/Shopify/worldwide/pull/299)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Security in case of vulnerabilities.
 
 ## [Unreleased]
-- Add example_city_zip and priority accessors to Regions [#298](https://github.com/Shopify/worldwide/pull/298)
-- Add tax_type accessor to Regions [#299](https://github.com/Shopify/worldwide/pull/299)
+- Nil.
 
 ---
+
+## [1.14.0] - 2024-11-07
+- Add example_city_zip and priority accessors to Regions [#298](https://github.com/Shopify/worldwide/pull/298)
+- Add tax_type accessor to Regions [#299](https://github.com/Shopify/worldwide/pull/299)
 
 ## [1.13.0] - 2024-11-06
 - Add `zip_prefixes` for Spain. [#295](https://github.com/Shopify/worldwide/pull/295)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (1.13.0)
+    worldwide (1.14.0)
       activesupport (>= 7.0)
       i18n
       phonelib (~> 0.8)

--- a/lib/worldwide/region.rb
+++ b/lib/worldwide/region.rb
@@ -166,6 +166,9 @@ module Worldwide
     # "generic" VAT tax rate on "most" goods
     attr_reader :tax_rate
 
+    # The type of tax for this region, e.g. "harmonized"
+    attr_accessor :tax_type
+
     # tags that help us group the region, e.g. "EU-member"
     attr_accessor :tags
 

--- a/lib/worldwide/regions_loader.rb
+++ b/lib/worldwide/regions_loader.rb
@@ -134,6 +134,7 @@ module Worldwide
       region.example_city = zone["example_city"]
       region.example_city_zip = zone["example_city_zip"]
       region.priority = zone["priority"]
+      region.tax_type = zone["tax_type"] || nil
       region.neighbours = zone["neighboring_zones"]
       region.zip_prefixes = zone["zip_prefixes"] || []
     end

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "1.13.0"
+  VERSION = "1.14.0"
 end

--- a/test/worldwide/region_test.rb
+++ b/test/worldwide/region_test.rb
@@ -86,8 +86,12 @@ module Worldwide
       assert_empty region.zip_prefixes
       assert_nil region.zip_regex
       assert_nil region.example_address
+      assert_nil region.example_city
+      assert_nil region.example_city_zip
       assert_empty region.parents
       assert_empty region.zones
+      assert_nil region.tax_name
+      assert_equal 0, (region.tax_rate * 100).floor
     end
 
     test "#short_name returns values as expected" do
@@ -507,6 +511,18 @@ module Worldwide
 
     test "#priority returns values as expected" do
       assert_equal 47, Worldwide.region(code: "JP").zone(code: "JP-01").priority
+    end
+
+    test "#tax_type returns values as expected" do
+      assert_equal "harmonized", Worldwide.region(code: "CA").zone(code: "ON").tax_type
+    end
+
+    test "#tax_name returns values as expected" do
+      assert_equal "HST", Worldwide.region(code: "CA").zone(code: "ON").tax_name
+    end
+
+    test "#tax_rate returns values as expected" do
+      assert_in_delta(0.13, Worldwide.region(code: "CA").zone(code: "ON").tax_rate)
     end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?
Region ymls contain data on the zone tax_types 
https://github.com/Shopify/worldwide/blob/dc40ce83e34430a65feae255cbd6b045468ad6c2/db/data/regions/CA.yml#L121-L122

This PR makes the tax type available via the Region object.

Also cuts version `1.14.0`. 

### What approach did you choose and why?
Added region territory accessor for tax_type. Unlike tax_name and tax_rate, the tax_type is only defined on the territory or zone level. 

### What should reviewers focus on?
<!--
Outline anything you'd like reviewers to pay extra attention to. List open questions for discussion.
-->

...

### The impact of these changes

```
 ❯ bin/console
irb(main):001> ca = Worldwide.region(code: "CA")
=> #<Worldwide::Region:26800 @alpha_three="CAN", @building_number_required=true, @currency=#<Worldwide::Currency:0x00000001391edf40 @currency_code="CAD", @numeric_code=124>, @example_city=nil, @example_city_zip=nil, @example_address={"address1"=>"1 ...
irb(main):002> ca.zone(code: "ON").tax_type
=> "harmonized"
irb(main):003> Worldwide.region(code: "US").zone(code: "CA").tax_type
=> nil
```
on a country-level region, returns nil 
```
irb(main):001> ca = Worldwide.region(code:'CA')
=> #<Worldwide::Region:28280 @alpha_three="CAN", @building_number_required=true, @currency=#<Worldwide::Currency:0x000000011ea12538 @currency_code="CAD", @numeric_code=124>, @example_city=nil, @example_city_zip=nil, @example_address={"address1"=>"1 Sussex Drive", ...
irb(main):002> ca.tax_type
=> nil
```

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
