### PR TITLE
[TS] append delimiter to the returned value of `splitAddress2` when missing

### DIFF
--- a/lang/typescript/src/extended-address/splitAddress2.test.ts
+++ b/lang/typescript/src/extended-address/splitAddress2.test.ts
@@ -10,9 +10,9 @@ describe('splitAddress2', () => {
     expect(splitAddress2('BR', '')).toEqual({});
   });
 
-  test('returns address2 as line2 when no delimiter is present', () => {
-    expect(splitAddress2('CL', 'dpto 4')).toEqual({line2: 'dpto 4'});
-    expect(splitAddress2('BR', 'dpto 4')).toEqual({line2: 'dpto 4'});
+  test('returns an empty object when no delimiter is present', () => {
+    expect(splitAddress2('CL', 'dpto 4')).toEqual({});
+    expect(splitAddress2('BR', 'dpto 4')).toEqual({});
   });
 
   test('returns neighborhood if string before delimiter is empty', () => {

--- a/lang/typescript/src/extended-address/splitAddress2.test.ts
+++ b/lang/typescript/src/extended-address/splitAddress2.test.ts
@@ -10,9 +10,9 @@ describe('splitAddress2', () => {
     expect(splitAddress2('BR', '')).toEqual({});
   });
 
-  test('returns an empty object when no delimiter is present', () => {
-    expect(splitAddress2('CL', 'dpto 4')).toEqual({});
-    expect(splitAddress2('BR', 'dpto 4')).toEqual({});
+  test('returns address2 as line2 with the delimiter when no delimiter is present', () => {
+    expect(splitAddress2('CL', 'dpto 4')).toEqual({line2: 'dpto 4\u2060'});
+    expect(splitAddress2('BR', 'dpto 4')).toEqual({line2: 'dpto 4\u2060'});
   });
 
   test('returns neighborhood if string before delimiter is empty', () => {

--- a/lang/typescript/src/utils/address-fields.test.ts
+++ b/lang/typescript/src/utils/address-fields.test.ts
@@ -169,7 +169,9 @@ describe('splitAddressField', () => {
       {key: 'streetNumber'},
       {key: 'streetName'},
     ];
-    expect(splitAddressField(fieldDefinition, '123')).toEqual({});
+    expect(splitAddressField(fieldDefinition, '123')).toEqual({
+      streetNumber: '123\u2060',
+    });
     expect(splitAddressField(fieldDefinition, '\u2060Main')).toEqual({
       streetName: 'Main',
     });
@@ -196,9 +198,9 @@ describe('splitAddressField', () => {
       ];
       const concatenatedAddress = 'Main';
 
-      expect(splitAddressField(fieldDefinition, concatenatedAddress)).toEqual(
-        {},
-      );
+      expect(splitAddressField(fieldDefinition, concatenatedAddress)).toEqual({
+        streetName: 'Main\u2060',
+      });
     });
 
     test('splits address without defined decorator if leading delimiter is found', () => {

--- a/lang/typescript/src/utils/address-fields.test.ts
+++ b/lang/typescript/src/utils/address-fields.test.ts
@@ -169,9 +169,7 @@ describe('splitAddressField', () => {
       {key: 'streetNumber'},
       {key: 'streetName'},
     ];
-    expect(splitAddressField(fieldDefinition, '123')).toEqual({
-      streetNumber: '123',
-    });
+    expect(splitAddressField(fieldDefinition, '123')).toEqual({});
     expect(splitAddressField(fieldDefinition, '\u2060Main')).toEqual({
       streetName: 'Main',
     });
@@ -198,9 +196,9 @@ describe('splitAddressField', () => {
       ];
       const concatenatedAddress = 'Main';
 
-      expect(splitAddressField(fieldDefinition, concatenatedAddress)).toEqual({
-        streetName: 'Main',
-      });
+      expect(splitAddressField(fieldDefinition, concatenatedAddress)).toEqual(
+        {},
+      );
     });
 
     test('splits address without defined decorator if leading delimiter is found', () => {

--- a/lang/typescript/src/utils/address-fields.ts
+++ b/lang/typescript/src/utils/address-fields.ts
@@ -45,6 +45,11 @@ export function splitAddressField(
   fieldDefinition: FieldConcatenationRule[],
   concatenatedAddress: string,
 ): Partial<Address> {
+  // Return empty object if no delimiter is found
+  if (!concatenatedAddress.includes(RESERVED_DELIMITER)) {
+    return {};
+  }
+
   const [firstField, ...rest] = concatenatedAddress.split(RESERVED_DELIMITER);
   const secondField = rest.join(RESERVED_DELIMITER);
   const values = [firstField, secondField];

--- a/lang/typescript/src/utils/address-fields.ts
+++ b/lang/typescript/src/utils/address-fields.ts
@@ -45,9 +45,16 @@ export function splitAddressField(
   fieldDefinition: FieldConcatenationRule[],
   concatenatedAddress: string,
 ): Partial<Address> {
-  // Return empty object if no delimiter is found
-  if (!concatenatedAddress.includes(RESERVED_DELIMITER)) {
+  if (concatenatedAddress === '') {
     return {};
+  }
+
+  // If no delimiter is found, add it to the end and assign to the first field
+  if (!concatenatedAddress.includes(RESERVED_DELIMITER)) {
+    const field = fieldDefinition[0];
+    return {
+      [field.key]: concatenatedAddress + RESERVED_DELIMITER,
+    };
   }
 
   const [firstField, ...rest] = concatenatedAddress.split(RESERVED_DELIMITER);


### PR DESCRIPTION
### What are you trying to accomplish?

Append the delimiter character to the value returned by `splitAddress2`, when no delimiter was found in the string to split.

### What approach did you choose and why?

This ensures that the whole string is still used as the value of the `line2` field in Checkout's address forms, while offering something to split and concatenate on.

### What should reviewers focus on?

Could this have side-effects on different clients/consumers?

### The impact of these changes

TBC -- should be none

### Testing

This is tricky to tophat as it involves several repositories.

### Checklist

* [ ] I have added a CHANGELOG entry for this change (or determined that it isn't needed)