### PR TITLE
Added administrative division (zones) to Poland

### DIFF
--- a/data/regions/PL.yml
+++ b/data/regions/PL.yml
@@ -5,6 +5,7 @@ tax: 0.23
 currency: PLN
 unit_system: metric
 tax_name: VAT
+zone_key: administrative_division
 tax_inclusive: true
 # Polish postal codes are normally written with a hyphen after the 2nd digit.
 # EU guidance, however, implies that the hyphen is optional, and a space may be used instead.
@@ -22,8 +23,8 @@ week_start_day: monday
 format:
   address1: "{street} {building_num}"
   address1_with_unit: "{street} {building_num}/{unit}"
-  edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{phone}"
-  show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{country}_{phone}"
+  edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{administrative_division}_{phone}"
+  show: "{firstName} {lastName}_{company}_{address1}_{address2}_{zip} {city}_{administrative_division}_{country}_{phone}"
 emoji: "\U0001F1F5\U0001F1F1"
 languages:
 - pl
@@ -34,3 +35,68 @@ example_address:
   zip: 00-277
   phone: "+48 22 355 51 70"
 timezone: Europe/Warsaw
+zones:
+- tax: 0
+  name: Dolnośląskie
+  tax_name: VAT
+  code: DS
+- tax: 0
+  name: Kujawsko-Pomorskie
+  tax_name: VAT
+  code: KP
+- tax: 0
+  name: Lubelskie
+  tax_name: VAT
+  code: LU
+- tax: 0
+  name: Lubuskie
+  tax_name: VAT
+  code: LB
+- tax: 0
+  name: Łódzkie
+  tax_name: VAT
+  code: LD
+- tax: 0
+  name: Małopolskie
+  tax_name: VAT
+  code: MA
+- tax: 0
+  name: Mazowieckie
+  tax_name: VAT
+  code: MZ
+- tax: 0
+  name: Opolskie
+  tax_name: VAT
+  code: OP
+- tax: 0
+  name: Podkarpackie
+  tax_name: VAT
+  code: PK
+- tax: 0
+  name: Podlaskie
+  tax_name: VAT
+  code: PD
+- tax: 0
+  name: Pomorskie
+  tax_name: VAT
+  code: PM
+- tax: 0
+  name: Śląskie
+  tax_name: VAT
+  code: SL
+- tax: 0
+  name: Świętokrzyskie
+  tax_name: VAT
+  code: SK
+- tax: 0
+  name: Warmińsko-Mazurskie
+  tax_name: VAT
+  code: WN
+- tax: 0
+  name: Wielkopolskie
+  tax_name: VAT
+  code: WP
+- tax: 0
+  name: Zachodniopomorskie
+  tax_name: VAT
+  code: ZP


### PR DESCRIPTION
### What are you trying to accomplish?
<!--
Link to an issue or provide enough context so that someone new can understand the 'why' behind this change.
-->
https://github.com/Shopify/temp-project-mover-Archetypically-20250318093910/issues/185
...

### What approach did you choose and why?
<!--
There are many ways to solve a problem. How did you approach this problem and why?
-->
After talking to @gabypancu to new way to add provinces is through `worldwide` repo in place of `country_db`.
link to `country_db` [repo](https://github.com/Shopify/country_db/pull/1829).

Right now during domain checkout in the `front end`, the geolocation fields required (Country, Province, Address, etc.)  are generated through the [AddressForm](https://github.com/Shopify/web/blob/main/areas/clients/admin-web/app/shared/components/AddressForm/AddressForm.tsx) component. This components ends up calling `Atlas` (some layers deep) if any zones are defined but when no zones are found, the zone field is not rendered. 

...

### What should reviewers focus on?
<!--
Outline anything you'd like reviewers to pay extra attention to. List open questions for discussion.
-->

Name of the polish zones and the format of addresses.

...

### The impact of these changes
<!--
Are there any specific impacts from this change that you'd like to call out?
-->
All checkouts forms in the `ui` will show the zone fields for Poland

...

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

...

### Checklist

* [ ] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
