### PR TITLE
Require postcodes and update regex in MT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Security in case of vulnerabilities.
 
 ## [Unreleased]
+- Require postcodes and update regex in MT [#354](https://github.com/Shopify/worldwide/pull/354)
 
 ---
 

--- a/data/regions/MT.yml
+++ b/data/regions/MT.yml
@@ -9,11 +9,10 @@ tax_inclusive: true
 group: European Countries
 group_name: Europe
 phone_number_prefix: 356
-zip_regex: "^(MT?-?)?[ABĊCDEFĠGHĦIJKLMNOPQRSTUVWXYŻZ]{2,3}( ?\\d{2,4})?$"
-zip_requirement: recommended
+zip_regex: "^(MT-?)?([Tt][Pp]|[A-Za-z]{3}) ?[0-9]{4}$"
 tags:
 - EU-member
-zip_example: NXR 01
+zip_example: VLT 1933
 format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{city}{zip}_{phone}"
   show: "{firstName} {lastName}_{company}_{address1}_{address2}_{city} {zip}_{country}_{phone}"

--- a/test/worldwide/regions/mt_test.rb
+++ b/test/worldwide/regions/mt_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Worldwide
+  class MtTest < ActiveSupport::TestCase
+    setup do
+      @region = Worldwide.region(code: "MT")
+    end
+
+    test "zip codes with country prefix are valid" do
+      assert @region.valid_zip?("MT-VLT 1933")
+      assert @region.valid_zip?("MT-VLT1933")
+    end
+
+    test "zip codes without country prefix are valid" do
+      assert @region.valid_zip?("VLT 1933")
+      assert @region.valid_zip?("VLT1933")
+    end
+
+    test "two-letter zip codes from Tigné Point are valid" do
+      assert @region.valid_zip?("TP 1933")
+      assert @region.valid_zip?("TP1933")
+    end
+
+    test "other two-letter zip codes are invalid" do
+      assert_not @region.valid_zip?("AA 1933")
+    end
+
+    test "pre-2007 formatted zip codes are invalid" do
+      assert_not @region.valid_zip?("VLT 05")
+    end
+
+    test "malformed zip codes are invalid" do
+      assert_not @region.valid_zip?("VLT 193")
+      assert_not @region.valid_zip?("VLT 19333")
+    end
+  end
+end


### PR DESCRIPTION
### What are you trying to accomplish?
Postal codes were recently made required in shipping addresses in Malta
Source: https://www.mca.org.mt/articles/mca-publishes-decision-postcodes-integral-part-postal-address

Summary from Perplexity:
> Postal codes are required for shipping addresses in Malta, but this requirement was only recently introduced. While postcodes have been in use in Malta since 1991, they were not mandatory for a long time[4](https://www.maltapost.com/news-details?id=3741)[7](https://www.mca.org.mt/articles/mca-publishes-decision-postcodes-integral-part-postal-address).
> 
> The Malta Communications Authority (MCA) published a decision in 2024 to make postcodes an integral part of postal addresses[7](https://www.mca.org.mt/articles/mca-publishes-decision-postcodes-integral-part-postal-address). This decision followed a consultation in October 2016 proposing to amend regulation 15 of the 'Postal Services (General) Regulations' to require addressed postal articles to include a postcode[7](https://www.mca.org.mt/articles/mca-publishes-decision-postcodes-integral-part-postal-address).
> 
> The implementation of this requirement involves several steps:
> 
> MaltaPost, the universal service provider, must undertake an extensive information program to inform the public about the change[7](https://www.mca.org.mt/articles/mca-publishes-decision-postcodes-integral-part-postal-address).
> 
> Each address in Malta and Gozo will receive individual notification of their postcode[7](https://www.mca.org.mt/articles/mca-publishes-decision-postcodes-integral-part-postal-address).
> 
> A six-month timeframe is applicable from the publication of the decision to the coming into force of the updated regulations[7](https://www.mca.org.mt/articles/mca-publishes-decision-postcodes-integral-part-postal-address).

### What approach did you choose and why?
Update the regular expression used to validate MT postcodes, using [this topic](https://en.wikipedia.org/wiki/Postal_codes_in_Malta) as a reference. Note that the old pattern allowed pre-2007 postcodes of the form XXX 00. We now follow the newer XXX 0000 or TP 0000 formats.

The pattern was tested against over 3000 real shipping addresses from checkout, where about 9% were found to have an invalid postcode, all legitimate rejections.

### 🎩 
Shopify devs can see a test PR from our monorepo that points to this branch. All test-related checks pass!

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
