### PR TITLE
release 1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Security in case of vulnerabilities.
 
 ## [Unreleased]
-- Add zip requirement and tax inclusive methods to country regions [#320](https://github.com/Shopify/worldwide/pull/320)
-- Set Ireland (IE) zip as a required address field [#321](https://github.com/Shopify/worldwide/pull/321)
+
+Nil.
 
 ---
+
+## [1.15.0] - 2024-12-16
+- Add zip requirement and tax inclusive methods to country regions [#320](https://github.com/Shopify/worldwide/pull/320)
+- Set Ireland (IE) zip as a required address field [#321](https://github.com/Shopify/worldwide/pull/321)
 
 ## [1.14.4] - 2024-12-12
 - Speed up configure_i18n by precomputing paths and indexing descendants [#316](https://github.com/Shopify/worldwide/pull/316)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (1.14.4)
+    worldwide (1.15.0)
       activesupport (>= 7.0)
       i18n
       phonelib (~> 0.8)

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "1.14.4"
+  VERSION = "1.15.0"
 end


### PR DESCRIPTION
### What are you trying to accomplish?
Prepare a minor release.

### The impact of these changes
The `Region#zip_requirement` field is no longer nilable, and returns a value even if the country does not set `zip_requirement` in the yaml. Instead of `nil`, it returns `"required"` if `zip_regex` is set or `"optional"` otherwise.  This is a behavior change, but IMO more of a bug fix: a `nil` `zip_requirement` had no defined meaning, and we are clarifying that.

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
