### PR TITLE
Setup GitHub Actions Dependabot and pin actions to commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,11 @@ updates:
     open-pull-requests-limit: 100
     insecure-external-code-execution: allow
     registries: "*"
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    ignore:
+      # Can not bump past v1.5.1 until https://github.com/changesets/action/issues/501 is fixed
+      - dependency-name: "changesets/action"
+        versions: [">=1.5.1"]

--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -11,13 +11,13 @@ jobs:
         working-directory: lang/typescript
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 20
       - name: Setup PNPM
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
         with:
           version: 9.1.3
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
     - name: Set up Ruby ${{ matrix.ruby }}
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@e34163cd15f4bb403dcd72d98e295997e6a55798 # v1.238.0
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -20,23 +20,22 @@ jobs:
         working-directory: lang/typescript
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           token: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 20
       - name: Setup PNPM
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
         with:
           version: 9.1.3
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Create release Pull Request or publish to NPM
         id: changesets
-        # uses: changesets/action@v1
-        uses: changesets/action@v1.5.1 # workaround until fix for https://github.com/changesets/action/issues/501
+        uses: changesets/action@001cd79f0a536e733315164543a727bdf2d70aff # v1.5.1
         with:
           publish: pnpm release
           cwd: lang/typescript


### PR DESCRIPTION
### What are you trying to accomplish?

Trying to get `worldwide` setup with Dependabot updates for GitHub Actions while also pinning the ones we're using to commit SHAs for security. Note, intentionally excluding `changesets/action` from bumps as appears necessary re: https://github.com/Shopify/worldwide/pull/358.

Supersedes https://github.com/Shopify/worldwide/pull/351
Semi-follow up to https://github.com/Shopify/worldwide/pull/358

### What approach did you choose and why?

This is standard procedure. There's even a PR already proposing doing this. Unfortunately it's outdated at this point.

### What should reviewers focus on?

Any concerns? I don't have any.

### The impact of these changes

Better more secure repository.

### Testing

Not relevant assuming CI is happy.

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)

Determined not necessary as it's a developer facing change, not user facing.