### PR TITLE
[NPM] return `isUnsplittableField` in `splitAddressX` when no delimiter is found

### DIFF
--- a/lang/typescript/.changeset/rare-phones-laugh.md
+++ b/lang/typescript/.changeset/rare-phones-laugh.md
@@ -1,0 +1,5 @@
+---
+'@shopify/worldwide': patch
+---
+
+Add the `isUnsplittableField` flag to the returned value of `splitAddress1` and `splitAddress2` when the functions were not provided with a delimiter.

--- a/lang/typescript/src/extended-address/splitAddress1.test.ts
+++ b/lang/typescript/src/extended-address/splitAddress1.test.ts
@@ -18,9 +18,11 @@ describe('splitAddress1', () => {
   test('returns address1 as street name when no delimiter is present and tryRegexFallback is false', () => {
     expect(splitAddress1('CL', '123 Main', false)).toEqual({
       streetName: '123 Main',
+      isUnsplittableField: true,
     });
     expect(splitAddress1('BR', '123 Main', false)).toEqual({
       streetName: '123 Main',
+      isUnsplittableField: true,
     });
   });
 

--- a/lang/typescript/src/extended-address/splitAddress1.ts
+++ b/lang/typescript/src/extended-address/splitAddress1.ts
@@ -26,7 +26,7 @@ export function splitAddress1(
   countryCode: string,
   address: string,
   tryRegexFallback = false,
-): Partial<Address> | null {
+): (Partial<Address> & {isUnsplittableField?: boolean}) | null {
   const config = getRegionConfig(countryCode);
   const fieldConcatenationRules = config
     ? getConcatenationRules(config, address, 'address1')
@@ -50,5 +50,5 @@ export function splitAddress1(
       address,
     );
   }
-  return {[fieldConcatenationRules[0].key]: address};
+  return {[fieldConcatenationRules[0].key]: address, isUnsplittableField: true};
 }

--- a/lang/typescript/src/extended-address/splitAddress2.test.ts
+++ b/lang/typescript/src/extended-address/splitAddress2.test.ts
@@ -11,8 +11,14 @@ describe('splitAddress2', () => {
   });
 
   test('returns address2 as line2 when no delimiter is present', () => {
-    expect(splitAddress2('CL', 'dpto 4')).toEqual({line2: 'dpto 4'});
-    expect(splitAddress2('BR', 'dpto 4')).toEqual({line2: 'dpto 4'});
+    expect(splitAddress2('CL', 'dpto 4')).toEqual({
+      line2: 'dpto 4',
+      isUnsplittableField: true,
+    });
+    expect(splitAddress2('BR', 'dpto 4')).toEqual({
+      line2: 'dpto 4',
+      isUnsplittableField: true,
+    });
   });
 
   test('returns neighborhood if string before delimiter is empty', () => {

--- a/lang/typescript/src/utils/address-fields.test.ts
+++ b/lang/typescript/src/utils/address-fields.test.ts
@@ -171,6 +171,7 @@ describe('splitAddressField', () => {
     ];
     expect(splitAddressField(fieldDefinition, '123')).toEqual({
       streetNumber: '123',
+      isUnsplittableField: true,
     });
     expect(splitAddressField(fieldDefinition, '\u2060Main')).toEqual({
       streetName: 'Main',
@@ -200,6 +201,7 @@ describe('splitAddressField', () => {
 
       expect(splitAddressField(fieldDefinition, concatenatedAddress)).toEqual({
         streetName: 'Main',
+        isUnsplittableField: true,
       });
     });
 

--- a/lang/typescript/src/utils/address-fields.ts
+++ b/lang/typescript/src/utils/address-fields.ts
@@ -44,10 +44,11 @@ export function concatAddressField(
 export function splitAddressField(
   fieldDefinition: FieldConcatenationRule[],
   concatenatedAddress: string,
-): Partial<Address> {
+): Partial<Address> & {isUnsplittableField?: boolean} {
   const [firstField, ...rest] = concatenatedAddress.split(RESERVED_DELIMITER);
   const secondField = rest.join(RESERVED_DELIMITER);
   const values = [firstField, secondField];
+  const hasNoDelimiter = secondField.length === 0;
 
   const parsedAddressObject = fieldDefinition.reduce((obj, field, index) => {
     if (values[index]) {
@@ -68,6 +69,7 @@ export function splitAddressField(
       return {
         ...obj,
         [field.key]: fieldValue,
+        ...(hasNoDelimiter ? {isUnsplittableField: true} : {}),
       };
     }
 


### PR DESCRIPTION
### What are you trying to accomplish?

Sending a flag/boolean value alongside the returned value of `splitAddress1` and `splitAddress2` when the address to parse does not contain the `RESERVED_DELIMITER`.

### What approach did you choose and why?

This is a non-breaking approach (see [former attempt](https://github.com/Shopify/worldwide/pull/342)) as we're not changing the output value, but rather add some information to the returned object.

### What should reviewers focus on?

Am I omitting cases where this would be relevant?

### The impact of these changes

Should be a noop.

### Testing

This is tricky to 🎩 but I've updated our test coverage.

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
