### PR TITLE
remove AU Islands exclusions, cut v1.14.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Nil.
 
 ---
+## [1.14.3] - 2024-11-11
+- Remove zip exclusions for Norfolk Island, Christmas Island, and Cocos Islands in AU [#312](https://github.com/Shopify/worldwide/pull/312)
+
 ## [1.14.2] - 2024-11-11
 - Update translations [#303](https://github.com/Shopify/worldwide/pull/303)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (1.14.2)
+    worldwide (1.14.3)
       activesupport (>= 7.0)
       i18n
       phonelib (~> 0.8)

--- a/data/regions/AU.yml
+++ b/data/regions/AU.yml
@@ -8,11 +8,7 @@ tax_name: GST
 tax_inclusive: true
 group: Oceanian Countries
 group_name: Oceania
-# Some codes in the AU namespace are not in AU:
-#  - 2899 NF Norfolk Island
-#  - 6798 CX Christmas Island
-#  - 6799 CC Cocos (Keeling) Islands
-zip_regex: "^(?!2899|679[89])(\\d{4})$"
+zip_regex: "^(\\d{4})$"
 zip_example: '2060'
 phone_number_prefix: 61
 building_number_required: true

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "1.14.2"
+  VERSION = "1.14.3"
 end


### PR DESCRIPTION
### What are you trying to accomplish?
Postcodes in Australia's Norfolks Island, Christmas Island, and Cocos Island are considered invalid. 

They are in fact valid, and furthermore each island has ~500-2k residents, as pulled from the[ 2021 census.](https://www.abs.gov.au/census/find-census-data/quickstats/2021/SAL90004) 

### What approach did you choose and why?
Remove the specific Island exclusions from the `zip_regex` 

Island postcodes [here](https://auspost.com.au/postcode/norfolk-island):
- Norfolk Island, 2899, NSW
- Christmas island, [6798](https://auspost.com.au/postcode/christmas-island/wa/ghji), WA
- Cocos Island, [6799](https://auspost.com.au/postcode/cocos-island), WA

### What should reviewers focus on?
<!--
Outline anything you'd like reviewers to pay extra attention to. List open questions for discussion.
-->

...

### The impact of these changes
These zips are considered valid. 

Before:
```
irb(main):001> region = Worldwide.region(code:"AU")
=> #<Worldwide::Region:6780 @alpha_three="AUS", @building_number_required=true, @currency=#<Worldwide::Currency:0x00000001293b8358 @currency_cod...
irb(main):002> region.valid_zip?("6798")
=> false
```

After:

```
irb(main):002> region = Worldwide.region(code:"AU")
=> #<Worldwide::Region:40880 @alpha_three="AUS", @building_number_required=true, @currency=#<Worldwide::Currency:0x00000001213dde80 @currency_co...
irb(main):003> region.valid_zip?("6798")
=> true
```

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

...

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
