### PR TITLE
[NPM] update type definition of `splitAddress2`

### DIFF
--- a/lang/typescript/.changeset/modern-queens-love.md
+++ b/lang/typescript/.changeset/modern-queens-love.md
@@ -1,0 +1,5 @@
+---
+'@shopify/worldwide': patch
+---
+
+Update typing of splitAddress2 function

--- a/lang/typescript/src/extended-address/splitAddress1.ts
+++ b/lang/typescript/src/extended-address/splitAddress1.ts
@@ -1,4 +1,4 @@
-import type {Address} from '../types/address';
+import type {SplitAddress} from '../types/address';
 import {
   RESERVED_DELIMITER,
   splitAddressField,
@@ -26,7 +26,7 @@ export function splitAddress1(
   countryCode: string,
   address: string,
   tryRegexFallback = false,
-): (Partial<Address> & {isUnsplittableField?: boolean}) | null {
+): SplitAddress | null {
   const config = getRegionConfig(countryCode);
   const fieldConcatenationRules = config
     ? getConcatenationRules(config, address, 'address1')

--- a/lang/typescript/src/extended-address/splitAddress2.ts
+++ b/lang/typescript/src/extended-address/splitAddress2.ts
@@ -1,4 +1,5 @@
-import type {Address} from '../types/address';
+import type {SplitAddress} from 'src/types/address';
+
 import {splitAddressField} from '../utils/address-fields';
 import {getRegionConfig, getConcatenationRules} from '../utils/regions';
 
@@ -13,7 +14,7 @@ import {getRegionConfig, getConcatenationRules} from '../utils/regions';
 export function splitAddress2(
   countryCode: string,
   concatenatedAddress: string,
-): Partial<Address> | null {
+): SplitAddress | null {
   const config = getRegionConfig(countryCode);
   const fieldConcatenationRules = config
     ? getConcatenationRules(config, concatenatedAddress, 'address2')

--- a/lang/typescript/src/types/address.ts
+++ b/lang/typescript/src/types/address.ts
@@ -14,3 +14,5 @@ export interface Address {
   line2?: string;
   neighborhood?: string;
 }
+
+export type SplitAddress = Partial<Address> & {isUnsplittableField?: boolean};

--- a/lang/typescript/src/utils/address-fields.ts
+++ b/lang/typescript/src/utils/address-fields.ts
@@ -1,5 +1,5 @@
 import type {FieldConcatenationRule} from '../types/region-yaml-config';
-import type {Address} from '../types/address';
+import type {Address, SplitAddress} from '../types/address';
 
 export const RESERVED_DELIMITER = '\u2060';
 
@@ -44,7 +44,7 @@ export function concatAddressField(
 export function splitAddressField(
   fieldDefinition: FieldConcatenationRule[],
   concatenatedAddress: string,
-): Partial<Address> & {isUnsplittableField?: boolean} {
+): SplitAddress {
   const [firstField, ...rest] = concatenatedAddress.split(RESERVED_DELIMITER);
   const secondField = rest.join(RESERVED_DELIMITER);
   const values = [firstField, secondField];


### PR DESCRIPTION
### What are you trying to accomplish?

Following up https://github.com/Shopify/worldwide/pull/343, I did not update the types for the returned value of `splitAddress2`.

### What approach did you choose and why?

Just accounting for the optional `isUnsplittableField`.

### What should reviewers focus on?

🦉 

### The impact of these changes

Noop

### Testing

N/A

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
