### PR TITLE
Require postal codes in Romania

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Security in case of vulnerabilities.
 
 ## [Unreleased]
-
+- Require postal codes in Romania [#368](https://github.com/Shopify/worldwide/pull/368)
 
 ---
 

--- a/data/regions/RO.yml
+++ b/data/regions/RO.yml
@@ -14,7 +14,6 @@ zip_regex: "^(RO-?)?\\d{6}$"
 zip_example: '060274'
 phone_number_prefix: 40
 building_number_required: true
-zip_requirement: recommended
 week_start_day: monday
 format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}{province}_{phone}"


### PR DESCRIPTION
### What are you trying to accomplish?
Approximately 90% of all checkouts shipping to a Romanian address include a postal code value (with 94% of those being syntactically valid), despite our form labelling the postal code field as optional. Merchants have been asking to make this field mandatory in order to avoid fulfillment issues.

The Romanian Post website does not explicitly say that postal codes are required, but it does say the following:

>[For which services do I have to provide the zip code?](https://www.posta-romana.ro/en/help.html#collapseads22)
The zip code must be provided for all electronic monitored items and all the postal items for which tariff reduction is granted for sorting by zip code. In these cases, posting an item is possible under the condition that the zip code is provided for each item.

Sources like the GRCDI global sourcebook, Wikipedia and the Universal Postal Union do not flag postal codes as optional.

### Testing
I will link CI runs for Shopify services pointing to this branch.

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
