### PR TITLE
Fix `example_city` and `example_city_zip` non-nil tests so they actually assert such

### DIFF
--- a/test/worldwide/region_yml_consistency_test.rb
+++ b/test/worldwide/region_yml_consistency_test.rb
@@ -485,14 +485,22 @@ module Worldwide
     end
 
     test "example_city is available for each US state" do
-      assert_predicate Worldwide.region(code: "US").zones, :all? do |state|
-        !state.example_city&.empty?
+      Worldwide.region(code: "US").zones.each do |state|
+        # Skip territories that legitimately don't have cities
+        next if state.iso_code == "UM" # United States Minor Outlying Islands
+
+        assert_kind_of String, state.example_city, "example_city should be a String for #{state.iso_code}"
+        refute_predicate state.example_city, :empty?, "example_city should not be empty for #{state.iso_code}"
       end
     end
 
     test "example_city_zip is available for each US state" do
-      assert_predicate Worldwide.region(code: "US").zones, :all? do |state|
-        !state.example_city_zip&.empty?
+      Worldwide.region(code: "US").zones.each do |state|
+        # Skip territories that legitimately don't have zip codes
+        next if state.iso_code == "UM" # United States Minor Outlying Islands
+
+        assert_kind_of String, state.example_city_zip, "example_city_zip should be a String for #{state.iso_code}"
+        refute_predicate state.example_city_zip, :empty?, "example_city_zip should not be empty for #{state.iso_code}"
       end
     end
 


### PR DESCRIPTION
### What are you trying to accomplish?

Ensure the updated tests actually assert that all US states/territories (aside from UM) have an example city and zip. The tests currently appear to not be testing anything as `assert_predicate` does not appear to accept a block re: [docs](https://devdocs.io/minitest/minitest/assertions#method-i-assert_predicate) and the following warning which appears when running the tests:

```console
/home/larouxn/src/github.com/larouxn/worldwide/test/worldwide/region_yml_consistency_test.rb:488: warning: the block passed to 'assert_predicate' defined at /home/larouxn/.gem/ruby/3.4.4/gems/minitest-5.25.5/lib/minitest/assertions.rb:391 may be ignored
```

### What approach did you choose and why?

Broke down the assertions into one by one within a loop and added a skip for `UM` as it's an outlier.

### What should reviewers focus on?

Are we okay with the method of skipping `UM`?

### The impact of these changes

Tests actually assert what we want to assert.

### Testing

With the updated tests but no `UM` skip.

![Screenshot From 2025-06-08 18-37-14](https://github.com/user-attachments/assets/1283e139-cf4d-4646-ba0b-1558f57e8e9b)

With the updated test plus `UM` skip.

![Screenshot From 2025-06-08 18-37-32](https://github.com/user-attachments/assets/be019349-b04a-4641-bd0e-ee62fdbbd931)

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)

Determined not necessary as it's a developer facing change, not user facing.