### PR TITLE
Set Malaysia and Singapore as tax_inclusive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-Nil.
+- Set Malaysia and Singapore as tax_inclusive [#323](https://github.com/Shopify/worldwide/pull/323)
 
 ---
 

--- a/data/regions/MY.yml
+++ b/data/regions/MY.yml
@@ -2,6 +2,7 @@
 name: Malaysia
 code: MY
 tax: 0.1
+tax_inclusive: true
 currency: MYR
 unit_system: metric
 tax_name: SST

--- a/data/regions/SG.yml
+++ b/data/regions/SG.yml
@@ -2,6 +2,7 @@
 name: Singapore
 code: SG
 tax: 0.09
+tax_inclusive: true
 currency: SGD
 unit_system: metric
 tax_name: GST


### PR DESCRIPTION
### What are you trying to accomplish?
Shopify considers Malaysia and Singapore to be tax-inclusive countries.

https://www.iras.gov.sg/taxes/goods-services-tax-(gst)/basics-of-gst/invoicing-price-display-and-record-keeping/displaying-and-quoting-prices

I cannot find supporting evidence that prices are indeed tax inclusive in Malaysia 🤷, but for now let's update the yaml to be consistent.

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
