### PR TITLE
Update FI tax rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 - Update BV phone number prefix to 47 (Norway) [#318](https://github.com/Shopify/worldwide/pull/318)
-
+- Update Finland's (FI) tax rate [#319](https://github.com/Shopify/worldwide/pull/319)
 ---
 
 ## [1.14.3] - 2024-12-02

--- a/data/regions/FI.yml
+++ b/data/regions/FI.yml
@@ -1,7 +1,7 @@
 ---
 name: Finland
 code: FI
-tax: 0.24
+tax: 0.255
 currency: EUR
 unit_system: metric
 tax_name: VAT


### PR DESCRIPTION
### What are you trying to accomplish?
Related - [Finland VAT update from 24% to 25.5% on Sept 1st, 2024](https://www.vero.fi/en/businesses-and-corporations/taxes-and-charges/vat/rates-of-vat/new-vat-rate-from-1-september-2024--instructions-for-vat-reporting/)

Finland have changed their country's tax rate on September 1 2024.

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
