### PR TITLE
Remove Ruby 3.1 from CI version matrix; add Ruby 3.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         gemfile:
          - Gemfile
-        ruby: ["3.1", "3.2", "3.3"]
+        ruby: ["3.2", "3.3", "3.4"]
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     steps:


### PR DESCRIPTION
### What are you trying to accomplish?
Remove the three year old Ruby 3.1 from the test matrix and add 3.4. I chose to leave Ruby 3.1 as the gem's minimal supported version.

### Checklist

* [ ] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
  - There is no direct impact on the gem. Just what we test thre codebase against. 
