### PR TITLE
Add ignore_provinces to Region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-Nil.
+- Add `ignore_provinces` to regions [#329](https://github.com/Shopify/worldwide/pull/329)
 
 ---
 

--- a/data/regions/GB.yml
+++ b/data/regions/GB.yml
@@ -7,7 +7,7 @@ unit_system: imperial
 tax_name: VAT
 tax_inclusive: true
 hide_provinces_from_addresses: true
-ignore_zones: true
+ignore_provinces: true
 group: European Countries
 group_name: Europe
 zip_label: Postcode

--- a/data/regions/VE.yml
+++ b/data/regions/VE.yml
@@ -14,7 +14,6 @@ format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{city}{zip}{province}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip} {province}_{country}_{phone}"
 emoji: "\U0001F1FB\U0001F1EA"
-ignore_zones: false
 languages:
 - es
 example_address:

--- a/lib/worldwide/region.rb
+++ b/lib/worldwide/region.rb
@@ -109,6 +109,10 @@ module Worldwide
     # based on the zip (note that this auto-inference may be wrong for some addresses near a border).
     attr_accessor :hide_provinces_from_addresses
 
+    # Returns true if provinces should be ignored
+    # Used when adding provinces to a country that has none as an intermediate step
+    attr_accessor :ignore_provinces
+
     # The CLDR code for this region.
     attr_reader :cldr_code
 

--- a/lib/worldwide/regions_loader.rb
+++ b/lib/worldwide/regions_loader.rb
@@ -110,6 +110,7 @@ module Worldwide
       region.group = spec["group"]
       region.group_name = spec["group_name"]
       region.hide_provinces_from_addresses = spec["hide_provinces_from_addresses"] || false
+      region.ignore_provinces = spec["ignore_provinces"] || false
       region.languages = spec["languages"]
       region.partial_zip_regex = spec["partial_zip_regex"]
       region.phone_number_prefix = spec["phone_number_prefix"]

--- a/test/worldwide/region_data_consistency_test.rb
+++ b/test/worldwide/region_data_consistency_test.rb
@@ -135,12 +135,13 @@ module Worldwide
       end
     end
 
-    test "country shows provices if it has them, unless hide_provinces_from_addresses is set" do
+    test "country shows provices if it has them, unless provinces are hidden/ignored" do
       Regions.all.select(&:country?).each do |country|
         shows_provinces = country.format["show"].include?("{province}")
 
         if Worldwide::Util.present?(country.zones.select(&:province?))
           assert_equal !shows_provinces, country.hide_provinces_from_addresses, "country: #{country.iso_code}"
+          assert_equal !shows_provinces, country.ignore_provinces, "country: #{country.iso_code}"
         else
           assert_equal false, shows_provinces
         end

--- a/test/worldwide/region_test.rb
+++ b/test/worldwide/region_test.rb
@@ -537,5 +537,20 @@ module Worldwide
     test "#tax_rate returns values as expected" do
       assert_in_delta(0.13, Worldwide.region(code: "CA").zone(code: "ON").tax_rate)
     end
+
+    test "#ignore_provinces returns values as expected" do
+      assert Worldwide.region(code: "GB").ignore_provinces
+      refute Worldwide.region(code: "CA").ignore_provinces
+    end
+
+    test "#hide_provinces_from_addresses returns values as expected" do
+      assert Worldwide.region(code: "GB").hide_provinces_from_addresses
+      refute Worldwide.region(code: "CA").hide_provinces_from_addresses
+    end
+
+    test "#province_optional returns values as expected" do
+      assert Worldwide.region(code: "NZ").province_optional
+      refute Worldwide.region(code: "CA").province_optional
+    end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Worldwide has `ignore_zones` in some country yaml files, but it's not used anywhere. It should be renamed to use 'provinces' instead of 'zones' and then added as an attribute of `Region`.

### What approach did you choose and why?

1. Rename `ignore_zones` to `ignore_provinces` in yaml files for consistency with other keys
2. Remove `ignore_provinces` from `VE.yml` as it's set to `false`, which is the default
3. Add to RegionsLoader
4. Add accessor in Region

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
