### PR TITLE
Set Ireland (IE) zip as a required address field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 - Add zip requirement and tax inclusive methods to country regions [#320](https://github.com/Shopify/worldwide/pull/320)
+- Set Ireland (IE) zip as a required address field [#321](https://github.com/Shopify/worldwide/pull/321)
 
 ---
 

--- a/data/regions/IE.yml
+++ b/data/regions/IE.yml
@@ -13,7 +13,6 @@ tags:
 zip_regex: "^(D6W|[AC-FHKNPRT-Z]\\d{2}) ?[0-9AC-FHKNPRT-Z]{4}$"
 partial_zip_regex: "^(D6W|[AC-FHKNPRT-Z]\\d{2})$"
 zip_example: A65 F4E2
-zip_requirement: recommended
 phone_number_prefix: 353
 week_start_day: monday
 format:


### PR DESCRIPTION
### What are you trying to accomplish?
Follows https://github.com/Shopify/worldwide/pull/320

[Since July 2023](https://changelog.shopify.com/posts/shipments-to-the-republic-of-ireland-now-require-postal-code-eircode) Shopify has required postal codes for Ireland addresses. This should be reflected in Worldwide.

### Testing
```
irb(main):002> Worldwide.region(code: "IE").zip_required?
=> true
```

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
