### PR TITLE
Bump bundler from 2.4.10 to 4.0.11

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,4 +148,4 @@ DEPENDENCIES
   worldwide!
 
 BUNDLED WITH
-   2.4.10
+  4.0.11


### PR DESCRIPTION
### What are you trying to accomplish?

Small gem maintenance fix to bring Bundler in-use up to date to the latest and greatest. 🚀

- https://github.com/rubygems/rubygems/releases/tag/bundler-v2.7.0
- https://github.com/rubygems/rubygems/releases/tag/bundler-v2.7.1
- https://github.com/rubygems/rubygems/releases/tag/bundler-v2.7.2
- https://github.com/ruby/rubygems/releases/tag/bundler-v4.0.0
- https://github.com/ruby/rubygems/releases/tag/bundler-v4.0.1
- https://github.com/ruby/rubygems/releases/tag/bundler-v4.0.2
- https://github.com/ruby/rubygems/releases/tag/bundler-v4.0.3
- https://github.com/ruby/rubygems/releases/tag/bundler-v4.0.4
- https://github.com/ruby/rubygems/releases/tag/bundler-v4.0.5
- https://github.com/ruby/rubygems/releases/tag/bundler-v4.0.6
- https://github.com/ruby/rubygems/releases/tag/bundler-v4.0.7
- https://github.com/ruby/rubygems/releases/tag/bundler-v4.0.8
- https://github.com/ruby/rubygems/releases/tag/bundler-v4.0.9
- https://github.com/ruby/rubygems/releases/tag/bundler-v4.0.10
- https://github.com/ruby/rubygems/releases/tag/bundler-v4.0.11

### What approach did you choose and why?

Standard `bundle update --bundler`.

### What should reviewers focus on?

Any concerns using latest Bundler? I don't have any.

### The impact of these changes

Better development experience.

### Testing

![Screenshot From 2025-06-08 15-26-12](https://github.com/user-attachments/assets/b55e1d55-2e50-4a41-94eb-eaf80da66843)

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)

Determined not necessary as it's a developer facing change, not user facing.