### PR TITLE
Add a provenance statement to the NPM package

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -11,6 +11,10 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
     defaults:
       run:
         working-directory: lang/typescript
@@ -40,3 +44,4 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true

--- a/lang/typescript/.changeset/eleven-birds-perform.md
+++ b/lang/typescript/.changeset/eleven-birds-perform.md
@@ -1,0 +1,5 @@
+---
+'@shopify/worldwide': patch
+---
+
+Add NPM provenance statement


### PR DESCRIPTION
### What are you trying to accomplish?

Fix https://github.com/Shopify/address/issues/2913

Simply adding a `provenance` statement to our NPM package to comply with the [_enhanced security and efficiency for public node.js packages_](https://vault.shopify.io/gsd/projects/43079-Enhanced-security-and-efficiency-for-public-node-js-packages) project.

### What approach did you choose and why?

From `#proj-npm-security-update`:
> When modifying an existing workflow:
> * The id-token: write permission will need to be added to the permissions: block.
> * If you’re calling npm publish directly, add the --provenance argument.
> * If you’re using changesets, add NPM_CONFIG_PROVENANCE: true environment variable.

> To my fellow other devs doing a changeset/action workflow update, you’ll also need `contents: write` and `pull-requests: write` permissions or else the PR update won’t work.

Should get us covered 🤔 

### What should reviewers focus on?

I don't think that there's a need to update [`ci-typescript.yml`](https://github.com/Shopify/worldwide/blob/main/.github/workflows/ci-typescript.yml) 🤷 

According to the [readme](https://github.com/Shopify/worldwide/tree/main/lang/typescript#releasing-a-new-version), the new version should be published automatically?
> Changesets will handle combining unreleased changesets on the main branch into a new version following [semver](https://semver.org/) in a GH Action workflow into a [corresponding PR](https://github.com/Shopify/worldwide/pulls?q=is%3Apr+is%3Aopen+%22Version+Packages%22). Merging that PR into main will release the new version to NPM.

### The impact of these changes

N/A

### Testing
 N/A

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
