### PR TITLE
Bump minitest from 5.17.0 to 5.27.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ GEM
     json (2.7.1)
     language_server-protocol (3.17.0.3)
     method_source (1.1.0)
-    minitest (5.17.0)
+    minitest (5.27.0)
     minitest-focus (1.3.1)
       minitest (>= 4, < 6)
     minitest-reporters (1.5.0)


### PR DESCRIPTION
### What are you trying to accomplish?

Bumps minitest from 5.17.0 to 5.27.0 (cannot upgrade to 6.x yet) ~and mocha from 2.0.2 to 3.0.2~.

- https://github.com/minitest/minitest/blob/400c5a30adfe67a51b6f10b2875327557e0db00c/History.rdoc#label-5.27.0+-2F+2025-12-11
- ~https://github.com/freerange/mocha/releases/tag/v3.0.2~

In general we should use the latest versions of Minitest and Mocha as a best practice.

### What approach did you choose and why?

Standard bump overall.

### What should reviewers focus on?

Nothing in particular.

### The impact of these changes

Better CI and development experience.

### Testing

<img width="2123" height="650" alt="Screenshot From 2026-01-03 13-56-05" src="https://github.com/user-attachments/assets/8894d9ba-99a8-497a-bd65-7b0bbab4260e" />

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)

Determined not necessary as it's a developer facing change, not user facing.