### PR TITLE
Require post code for Romania

### DIFF
--- a/data/regions/RO.yml
+++ b/data/regions/RO.yml
@@ -14,7 +14,7 @@ zip_regex: "^(RO-?)?\\d{6}$"
 zip_example: '060274'
 phone_number_prefix: 40
 building_number_required: true
-zip_requirement: recommended
+zip_requirement: required
 week_start_day: monday
 format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}{province}_{phone}"


### PR DESCRIPTION
### What are you trying to accomplish?

Fix https://github.com/shop/issues-addresses/issues/213

As reported by a merchant and confirmed by Perplexity, we should consider requiring post codes in Romania:
> No recent changes have been implemented to Romania's postcode standards or requirements as of April 2025.
The traditional 6-digit, address-based system remains in use, and postcodes are required for mail delivery.
There are plans to introduce personal postal codes in the future, but this system has not yet been rolled out nationwide

### What approach did you choose and why?

Changing the `zip_requirement` from `recommended` to `required`.

### What should reviewers focus on?

🦅 

### The impact of these changes

Post codes will be required in Checkout.

### Testing

N/A

### Checklist

* [ ] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
