### PR TITLE
Introduce name_alternates for NZ regions, cut v1.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Security in case of vulnerabilities.
 
 ## [Unreleased]
-- Require postcodes and update regex in MT [#354](https://github.com/Shopify/worldwide/pull/354)
 
 ---
+
+## [1.17.1] - 2025-06-06
+- Require postcodes and update regex in MT [#354](https://github.com/Shopify/worldwide/pull/354)
+- Introduce name_alternates for NZ regions [#357](https://github.com/Shopify/worldwide/pull/357)
 
 ## [1.17.0] - 2025-02-27
 - Add has_cities? method to regions [#331](https://github.com/Shopify/worldwide/pull/331)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (1.17.0)
+    worldwide (1.17.1)
       activesupport (>= 7.0)
       i18n
       phonelib (~> 0.8)

--- a/data/regions/NZ.yml
+++ b/data/regions/NZ.yml
@@ -30,6 +30,8 @@ example_address:
   phone: "+64 9 921 9999"
 zones:
 - name: Auckland
+  name_alternates:
+  - Auckland Region
   code: AUK
   tax: 0.0
   tax_name: GST
@@ -76,6 +78,8 @@ zones:
   - '2683'
   - '2684'
 - name: Bay of Plenty
+  name_alternates:
+  - Bay of Plenty Region
   code: BOP
   tax: 0.0
   tax_name: GST
@@ -101,6 +105,8 @@ zones:
   - '3611'
   - '3642'
 - name: Canterbury
+  name_alternates:
+  - Canterbury Region
   code: CAN
   tax: 0.0
   tax_name: GST
@@ -149,6 +155,8 @@ zones:
   - '9448'
   - '9498'
 - name: Chatham Islands
+  name_alternates:
+  - Chatham Islands Territory
   code: CIT
   tax: 0.0
   tax_name: GST
@@ -157,6 +165,8 @@ zones:
   - '8942'
   - '8944'
 - name: Gisborne
+  name_alternates:
+  - Gisborne Region
   code: GIS
   tax: 0.0
   tax_name: GST
@@ -166,6 +176,8 @@ zones:
   zip_prefixes:
   - '40'
 - name: Hawke's Bay
+  name_alternates:
+  - Hawke's Bay Region
   code: HKB
   tax: 0.0
   tax_name: GST
@@ -190,6 +202,8 @@ zones:
   - '4288'
   - '429'
 - name: Manawatu-Wanganui
+  name_alternates:
+  - Manawatu-Whanganui Region
   code: MWT
   tax: 0.0
   tax_name: GST
@@ -236,6 +250,8 @@ zones:
   - '5541'
   - '557'
 - name: Marlborough
+  name_alternates:
+  - Marlborough Region
   code: MBH
   tax: 0.0
   tax_name: GST
@@ -261,6 +277,8 @@ zones:
   - '728'
   - '7371'
 - name: Nelson
+  name_alternates:
+  - Nelson Region
   code: NSN
   tax: 0.0
   tax_name: GST
@@ -279,6 +297,8 @@ zones:
   - '7047'
   - '7071'
 - name: Northland
+  name_alternates:
+  - Northland Region
   code: NTL
   tax: 0.0
   tax_name: GST
@@ -292,6 +312,8 @@ zones:
   - '05'
   - '0975'
 - name: Otago
+  name_alternates:
+  - Otago Region
   code: OTA
   tax: 0.0
   tax_name: GST
@@ -341,6 +363,8 @@ zones:
   - '9775'
   - '9793'
 - name: Southland
+  name_alternates:
+  - Southland Region
   code: STL
   tax: 0.0
   tax_name: GST
@@ -376,6 +400,8 @@ zones:
   - '9794'
   - '98'
 - name: Taranaki
+  name_alternates:
+  - Taranaki Region
   code: TKI
   tax: 0.0
   tax_name: GST
@@ -416,6 +442,8 @@ zones:
   - '467'
   - '468'
 - name: Tasman
+  name_alternates:
+  - Tasman Region
   code: TAS
   tax: 0.0
   tax_name: GST
@@ -448,6 +476,8 @@ zones:
   - '7197'
   - '7198'
 - name: Waikato
+  name_alternates:
+  - Waikato Region
   code: WKO
   tax: 0.0
   tax_name: GST
@@ -525,6 +555,8 @@ zones:
   - '4350'
   - '4376'
 - name: Wellington
+  name_alternates:
+  - Wellington Region
   code: WGN
   tax: 0.0
   tax_name: GST
@@ -544,6 +576,8 @@ zones:
   - '58'
   - '6'
 - name: West Coast
+  name_alternates:
+  - West Coast Region
   code: WTC
   tax: 0.0
   tax_name: GST

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "1.17.0"
+  VERSION = "1.17.1"
 end


### PR DESCRIPTION
### What are you trying to accomplish?
Introduce name_alternates for NZ regions commonly returned by google's APIs. 

Cut new minor version 1.17.1


### What approach did you choose and why?
Introduced name alternates for New Zealand's 16 regions and 1 territory. 

### What should reviewers focus on?
<!--
Outline anything you'd like reviewers to pay extra attention to. List open questions for discussion.
-->

...

### The impact of these changes
Will improve internal systems autocomplete results for NZ. 

### Testing
Tested with the internal system running on this change. Were able to map the google results back to the desired zone code. 

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
