### PR TITLE
Set changesets GitHub action to v1.5.1 to fix a failing step in our release flow

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -35,7 +35,8 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Create release Pull Request or publish to NPM
         id: changesets
-        uses: changesets/action@v1
+        # uses: changesets/action@v1
+        uses: changesets/action@v1.5.1 # workaround until fix for https://github.com/changesets/action/issues/501
         with:
           publish: pnpm release
           cwd: lang/typescript


### PR DESCRIPTION
### What are you trying to accomplish?
We currently cannot release a new version of our gem due to an error in the npm release flow.

#### _Create release Pull Request or publish to NPM_ step
```
Run changesets/action@v[1](https://github.com/Shopify/worldwide/actions/runs/15397227305/job/43320963546#step:6:1)
  with:
    publish: pnpm release
    cwd: lang/typescript
    title: Version NPM Package
    commit: Version NPM Package
    setupGitUser: true
    createGithubReleases: true
    commitMode: git-cli
  env:
    PNPM_HOME: /home/runner/setup-pnpm/node_modules/.bin
    NPM_TOKEN: ***
    GITHUB_TOKEN: ***
    NPM_CONFIG_PROVENANCE: true
setting git user
/usr/bin/git config user.name "github-actions[bot]"
/usr/bin/git config user.email "41898[2](https://github.com/Shopify/worldwide/actions/runs/15397227305/job/43320963546#step:6:2)82+github-actions[bot]@users.noreply.github.com"
setting GitHub credentials
Error: Error: There is no .changeset directory in this project
Error: There is no .changeset directory in this project
```
I found this [existing bug](https://github.com/changesets/action/issues/501) on the action's repo. Users are rolling back to an older version until a fix such as [this one](https://github.com/changesets/action/pull/502) restores proper support for the `cwd` action param.

### What approach did you choose and why?
Pin to 1.5.1 which seems to have worked for others.


### Testing
We'll see what happens during the release process!

### Checklist

* [ ] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
