### PR TITLE
Bump phonelib from 0.8.7 to 0.10.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- Upgrade phonelib gem from 0.8.7 to 0.10.16 to pick up latest phone number data and bug fixes [#366](https://github.com/Shopify/worldwide/pull/366)
+
 ---
 ## [1.22.0] - 2026-03-09
 - Add CLDR unit formatting support for 12 new measurement categories: area, duration, electric, energy, frequency, light, power, pressure, speed, temperature, digital, and graphics (~50 new unit keys with locale-aware formatting) [#436](https://github.com/Shopify/worldwide/pull/436)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ PATH
     worldwide (1.22.0)
       activesupport (>= 7.0)
       i18n
-      phonelib (~> 0.8)
+      phonelib (~> 0.10)
 
 GEM
   remote: https://rubygems.org/
@@ -66,7 +66,7 @@ GEM
     parser (3.3.0.5)
       ast (~> 2.4.1)
       racc
-    phonelib (0.8.7)
+    phonelib (0.10.16)
     prettier_print (1.2.0)
     pry (0.14.2)
       coderay (~> 1.1)

--- a/worldwide.gemspec
+++ b/worldwide.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency("activesupport", ">= 7.0")
   spec.add_dependency("i18n")
-  spec.add_dependency("phonelib", "~> 0.8")
+  spec.add_dependency("phonelib", "~> 0.10")
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Update `phonelib` gem to latest for the following benefits:

1. Brings with it the latest phone number data and bug fixes.
2. Fixes frozen string warnings that appear as of Ruby 3.4 re: [#359](https://github.com/Shopify/worldwide/pull/359).

Main big releases between 0.8.7 and 0.10.16 are as follows. Rest are data update releases.

- https://github.com/daddyz/phonelib/releases/tag/v0.9.0
- https://github.com/daddyz/phonelib/releases/tag/v0.10.1

### What approach did you choose and why?

Standard gem bump.

### What should reviewers focus on?

Any concerns with this upgrade? Should definitely test in some system/app that uses this gem.

### The impact of these changes

Should improve phone number parsing overall.

### Testing

![Screenshot From 2025-06-08 18-39-10](https://github.com/user-attachments/assets/2d34b5bb-b755-4e72-8624-56e6941fb918)

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
