### PR TITLE
Remove isUnsplittableField logic

### DIFF
--- a/lang/typescript/.changeset/large-bananas-relate.md
+++ b/lang/typescript/.changeset/large-bananas-relate.md
@@ -1,0 +1,5 @@
+---
+'@shopify/worldwide': patch
+---
+
+Removing occurrences of isUnsplittableField

--- a/lang/typescript/src/extended-address/splitAddress1.test.ts
+++ b/lang/typescript/src/extended-address/splitAddress1.test.ts
@@ -18,11 +18,9 @@ describe('splitAddress1', () => {
   test('returns address1 as street name when no delimiter is present and tryRegexFallback is false', () => {
     expect(splitAddress1('CL', '123 Main', false)).toEqual({
       streetName: '123 Main',
-      isUnsplittableField: true,
     });
     expect(splitAddress1('BR', '123 Main', false)).toEqual({
       streetName: '123 Main',
-      isUnsplittableField: true,
     });
   });
 

--- a/lang/typescript/src/extended-address/splitAddress1.ts
+++ b/lang/typescript/src/extended-address/splitAddress1.ts
@@ -1,4 +1,4 @@
-import type {SplitAddress} from '../types/address';
+import type {Address} from '../types/address';
 import {
   RESERVED_DELIMITER,
   splitAddressField,
@@ -26,7 +26,7 @@ export function splitAddress1(
   countryCode: string,
   address: string,
   tryRegexFallback = false,
-): SplitAddress | null {
+): Partial<Address> | null {
   const config = getRegionConfig(countryCode);
   const fieldConcatenationRules = config
     ? getConcatenationRules(config, address, 'address1')
@@ -50,5 +50,5 @@ export function splitAddress1(
       address,
     );
   }
-  return {[fieldConcatenationRules[0].key]: address, isUnsplittableField: true};
+  return {[fieldConcatenationRules[0].key]: address};
 }

--- a/lang/typescript/src/extended-address/splitAddress2.test.ts
+++ b/lang/typescript/src/extended-address/splitAddress2.test.ts
@@ -11,14 +11,8 @@ describe('splitAddress2', () => {
   });
 
   test('returns address2 as line2 when no delimiter is present', () => {
-    expect(splitAddress2('CL', 'dpto 4')).toEqual({
-      line2: 'dpto 4',
-      isUnsplittableField: true,
-    });
-    expect(splitAddress2('BR', 'dpto 4')).toEqual({
-      line2: 'dpto 4',
-      isUnsplittableField: true,
-    });
+    expect(splitAddress2('CL', 'dpto 4')).toEqual({line2: 'dpto 4'});
+    expect(splitAddress2('BR', 'dpto 4')).toEqual({line2: 'dpto 4'});
   });
 
   test('returns neighborhood if string before delimiter is empty', () => {

--- a/lang/typescript/src/extended-address/splitAddress2.ts
+++ b/lang/typescript/src/extended-address/splitAddress2.ts
@@ -1,5 +1,4 @@
-import type {SplitAddress} from 'src/types/address';
-
+import type {Address} from '../types/address';
 import {splitAddressField} from '../utils/address-fields';
 import {getRegionConfig, getConcatenationRules} from '../utils/regions';
 
@@ -14,7 +13,7 @@ import {getRegionConfig, getConcatenationRules} from '../utils/regions';
 export function splitAddress2(
   countryCode: string,
   concatenatedAddress: string,
-): SplitAddress | null {
+): Partial<Address> | null {
   const config = getRegionConfig(countryCode);
   const fieldConcatenationRules = config
     ? getConcatenationRules(config, concatenatedAddress, 'address2')

--- a/lang/typescript/src/types/address.ts
+++ b/lang/typescript/src/types/address.ts
@@ -14,5 +14,3 @@ export interface Address {
   line2?: string;
   neighborhood?: string;
 }
-
-export type SplitAddress = Partial<Address> & {isUnsplittableField?: boolean};

--- a/lang/typescript/src/utils/address-fields.test.ts
+++ b/lang/typescript/src/utils/address-fields.test.ts
@@ -171,7 +171,6 @@ describe('splitAddressField', () => {
     ];
     expect(splitAddressField(fieldDefinition, '123')).toEqual({
       streetNumber: '123',
-      isUnsplittableField: true,
     });
     expect(splitAddressField(fieldDefinition, '\u2060Main')).toEqual({
       streetName: 'Main',
@@ -201,7 +200,6 @@ describe('splitAddressField', () => {
 
       expect(splitAddressField(fieldDefinition, concatenatedAddress)).toEqual({
         streetName: 'Main',
-        isUnsplittableField: true,
       });
     });
 

--- a/lang/typescript/src/utils/address-fields.ts
+++ b/lang/typescript/src/utils/address-fields.ts
@@ -1,5 +1,5 @@
 import type {FieldConcatenationRule} from '../types/region-yaml-config';
-import type {Address, SplitAddress} from '../types/address';
+import type {Address} from '../types/address';
 
 export const RESERVED_DELIMITER = '\u2060';
 
@@ -44,11 +44,10 @@ export function concatAddressField(
 export function splitAddressField(
   fieldDefinition: FieldConcatenationRule[],
   concatenatedAddress: string,
-): SplitAddress {
+): Partial<Address> {
   const [firstField, ...rest] = concatenatedAddress.split(RESERVED_DELIMITER);
   const secondField = rest.join(RESERVED_DELIMITER);
   const values = [firstField, secondField];
-  const hasNoDelimiter = secondField.length === 0;
 
   const parsedAddressObject = fieldDefinition.reduce((obj, field, index) => {
     if (values[index]) {
@@ -69,7 +68,6 @@ export function splitAddressField(
       return {
         ...obj,
         [field.key]: fieldValue,
-        ...(hasNoDelimiter ? {isUnsplittableField: true} : {}),
       };
     }
 


### PR DESCRIPTION
### What are you trying to accomplish?

Fix https://github.com/shop/issues-addresses/issues/209

This is essentially reverting the changes introduced in versions [`0.7.4`](https://github.com/Shopify/worldwide/pull/343) & [`0.7.5`](https://github.com/Shopify/worldwide/pull/345).

### What approach did you choose and why?

🔥 🧹 

### What should reviewers focus on?

Just double checking changes 🤷 

### The impact of these changes

Should be none

### Testing

N/A

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
