### PR TITLE
Include postal code prefixes for japan zones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Security in case of vulnerabilities.
 
 ## [Unreleased]
+- Add zip prefixes for regions in Japan [#376](https://github.com/Shopify/worldwide/pull/376)
 
 ---
 

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ group :development do
   gem "rubocop", require: false
   gem "ruby-lsp", require: false
   gem "pry-byebug", require: false
+  gem "csv"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,7 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
+    csv (3.3.5)
     drb (2.1.1)
       ruby2_keywords
     i18n (1.14.1)
@@ -130,6 +131,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  csv
   minitest (~> 5.0)
   minitest-focus
   minitest-reporters

--- a/Rakefile
+++ b/Rakefile
@@ -19,6 +19,6 @@ require "rubocop/rake_task"
 
 RuboCop::RakeTask.new
 
-Dir.glob("rake/tasks/*.rake").each { |r| load r }
+Dir.glob("rake/tasks/**/*.rake").each { |r| load r }
 
 task default: [:test, :rubocop]

--- a/data/regions/JP.yml
+++ b/data/regions/JP.yml
@@ -26,7 +26,8 @@ example_address:
   phone: "+81 (3) 3581-0101"
 format:
   edit: "{country}_{lastName}{firstName}_{company}_{zip}{province}_{city}_{address1}_{address2}_{phone}"
-  show: "{country} 〒{zip}_{province} {city}_{address1}_{address2}_{company}_{lastName} {firstName}様_{phone}"
+  show: "{country} 〒{zip}_{province} {city}_{address1}_{address2}_{company}_{lastName}
+    {firstName}様_{phone}"
 emoji: "\U0001F1EF\U0001F1F5"
 zones:
 - name: Hokkaidō
@@ -37,6 +38,14 @@ zones:
   iso_code: JP-01
   tax: 0.0
   priority: 47
+  zip_prefixes:
+  - '00'
+  - '04'
+  - '05'
+  - '06'
+  - '07'
+  - '08'
+  - '09'
 - name: Aomori
   name_alternates:
   - Aomori Prefecture
@@ -47,6 +56,9 @@ zones:
   iso_code: JP-02
   tax: 0.0
   priority: 46
+  zip_prefixes:
+  - '018-550'
+  - '03'
 - name: Iwate
   name_alternates:
   - Iwate Prefecture
@@ -57,6 +69,8 @@ zones:
   iso_code: JP-03
   tax: 0.0
   priority: 45
+  zip_prefixes:
+  - '02'
 - name: Miyagi
   name_alternates:
   - Miyagi Prefecture
@@ -67,6 +81,8 @@ zones:
   iso_code: JP-04
   tax: 0.0
   priority: 44
+  zip_prefixes:
+  - '98'
 - name: Akita
   name_alternates:
   - Akita Prefecture
@@ -77,6 +93,29 @@ zones:
   iso_code: JP-05
   tax: 0.0
   priority: 43
+  zip_prefixes:
+  - '010'
+  - '011'
+  - '012'
+  - '013'
+  - '014'
+  - '015'
+  - '016'
+  - '017'
+  - '018-0'
+  - '018-1'
+  - '018-2'
+  - '018-3'
+  - '018-4'
+  - '018-51'
+  - '018-52'
+  - '018-53'
+  - '018-54'
+  - '018-551'
+  - '018-56'
+  - '018-57'
+  - '018-58'
+  - '019'
 - name: Yamagata
   name_alternates:
   - Yamagata Prefecture
@@ -87,6 +126,8 @@ zones:
   iso_code: JP-06
   tax: 0.0
   priority: 42
+  zip_prefixes:
+  - '99'
 - name: Fukushima
   name_alternates:
   - Fukushima Prefecture
@@ -97,6 +138,9 @@ zones:
   iso_code: JP-07
   tax: 0.0
   priority: 41
+  zip_prefixes:
+  - '96'
+  - '97'
 - name: Ibaraki
   name_alternates:
   - Ibaraki Prefecture
@@ -107,6 +151,27 @@ zones:
   iso_code: JP-08
   tax: 0.0
   priority: 40
+  zip_prefixes:
+  - '30'
+  - '310'
+  - 311-0
+  - 311-1
+  - 311-2
+  - 311-3
+  - 311-41
+  - 311-42
+  - 311-43
+  - 311-440
+  - 311-45
+  - 311-46
+  - '312'
+  - '313'
+  - '314'
+  - '315'
+  - '316'
+  - '317'
+  - '318'
+  - '319'
 - name: Tochigi
   name_alternates:
   - Tochigi Prefecture
@@ -117,6 +182,10 @@ zones:
   iso_code: JP-09
   tax: 0.0
   priority: 39
+  zip_prefixes:
+  - 311-441
+  - '32'
+  - 349-122
 - name: Gunma
   name_alternates:
   - Gunma Prefecture
@@ -127,6 +196,38 @@ zones:
   iso_code: JP-10
   tax: 0.0
   priority: 38
+  zip_prefixes:
+  - 370-0
+  - 370-11
+  - 370-12
+  - 370-13
+  - 370-14
+  - 370-1501
+  - 370-1502
+  - 370-1503
+  - 370-1504
+  - 370-1505
+  - 370-1506
+  - 370-151
+  - 370-16
+  - 370-2
+  - 370-3
+  - 370-85
+  - 370-860
+  - 370-861
+  - 370-862
+  - 370-866
+  - '371'
+  - '372'
+  - '373'
+  - '374'
+  - '375'
+  - '376'
+  - '377'
+  - '378'
+  - '379'
+  - 384-0097
+  - 389-012
 - name: Saitama
   name_alternates:
   - Saitama Prefecture
@@ -137,6 +238,30 @@ zones:
   iso_code: JP-11
   tax: 0.0
   priority: 37
+  zip_prefixes:
+  - 100-8620
+  - 100-8639
+  - 121-872
+  - 174-8741
+  - 174-8743
+  - '33'
+  - '340'
+  - '341'
+  - '342'
+  - '343'
+  - '344'
+  - '345'
+  - '346'
+  - '347'
+  - '348'
+  - 349-0
+  - 349-11
+  - 349-120
+  - 349-121
+  - 349-129
+  - '35'
+  - '36'
+  - 370-1507
 - name: Chiba
   name_alternates:
   - Chiba Prefecture
@@ -147,6 +272,12 @@ zones:
   iso_code: JP-12
   tax: 0.0
   priority: 36
+  zip_prefixes:
+  - 100-8677
+  - '26'
+  - '27'
+  - '28'
+  - '29'
 - name: Tōkyō
   name_alternates:
   - Tokyo Prefecture
@@ -157,6 +288,76 @@ zones:
   iso_code: JP-13
   tax: 0.0
   priority: 35
+  zip_prefixes:
+  - 100-0
+  - 100-1
+  - 100-2
+  - 100-6
+  - 100-7
+  - 100-80
+  - 100-81
+  - 100-82
+  - 100-83
+  - 100-84
+  - 100-85
+  - 100-860
+  - 100-861
+  - 100-8621
+  - 100-8629
+  - 100-8631
+  - 100-864
+  - 100-865
+  - 100-866
+  - 100-8676
+  - 100-87
+  - 100-89
+  - '101'
+  - '102'
+  - '103'
+  - '104'
+  - '105'
+  - '106'
+  - '107'
+  - '108'
+  - '109'
+  - '11'
+  - '120'
+  - 121-0
+  - 121-80
+  - 121-85
+  - 121-86
+  - 121-871
+  - '123'
+  - '124'
+  - '125'
+  - '13'
+  - '14'
+  - '15'
+  - '16'
+  - '170'
+  - '171'
+  - '173'
+  - 174-0
+  - 174-85
+  - 174-86
+  - 174-870
+  - 174-871
+  - 174-873
+  - 174-8740
+  - 174-8744
+  - 174-878
+  - 174-88
+  - 174-89
+  - '175'
+  - '176'
+  - '177'
+  - '178'
+  - '179'
+  - '18'
+  - '19'
+  - '20'
+  - 220-8604
+  - 370-868
 - name: Kanagawa
   name_alternates:
   - Kanagawa Prefecture
@@ -167,6 +368,32 @@ zones:
   iso_code: JP-14
   tax: 0.0
   priority: 34
+  zip_prefixes:
+  - '21'
+  - 220-0
+  - 220-6
+  - 220-80
+  - 220-81
+  - 220-84
+  - 220-85
+  - 220-8601
+  - 220-8609
+  - 220-861
+  - 220-862
+  - 220-865
+  - 220-866
+  - 220-868
+  - 220-87
+  - '221'
+  - '222'
+  - '223'
+  - '224'
+  - '225'
+  - '226'
+  - '227'
+  - '23'
+  - '24'
+  - '25'
 - name: Niigata
   name_alternates:
   - Niigata Prefecture
@@ -177,6 +404,33 @@ zones:
   iso_code: JP-15
   tax: 0.0
   priority: 33
+  zip_prefixes:
+  - 389-226
+  - '940'
+  - '941'
+  - '942'
+  - '943'
+  - '944'
+  - '945'
+  - '946'
+  - '947'
+  - '948'
+  - 949-0
+  - 949-1
+  - 949-2
+  - 949-3
+  - 949-4
+  - 949-5
+  - 949-6
+  - 949-7
+  - 949-81
+  - 949-82
+  - 949-831
+  - 949-84
+  - 949-85
+  - 949-86
+  - 949-87
+  - '95'
 - name: Toyama
   name_alternates:
   - Toyama Prefecture
@@ -187,6 +441,34 @@ zones:
   iso_code: JP-16
   tax: 0.0
   priority: 32
+  zip_prefixes:
+  - '930'
+  - '931'
+  - '932'
+  - '933'
+  - '934'
+  - '935'
+  - '936'
+  - '937'
+  - '938'
+  - 939-00
+  - 939-010
+  - 939-011
+  - 939-012
+  - 939-013
+  - 939-014
+  - 939-015
+  - 939-019
+  - 939-02
+  - 939-03
+  - 939-04
+  - 939-05
+  - 939-06
+  - 939-07
+  - 939-1
+  - 939-2
+  - 939-3
+  - 939-8
 - name: Ishikawa
   name_alternates:
   - Ishikawa Prefecture
@@ -197,6 +479,28 @@ zones:
   iso_code: JP-17
   tax: 0.0
   priority: 31
+  zip_prefixes:
+  - '920'
+  - '921'
+  - 922-00
+  - 922-01
+  - 922-02
+  - 922-03
+  - 922-04
+  - 922-05
+  - 922-0671
+  - 922-0672
+  - 922-0673
+  - 922-08
+  - 922-8
+  - '923'
+  - '924'
+  - '925'
+  - '926'
+  - '927'
+  - '928'
+  - '929'
+  - 939-017
 - name: Fukui
   name_alternates:
   - Fukui Prefecture
@@ -207,6 +511,9 @@ zones:
   iso_code: JP-18
   tax: 0.0
   priority: 30
+  zip_prefixes:
+  - '91'
+  - 922-0679
 - name: Yamanashi
   name_alternates:
   - Yamanashi Prefecture
@@ -217,6 +524,8 @@ zones:
   iso_code: JP-19
   tax: 0.0
   priority: 29
+  zip_prefixes:
+  - '40'
 - name: Nagano
   name_alternates:
   - Nagano Prefecture
@@ -227,6 +536,61 @@ zones:
   iso_code: JP-20
   tax: 0.0
   priority: 28
+  zip_prefixes:
+  - '380'
+  - '381'
+  - '382'
+  - '383'
+  - 384-000
+  - 384-001
+  - 384-002
+  - 384-003
+  - 384-004
+  - 384-005
+  - 384-006
+  - 384-007
+  - 384-008
+  - 384-0091
+  - 384-0092
+  - 384-0093
+  - 384-0094
+  - 384-0095
+  - 384-0096
+  - 384-03
+  - 384-04
+  - 384-05
+  - 384-06
+  - 384-07
+  - 384-08
+  - 384-1
+  - 384-2
+  - 384-8
+  - '385'
+  - '386'
+  - '387'
+  - '388'
+  - 389-010
+  - 389-011
+  - 389-019
+  - 389-02
+  - 389-04
+  - 389-05
+  - 389-06
+  - 389-08
+  - 389-1
+  - 389-21
+  - 389-220
+  - 389-223
+  - 389-224
+  - 389-225
+  - 389-229
+  - 389-23
+  - 389-24
+  - 389-25
+  - 389-26
+  - 389-27
+  - '39'
+  - 949-832
 - name: Gifu
   name_alternates:
   - Gifu Prefecture
@@ -237,6 +601,8 @@ zones:
   iso_code: JP-21
   tax: 0.0
   priority: 27
+  zip_prefixes:
+  - '50'
 - name: Shizuoka
   name_alternates:
   - Shizuoka Prefecture
@@ -247,6 +613,25 @@ zones:
   iso_code: JP-22
   tax: 0.0
   priority: 26
+  zip_prefixes:
+  - '41'
+  - '42'
+  - '430'
+  - 431-0
+  - 431-1
+  - 431-2
+  - 431-3
+  - 431-410
+  - 431-411
+  - 431-419
+  - '432'
+  - '433'
+  - '434'
+  - '435'
+  - '436'
+  - '437'
+  - '438'
+  - '439'
 - name: Aichi
   name_alternates:
   - Aichi Prefecture
@@ -257,6 +642,37 @@ zones:
   iso_code: JP-23
   tax: 0.0
   priority: 25
+  zip_prefixes:
+  - 431-412
+  - '44'
+  - '45'
+  - '46'
+  - '47'
+  - '48'
+  - '490'
+  - '491'
+  - '492'
+  - '493'
+  - '494'
+  - '495'
+  - '496'
+  - '497'
+  - 498-0001
+  - 498-0002
+  - 498-0003
+  - 498-0004
+  - 498-0005
+  - 498-0006
+  - 498-0007
+  - 498-001
+  - 498-002
+  - 498-003
+  - 498-004
+  - 498-005
+  - 498-006
+  - 498-8501
+  - 498-8502
+  - 498-8505
 - name: Mie
   name_alternates:
   - Mie Prefecture
@@ -267,6 +683,11 @@ zones:
   iso_code: JP-24
   tax: 0.0
   priority: 24
+  zip_prefixes:
+  - 498-08
+  - 498-8503
+  - '51'
+  - 647-13
 - name: Shiga
   name_alternates:
   - Shiga Prefecture
@@ -277,6 +698,27 @@ zones:
   iso_code: JP-25
   tax: 0.0
   priority: 23
+  zip_prefixes:
+  - 520-00
+  - 520-01
+  - 520-02
+  - 520-03
+  - 520-047
+  - 520-05
+  - 520-08
+  - 520-1
+  - 520-2
+  - 520-3
+  - 520-8
+  - '521'
+  - '522'
+  - '523'
+  - '524'
+  - '525'
+  - '526'
+  - '527'
+  - '528'
+  - '529'
 - name: Kyōto
   name_alternates:
   - Kyoto Prefecture
@@ -287,6 +729,27 @@ zones:
   iso_code: JP-26
   tax: 0.0
   priority: 22
+  zip_prefixes:
+  - 520-046
+  - '60'
+  - '610'
+  - '611'
+  - '612'
+  - '613'
+  - '614'
+  - '615'
+  - '616'
+  - '617'
+  - 618-007
+  - 618-008
+  - 618-009
+  - 618-8501
+  - 618-8511
+  - 618-852
+  - 618-8558
+  - 618-856
+  - '619'
+  - '62'
 - name: Ōsaka
   name_alternates:
   - Osaka Prefecture
@@ -297,6 +760,48 @@ zones:
   iso_code: JP-27
   tax: 0.0
   priority: 21
+  zip_prefixes:
+  - '530'
+  - '531'
+  - '532'
+  - '533'
+  - '534'
+  - '535'
+  - '536'
+  - '537'
+  - '538'
+  - 539-0
+  - '54'
+  - '55'
+  - '560'
+  - '561'
+  - '562'
+  - 563-00
+  - 563-01
+  - 563-02
+  - 563-03
+  - 563-8
+  - '564'
+  - '565'
+  - '566'
+  - '567'
+  - '568'
+  - '569'
+  - '57'
+  - '58'
+  - '59'
+  - 618-0001
+  - 618-0002
+  - 618-0003
+  - 618-0004
+  - 618-001
+  - 618-002
+  - 618-8502
+  - 618-8518
+  - 618-8555
+  - 618-857
+  - 618-858
+  - 630-027
 - name: Hyōgo
   name_alternates:
   - Hyogo Prefecture
@@ -307,6 +812,12 @@ zones:
   iso_code: JP-28
   tax: 0.0
   priority: 20
+  zip_prefixes:
+  - 539-8
+  - 563-08
+  - '65'
+  - '66'
+  - '67'
 - name: Nara
   name_alternates:
   - Nara Prefecture
@@ -317,6 +828,33 @@ zones:
   iso_code: JP-29
   tax: 0.0
   priority: 19
+  zip_prefixes:
+  - 630-00
+  - 630-01
+  - 630-020
+  - 630-021
+  - 630-022
+  - 630-023
+  - 630-024
+  - 630-025
+  - 630-026
+  - 630-028
+  - 630-029
+  - 630-1
+  - 630-2
+  - 630-8
+  - '631'
+  - '632'
+  - '633'
+  - '634'
+  - '635'
+  - '636'
+  - '637'
+  - '638'
+  - '639'
+  - 647-127
+  - 647-15
+  - 648-03
 - name: Wakayama
   name_alternates:
   - Wakayama Prefecture
@@ -327,6 +865,30 @@ zones:
   iso_code: JP-30
   tax: 0.0
   priority: 18
+  zip_prefixes:
+  - '640'
+  - '641'
+  - '642'
+  - '643'
+  - '644'
+  - '645'
+  - '646'
+  - 647-0
+  - 647-11
+  - 647-120
+  - 647-121
+  - 647-122
+  - 647-123
+  - 647-129
+  - 647-16
+  - 647-17
+  - 647-8
+  - 648-00
+  - 648-01
+  - 648-02
+  - 648-04
+  - 648-8
+  - '649'
 - name: Tottori
   name_alternates:
   - Tottori Prefecture
@@ -337,6 +899,14 @@ zones:
   iso_code: JP-31
   tax: 0.0
   priority: 17
+  zip_prefixes:
+  - '680'
+  - '681'
+  - '682'
+  - '683'
+  - 684-00
+  - 684-8
+  - '689'
 - name: Shimane
   name_alternates:
   - Shimane Prefecture
@@ -347,6 +917,13 @@ zones:
   iso_code: JP-32
   tax: 0.0
   priority: 16
+  zip_prefixes:
+  - 684-01
+  - 684-02
+  - 684-03
+  - 684-04
+  - '685'
+  - '69'
 - name: Okayama
   name_alternates:
   - Okayama Prefecture
@@ -357,6 +934,9 @@ zones:
   iso_code: JP-33
   tax: 0.0
   priority: 15
+  zip_prefixes:
+  - '70'
+  - '71'
 - name: Hiroshima
   name_alternates:
   - Hiroshima Prefecture
@@ -367,6 +947,9 @@ zones:
   iso_code: JP-34
   tax: 0.0
   priority: 14
+  zip_prefixes:
+  - '72'
+  - '73'
 - name: Yamaguchi
   name_alternates:
   - Yamaguchi Prefecture
@@ -377,6 +960,9 @@ zones:
   iso_code: JP-35
   tax: 0.0
   priority: 13
+  zip_prefixes:
+  - '74'
+  - '75'
 - name: Tokushima
   name_alternates:
   - Tokushima Prefecture
@@ -387,6 +973,8 @@ zones:
   iso_code: JP-36
   tax: 0.0
   priority: 12
+  zip_prefixes:
+  - '77'
 - name: Kagawa
   name_alternates:
   - Kagawa Prefecture
@@ -397,6 +985,8 @@ zones:
   iso_code: JP-37
   tax: 0.0
   priority: 11
+  zip_prefixes:
+  - '76'
 - name: Ehime
   name_alternates:
   - Ehime Prefecture
@@ -407,6 +997,8 @@ zones:
   iso_code: JP-38
   tax: 0.0
   priority: 10
+  zip_prefixes:
+  - '79'
 - name: Kōchi
   name_alternates:
   - Kochi Prefecture
@@ -417,6 +1009,8 @@ zones:
   iso_code: JP-39
   tax: 0.0
   priority: 9
+  zip_prefixes:
+  - '78'
 - name: Fukuoka
   name_alternates:
   - Fukuoka Prefecture
@@ -427,6 +1021,42 @@ zones:
   iso_code: JP-40
   tax: 0.0
   priority: 8
+  zip_prefixes:
+  - '80'
+  - '810'
+  - 811-0
+  - 811-1
+  - 811-2
+  - 811-3
+  - 811-4
+  - '812'
+  - '813'
+  - '814'
+  - '815'
+  - '816'
+  - '818'
+  - '819'
+  - '82'
+  - '830'
+  - '831'
+  - '832'
+  - '833'
+  - '834'
+  - '835'
+  - '836'
+  - '837'
+  - '838'
+  - 839-0
+  - 839-12
+  - 839-13
+  - 839-140
+  - 839-141
+  - 839-149
+  - 839-8
+  - 871-022
+  - 871-08
+  - 871-09
+  - 871-858
 - name: Saga
   name_alternates:
   - Saga Prefecture
@@ -437,6 +1067,19 @@ zones:
   iso_code: JP-41
   tax: 0.0
   priority: 7
+  zip_prefixes:
+  - '840'
+  - '841'
+  - '842'
+  - '843'
+  - '844'
+  - '845'
+  - '846'
+  - '847'
+  - 848-00
+  - 848-01
+  - 848-8
+  - '849'
 - name: Nagasaki
   name_alternates:
   - Nagasaki Prefecture
@@ -447,6 +1090,11 @@ zones:
   iso_code: JP-42
   tax: 0.0
   priority: 6
+  zip_prefixes:
+  - 811-5
+  - '817'
+  - 848-04
+  - '85'
 - name: Kumamoto
   name_alternates:
   - Kumamoto Prefecture
@@ -457,6 +1105,8 @@ zones:
   iso_code: JP-43
   tax: 0.0
   priority: 5
+  zip_prefixes:
+  - '86'
 - name: Ōita
   name_alternates:
   - Oita Prefecture
@@ -467,6 +1117,47 @@ zones:
   iso_code: JP-44
   tax: 0.0
   priority: 4
+  zip_prefixes:
+  - 839-142
+  - '870'
+  - 871-0001
+  - 871-0002
+  - 871-0003
+  - 871-0004
+  - 871-0005
+  - 871-0006
+  - 871-0007
+  - 871-0008
+  - 871-0009
+  - 871-001
+  - 871-002
+  - 871-003
+  - 871-004
+  - 871-005
+  - 871-006
+  - 871-007
+  - 871-008
+  - 871-009
+  - 871-01
+  - 871-020
+  - 871-029
+  - 871-03
+  - 871-04
+  - 871-07
+  - 871-850
+  - 871-851
+  - 871-852
+  - 871-855
+  - 871-857
+  - 871-86
+  - '872'
+  - '873'
+  - '874'
+  - '875'
+  - '876'
+  - '877'
+  - '878'
+  - '879'
 - name: Miyazaki
   name_alternates:
   - Miyazaki Prefecture
@@ -477,6 +1168,8 @@ zones:
   iso_code: JP-45
   tax: 0.0
   priority: 3
+  zip_prefixes:
+  - '88'
 - name: Kagoshima
   name_alternates:
   - Kagoshima Prefecture
@@ -487,6 +1180,8 @@ zones:
   iso_code: JP-46
   tax: 0.0
   priority: 2
+  zip_prefixes:
+  - '89'
 - name: Okinawa
   name_alternates:
   - Okinawa Prefecture
@@ -497,4 +1192,6 @@ zones:
   iso_code: JP-47
   tax: 0.0
   priority: 1
+  zip_prefixes:
+  - '90'
 timezone: Asia/Tokyo

--- a/docs/notebooks/README.md
+++ b/docs/notebooks/README.md
@@ -1,0 +1,127 @@
+# Japan Postal Code Prefix Validator
+
+This notebook validates Japanese postal codes against their expected prefecture-specific prefixes using real shipping data and the Worldwide library's Japanese region configuration.
+
+## Overview
+
+The `jp-prefix-validator.ipynb` notebook is a data analysis tool that validates the accuracy of Japanese postal codes by checking whether they use the correct prefixes for their corresponding prefectures/provinces. This validation helps ensure data quality and identifies potential issues in address datasets.
+
+## What It Does
+
+The validator performs the following operations:
+
+1. **Data Loading**: Loads shipping data from a CSV file containing postal codes and province information
+2. **Configuration Loading**: Imports Japanese postal code prefix mappings from YAML configuration files
+3. **Province Mapping**: Creates mappings between province names (in multiple languages/formats) and standardized zone codes
+4. **Postal Code Validation**: Validates that each postal code's prefix matches the expected prefixes for its province
+5. **Error Reporting**: Provides detailed statistics on validation results and identifies invalid postal codes
+
+## How Japanese Postal Codes Work
+
+Japanese postal codes (郵便番号) follow a 7-digit format: `XXX-XXXX`. The first 2-3 digits serve as prefixes that correspond to specific prefectures and regions within Japan. Each prefecture has one or more designated prefixes, and postal codes must use the correct prefix for their geographic location.
+
+## Dependencies
+
+Before running the notebook, ensure you have the following Python packages installed:
+
+```bash
+pip install pandas
+pip install python-dotenv
+pip install PyYAML
+```
+
+## Required Files
+
+The notebook expects the following files to be present:
+
+1. **`data.csv`**: A CSV file containing shipping data with at least these columns:
+
+   - `shipping_postal_code`: Japanese postal codes in XXX-XXXX format
+   - `shipping_province`: Prefecture names (can be in English, Japanese, or romanized formats)
+
+2. **`zip_prefixes.yaml`**: YAML configuration file containing Japanese region data with zip prefixes (from the Worldwide library's region data). You can also have a .env file in the same directory and specify with PATH_TO_YAML the path to the the yaml file.
+
+## Environment Configuration
+
+Create a `.env` file to specify the path to your YAML configuration:
+
+```bash
+PATH_TO_YAML=path/to/your/zip_prefixes.yaml
+```
+
+If not specified, the notebook will look for `zip_prefixes.yaml` in the current directory.
+
+## Usage
+
+1. **Prepare your data**: Ensure your CSV file contains the required columns with Japanese postal codes and prefecture names
+
+2. **Set up configuration**: Place the Japanese region configuration YAML file in the appropriate location
+
+3. **Run the notebook**: Execute all cells in sequence:
+   - Cell 0: Install dependencies
+   - Cell 1: Load and clean data
+   - Cell 2: Load YAML configuration
+   - Cell 3: Create province name mappings
+   - Cell 4: Create prefix mappings
+   - Cell 5: Filter and prepare data
+   - Cell 6: Validate postal codes and generate report
+
+## Output Interpretation
+
+The validation results include:
+
+- **Total rows processed**: Number of valid postal code records analyzed
+- **Total invalid prefixes**: Count of postal codes that don't match expected prefixes
+- **Total unique invalid prefixes**: Count of distinct invalid postal codes
+- **Percentage of invalid prefixes**: Error rate as a percentage
+- **Detailed invalid prefixes**: Breakdown by prefecture showing specific invalid postal codes
+
+### Example Output
+
+```
+Total rows: 80748
+Total invalid prefixes: 398
+Total unique invalid prefixes: 381
+Percentage of invalid prefixes: 0.49%
+```
+
+## Context Within Worldwide
+
+This validator is part of the [Worldwide gem](../../README.md), an internationalization and localization library that provides:
+
+- Address validation and formatting
+- Postal code validation by country and region
+- Multi-language support for region names
+- Comprehensive geographic data from Unicode CLDR
+
+The Japanese postal code validation logic tested here powers the production address validation features in the Worldwide library.
+
+## Technical Details
+
+### Supported Prefecture Formats
+
+The validator recognizes multiple name formats for Japanese prefectures:
+
+- **English**: "Tokyo", "Osaka", "Hokkaido"
+- **Japanese**: "東京都", "大阪府", "北海道"
+- **Romanized**: "Tokyo-to", "Osaka-fu", "Hokkaido"
+- **ISO codes**: "JP-13", "JP-27", "JP-01"
+
+### Validation Logic
+
+For each postal code, the validator:
+
+1. Extracts the prefecture from the shipping data
+2. Maps the prefecture name to a standardized zone code
+3. Looks up the allowed prefixes for that zone
+4. Checks if the postal code starts with any allowed prefix
+5. Reports mismatches as validation errors
+
+### Data Quality Insights
+
+Common sources of validation errors include:
+
+- **Data entry errors**: Typos in postal codes or province names
+- **Outdated postal codes**: Historical codes that have been reassigned
+- **Cross-border addresses**: Addresses near prefecture boundaries
+- **Special postal codes**: Corporate or institutional codes with different rules

--- a/docs/notebooks/jp-prefix-validator/.env.example
+++ b/docs/notebooks/jp-prefix-validator/.env.example
@@ -1,0 +1,1 @@
+PATH_TO_YAML=

--- a/docs/notebooks/jp-prefix-validator/.gitignore
+++ b/docs/notebooks/jp-prefix-validator/.gitignore
@@ -1,0 +1,3 @@
+.env
+venv
+data.csv

--- a/docs/notebooks/jp-prefix-validator/jp-prefix-validator.ipynb
+++ b/docs/notebooks/jp-prefix-validator/jp-prefix-validator.ipynb
@@ -1,0 +1,167 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f265101a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install pandas\n",
+    "!pip install dotenv\n",
+    "%pip install PyYAML\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "582684e3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load csv\n",
+    "import pandas as pd\n",
+    "\n",
+    "# Load the CSV file\n",
+    "df = pd.read_csv('data.csv')\n",
+    "\n",
+    "# drop null values in shipping_postal_code and shipping_province\n",
+    "df = df.dropna()\n",
+    "print(f\"DataFrame shape after dropping null values: {df.shape}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1f2dae86",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# import the YAML file with zip prefixes\n",
+    "from dotenv import load_dotenv\n",
+    "import os\n",
+    "from pprint import pprint\n",
+    "\n",
+    "load_dotenv()\n",
+    "\n",
+    "# load the YAML file\n",
+    "import yaml\n",
+    "\n",
+    "with open(os.getenv('PATH_TO_YAML') or \"zip_prefixes.yaml\", 'r') as file:\n",
+    "    zip_prefixes = yaml.safe_load(file)\n",
+    "\n",
+    "pprint(zip_prefixes)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "428326c7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# map zone names to zone codes\n",
+    "name_to_code = {}\n",
+    "for zone in zip_prefixes[\"zones\"]:\n",
+    "    name_to_code[zone[\"name\"]] = zone[\"code\"]\n",
+    "    for n in zone[\"name_alternates\"]:\n",
+    "        name_to_code[n] = zone[\"code\"]\n",
+    "\n",
+    "pprint(name_to_code)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0a8271d9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# map zone codes to allowed prefixes\n",
+    "allowed_prefixes_for_zone_code = {}\n",
+    "for zone in zip_prefixes[\"zones\"]:\n",
+    "    allowed_prefixes_for_zone_code[zone[\"code\"]] = set(zone[\"zip_prefixes\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6af2975c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import re\n",
+    "from collections import defaultdict\n",
+    "# get data rows from pandas df\n",
+    "rows = []\n",
+    "unmapped_cities = defaultdict(int)\n",
+    "\n",
+    "for _, row in df.iterrows():\n",
+    "    if row[\"shipping_province\"] not in name_to_code:\n",
+    "        unmapped_cities[row[\"shipping_province\"]] += 1\n",
+    "        continue\n",
+    "    zone_code, postal_code = name_to_code[row[\"shipping_province\"]], row[\"shipping_postal_code\"]\n",
+    "    if not isinstance(postal_code, str):\n",
+    "        continue\n",
+    "    rows.append({\n",
+    "        \"zone_code\": zone_code,\n",
+    "        \"postal_code\": postal_code,\n",
+    "    })\n",
+    "\n",
+    "regexp = \"^[0-9]{3}-[0-9]{4}$\"\n",
+    "rows = list(filter(lambda x: re.match(regexp, x[\"postal_code\"]), rows)) # filter out rows that don't match the format\n",
+    "print(\"Total rows: \", len(rows))\n",
+    "rows"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "244766db",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#validate the zip prefixes\n",
+    "invalid_prefixes = defaultdict(list)\n",
+    "for row in rows:\n",
+    "    zone_code, postal_code = row[\"zone_code\"], row[\"postal_code\"]\n",
+    "    zone_prefixes = allowed_prefixes_for_zone_code[zone_code]\n",
+    "    match = False\n",
+    "    for i in range(len(postal_code)):\n",
+    "        if postal_code[:i] in zone_prefixes:\n",
+    "            match = True\n",
+    "            continue\n",
+    "    if not match:\n",
+    "        invalid_prefixes[zone_code].append(postal_code)\n",
+    "\n",
+    "print(\"Total rows: \", len(rows))\n",
+    "print(\"Total invalid prefixes: \", sum(len(v) for v in invalid_prefixes.values()))\n",
+    "print(\"Total unique invalid prefixes: \", len(set(sum(invalid_prefixes.values(), []))))\n",
+    "print(\"Percentage of invalid prefixes: \", sum(len(v) for v in invalid_prefixes.values()) / len(rows))\n",
+    "\n",
+    "invalid_prefixes\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/lib/worldwide/locale.rb
+++ b/lib/worldwide/locale.rb
@@ -113,7 +113,7 @@ module Worldwide
         result = lookup(language, locale: target_locale)
         if result
           transformed = Worldwide::Cldr::ContextTransforms.transform(result, :languages, context, locale: target_locale)
-          break "#{transformed}#{i > 0 ? territories_suffix(code.to_s) : ""}"
+          break "#{transformed}#{territories_suffix(code.to_s) if i > 0}"
         end
       end
     end

--- a/lib/worldwide/regions_loader.rb
+++ b/lib/worldwide/regions_loader.rb
@@ -225,8 +225,6 @@ module Worldwide
       spec = YAML.safe_load_file(filename)
       code = spec["code"]
 
-      loaded_regions = []
-
       region = Region.new(
         alpha_three: country_codes.dig(code, "alpha3"),
         continent: false,

--- a/rake/cldr/csv_reader.rb
+++ b/rake/cldr/csv_reader.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "csv"
+
+module Worldwide
+  module Cldr
+    class CsvReader
+      def initialize(csv_path)
+        @csv_path = csv_path
+      end
+
+      def get_rows(&block)
+        raise NotImplementedError, "#{self.class.name} must implement #get_rows"
+      end
+
+      def get_postcode(row)
+        raise NotImplementedError, "#{self.class.name} must implement #get_postcode"
+      end
+
+      def get_iso2(row)
+        raise NotImplementedError, "#{self.class.name} must implement #get_iso2"
+      end
+    end
+
+    class CustomCSVReaderReader < CsvReader
+      def get_rows(&block)
+        CSV.foreach(@csv_path, headers: true, col_sep: ";", &block)
+      end
+
+      def get_postcode(row)
+        row["postcode"]
+      end
+
+      def get_iso2(row)
+        row["iso2"]
+      end
+    end
+
+    class CsvReaderFactory
+      class << self
+        def create(reader_type, csv_path)
+          case reader_type
+          when "custom_csv"
+            CustomCSVReaderReader.new(csv_path)
+          else
+            raise "Unknown reader type: #{reader_type}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/rake/cldr/deep_sort.rb
+++ b/rake/cldr/deep_sort.rb
@@ -80,7 +80,7 @@ module DeepSort
 
     # comparison for hashes is ill-defined. this performs array or string comparison if the normal comparison fails.
     def <=>(other)
-      super(other) || to_a <=> other.to_a || to_s <=> other.to_s
+      super || to_a <=> other.to_a || to_s <=> other.to_s
     end
   end
 end

--- a/rake/cldr/locale_generator.rb
+++ b/rake/cldr/locale_generator.rb
@@ -1001,7 +1001,7 @@ module Worldwide
           # END OF AUTO-GENERATED CONTENT
         CONTENTS
 
-        contents = contents.split("\n").map { |line| "#{line.strip.empty? ? "" : indentation_of_starting_line}#{line}" }.join("\n")
+        contents = contents.split("\n").map { |line| "#{indentation_of_starting_line unless line.strip.empty?}#{line}" }.join("\n")
 
         new_file_contents = existing_file_contents[0...start_of_auto_generated_content.begin(0)] + contents + existing_file_contents[end_of_auto_generated_content.end(0)..]
 

--- a/rake/cldr/region_patcher.rb
+++ b/rake/cldr/region_patcher.rb
@@ -1,0 +1,367 @@
+# frozen_string_literal: true
+
+require "yaml"
+require "fileutils"
+require "csv"
+
+module Worldwide
+  module Cldr
+    class RegionPatcher
+      attr_reader :country_code, :patches, :content, :yaml_path
+
+      def initialize(country_code)
+        @country_code = country_code.upcase
+        @patches = []
+
+        yaml_path = File.join(Worldwide::Paths::REGIONS_ROOT, "#{@country_code}.yml")
+        unless File.exist?(yaml_path)
+          raise ArgumentError, "Region file not found: #{yaml_path}"
+        end
+
+        @yaml_path = yaml_path
+        @content = YAML.safe_load_file(yaml_path)
+      end
+
+      # Add a patch to be applied to the YAML file
+      # @param path [Array<String>] The path to the value to patch (e.g., ["tax"], ["zones", 0, "name"])
+      # @param value [Object] The new value to set
+      # @param operation [Symbol] The operation to perform (:set, :append, :remove, :merge)
+      def add_patch(path:, value:, operation: :set)
+        @patches << { path: path, value: value, operation: operation }
+      end
+
+      def apply!
+        # Create a backup before modifying
+        backup_path = "#{yaml_path}.backup"
+        FileUtils.cp(yaml_path, backup_path)
+
+        begin
+          @patches.each do |patch|
+            apply_patch_to_content(content, patch)
+          end
+
+          File.write(yaml_path, YAML.dump(content))
+
+          # Remove backup on success
+          FileUtils.rm(backup_path) if File.exist?(backup_path)
+
+          true
+        rescue StandardError => e
+          # Restore from backup on error
+          FileUtils.mv(backup_path, yaml_path) if File.exist?(backup_path)
+          raise e
+        end
+      end
+
+      # Patch a specific zone/province within a country
+      # @param zone_code [String] The zone code to patch (e.g., "JP-13" for Tokyo)
+      # @param attribute [String] The attribute to patch within the zone
+      # @param value [Object] The new value
+      def patch_zone(zone_code:, attribute:, value:)
+        zone_index = find_zone_index(content, zone_code)
+
+        if zone_index.nil?
+          raise ArgumentError, "Zone not found: #{zone_code}"
+        end
+
+        add_patch(
+          path: ["zones", zone_index, attribute],
+          value: value,
+          operation: :set,
+        )
+      end
+
+      # warning: supports only Array and Hash, and if Array, can have at most one extra index
+      def make_path_patch(path:, desired_type:)
+        add_patch(
+          path: path,
+          value: desired_type,
+          operation: :make_path,
+        )
+      end
+
+      def get_zone_index(zone_code)
+        find_zone_index(content, zone_code)
+      end
+
+      private
+
+      def find_zone_index(content, zone_code)
+        zones = content["zones"] || []
+        zones.find_index { |zone| zone["code"] == zone_code || zone["iso_code"] == zone_code }
+      end
+
+
+      def apply_patch_to_content(content, patch)
+        path = patch[:path]
+        value = patch[:value]
+        operation = patch[:operation]
+
+        case operation
+        when :set
+          set_value_at_path(content, path, value)
+        when :append
+          append_value_at_path(content, path, value)
+        when :remove
+          remove_value_at_path(content, path)
+        when :merge
+          merge_value_at_path(content, path, value)
+        when :make_path
+          create_path_if_not_exists(content, path, value)
+        else
+          raise ArgumentError, "Unknown operation: #{operation}"
+        end
+      end
+
+      def get_value_at_path(content, path)
+        path.reduce(content) do |current, key|
+          return nil if current.nil?
+
+          if current.is_a?(Array) && key.is_a?(Integer)
+            current[key]
+          elsif current.is_a?(Hash)
+            current[key.to_s]
+          end
+        end
+      end
+
+      def create_path_if_not_exists(content, path, desired_type)
+        prev = nil
+        path.reduce(content) do |current, key|
+          return nil if current.nil?
+
+          if current.is_a?(Array) && key.is_a?(Integer)
+            current[key]
+          elsif current.is_a?(Hash)
+            if current.has_key?(key.to_s)
+              current[key.to_s]
+            else
+              current[key.to_s] = desired_type.dup
+              nil
+            end
+          else
+            raise ArgumentError, "Cannot create path: current is #{current.class}, key is #{key.class}"
+          end
+        end
+      end
+
+      def set_value_at_path(content, path, value)
+        # path is an Array of String/Integer keys representing the path to navigate
+        parent_path = path[0...-1]
+        last_key = path[-1]
+
+        parent = parent_path.empty? ? content : get_parent_at_path(content, parent_path)
+
+        if parent.is_a?(Array) && last_key.is_a?(Integer)
+          parent[last_key] = value
+        elsif parent.is_a?(Hash)
+          parent[last_key.to_s] = value
+        else
+          raise ArgumentError, "Cannot set value at path: #{path.join(" → ")}"
+        end
+      end
+
+      def append_value_at_path(content, path, value)
+        target = get_value_at_path(content, path)
+
+        if target.is_a?(Array)
+          target << value
+        else
+          raise ArgumentError, "Cannot append to non-array at path: #{path.join(" → ")}"
+        end
+      end
+
+      def remove_value_at_path(content, path)
+        *parent_path, last_key = path
+
+        parent = parent_path.empty? ? content : get_parent_at_path(content, parent_path)
+
+        if parent.is_a?(Array) && last_key.is_a?(Integer)
+          parent.delete_at(last_key)
+        elsif parent.is_a?(Hash)
+          parent.delete(last_key.to_s)
+        else
+          raise ArgumentError, "Cannot remove value at path: #{path.join(" → ")}"
+        end
+      end
+
+      def merge_value_at_path(content, path, value)
+        target = get_value_at_path(content, path)
+
+        if target.is_a?(Hash) && value.is_a?(Hash)
+          target.merge!(value)
+        else
+          raise ArgumentError, "Cannot merge non-hash values at path: #{path.join(" → ")}"
+        end
+      end
+
+      def get_parent_at_path(content, path)
+        path.reduce(content) do |current, key|
+          if current.is_a?(Array) && key.is_a?(Integer)
+            current[key]
+          elsif current.is_a?(Hash)
+            current[key.to_s]
+          else
+            raise ArgumentError, "Invalid path: #{path.join(" → ")}"
+          end
+        end
+      end
+    end
+
+    class JpZipPrefixPatcher
+      class << self
+        def perform(csv_path, csv_reader, max_length_prefix)
+          new(csv_path, csv_reader, max_length_prefix).perform
+        end
+      end
+
+      def initialize(csv_path, csv_reader, max_length_prefix)
+        @csv_path = csv_path
+        @csv_reader = csv_reader
+        @max_length_prefix = max_length_prefix
+        @zone_to_prefixes = Hash.new { |h, k| h[k] = Set.new }
+      end
+
+      def perform
+        process_csv
+        patch_regions
+      end
+
+      private
+
+      class TrieNode
+        attr_reader :children, :part_of_zone
+
+        def initialize
+          @children = {}
+          @part_of_zone = Set.new
+        end
+
+        def add_word_for_zone(word, zone_code)
+          current_node = self
+          current_node.part_of_zone << zone_code
+          word.each_char do |char|
+            current_node.children[char] ||= TrieNode.new
+            current_node = current_node.children[char]
+            current_node.part_of_zone << zone_code
+          end
+        end
+      end
+
+      def build_memoized_trie(trie_root)
+        @csv_reader.get_rows do |row|
+          iso2_code = @csv_reader.get_iso2(row)
+          postcode = @csv_reader.get_postcode(row)
+          if iso2_code.nil? || postcode.nil? || !iso2_code.start_with?("JP-")
+            next
+          end
+
+          trie_root.add_word_for_zone(postcode, iso2_code)
+        end
+
+        trie_root
+      end
+
+      def _helper(node, prefixes, prefix, depth)
+        # stop at length 3 prefixes
+        if depth > @max_length_prefix - 1
+          node.part_of_zone.each do |zone_code|
+            prefixes[zone_code] << prefix
+          end
+          return
+        end
+
+        if node.part_of_zone.size == 1
+          prefixes[node.part_of_zone.first] << prefix
+          return
+        end
+
+        node.children.each do |char, child|
+          _helper(child, prefixes, prefix + char, depth + 1)
+        end
+      end
+
+      def get_zone_unique_prefixes(trie_root)
+        # step 1: map each zone to its unique prefixes
+        prefixes = Hash.new { |h, k| h[k] = Set.new }
+        _helper(trie_root, prefixes, "", 0)
+
+        # step 2: identify and extract prefixes that are shared by multiple zones
+        prefix_to_zone = Hash.new { |h, k| h[k] = Set.new }
+        prefixes.each do |zone_code, prefixes|
+          prefixes.each do |prefix|
+            prefix_to_zone[prefix] << zone_code
+          end
+        end
+        shared_prefixes = prefix_to_zone.filter { |_, zones| zones.size > 1 }
+
+        # step 3: identify neighbouring zones
+        zone_to_neighboring_zones = Hash.new { |h, k| h[k] = Set.new }
+        shared_prefixes.each do |prefix, zone_codes|
+          zone_codes.each do |zone_code|
+            (zone_codes - [zone_code]).each do |neighbor_code|
+              zone_to_neighboring_zones[zone_code] << neighbor_code
+            end
+          end
+        end
+
+        [prefixes, shared_prefixes, zone_to_neighboring_zones]
+      end
+
+      def process_csv
+        trie_root = build_memoized_trie(TrieNode.new)
+        @zone_to_prefixes, @shared_prefixes, @zone_to_neighboring_zones = get_zone_unique_prefixes(trie_root)
+      end
+
+      def patch_regions
+        patcher = Worldwide::Cldr::RegionPatcher.new("JP")
+
+        all_jp_prefixes = Set.new
+        @zone_to_prefixes.each do |zone_code, prefixes|
+          patcher.patch_zone(
+            zone_code: zone_code,
+            attribute: "zip_prefixes",
+            value: prefixes.to_a.sort,
+          )
+          all_jp_prefixes.merge(prefixes)
+        end
+
+        if @shared_prefixes.any?
+          patcher.add_patch(
+            path: ["zips_crossing_provinces"],
+            value: {}, # init with empty hash to avoid nil errors
+            operation: :set,
+          )
+          @shared_prefixes.each do |prefix, zone_codes|
+            # add zips crossing provinces for each prefix
+            patcher.add_patch(
+              path: ["zips_crossing_provinces", prefix],
+              value: zone_codes.to_a.sort,
+              operation: :set,
+            )
+          end
+        else
+          patcher.add_patch(
+            path: ["zips_crossing_provinces"],
+            value: nil,
+            operation: :remove,
+          )
+        end
+
+        @zone_to_neighboring_zones.each do |zone_code, neighboring_zones|
+          patcher.make_path_patch( # ensure we have an array at the path
+            path: ["zones", patcher.get_zone_index(zone_code), "neighboring_zones"],
+            desired_type: [],
+          )
+          patcher.patch_zone(
+            zone_code: zone_code,
+            attribute: "neighboring_zones",
+            value: neighboring_zones.to_a.sort,
+          )
+        end
+
+        patcher.apply!
+      end
+    end
+  end
+end

--- a/rake/cldr/region_patcher.rb
+++ b/rake/cldr/region_patcher.rb
@@ -91,7 +91,6 @@ module Worldwide
         zones.find_index { |zone| zone["code"] == zone_code || zone["iso_code"] == zone_code }
       end
 
-
       def apply_patch_to_content(content, patch)
         path = patch[:path]
         value = patch[:value]
@@ -126,7 +125,6 @@ module Worldwide
       end
 
       def create_path_if_not_exists(content, path, desired_type)
-        prev = nil
         path.reduce(content) do |current, key|
           return nil if current.nil?
 
@@ -297,7 +295,7 @@ module Worldwide
 
         # step 3: identify neighbouring zones
         zone_to_neighboring_zones = Hash.new { |h, k| h[k] = Set.new }
-        shared_prefixes.each do |prefix, zone_codes|
+        shared_prefixes.each do |_prefix, zone_codes|
           zone_codes.each do |zone_code|
             (zone_codes - [zone_code]).each do |neighbor_code|
               zone_to_neighboring_zones[zone_code] << neighbor_code

--- a/rake/cldr/region_patcher.rb
+++ b/rake/cldr/region_patcher.rb
@@ -131,7 +131,7 @@ module Worldwide
           if current.is_a?(Array) && key.is_a?(Integer)
             current[key]
           elsif current.is_a?(Hash)
-            if current.has_key?(key.to_s)
+            if current.key?(key.to_s)
               current[key.to_s]
             else
               current[key.to_s] = desired_type.dup

--- a/test/worldwide/currencies_test.rb
+++ b/test/worldwide/currencies_test.rb
@@ -10,13 +10,13 @@ module Worldwide
       refute_empty currencies
 
       currencies.each do |currency|
-        assert currency.is_a?(Worldwide::Currency)
+        assert_kind_of Worldwide::Currency, currency
       end
     end
 
     test ".each should allow currencies to be enumerable" do
       Worldwide::Currencies.each do |currency|
-        assert currency.is_a?(Worldwide::Currency)
+        assert_kind_of Worldwide::Currency, currency
       end
     end
 


### PR DESCRIPTION
### What are you trying to accomplish?
<!--
Link to an issue or provide enough context so that someone new can understand the 'why' behind this change.
-->

We are trying to implement stricter validation for Japanese postal codes.


...

### What approach did you choose and why?
<!--
There are many ways to solve a problem. How did you approach this problem and why?
-->

I found a highly credible dataset from [GeoPostcodes](https://portal.geopostcodes.com/).
Then, I created a rake task that would read a CSV from this dataset and populate the existing JP.yml with valid zone prefixes.

- 1. Create a hash with zone codes as the key and an array of their postal codes as a value
- 2. Extract the smallest postal code prefix that will uniquely identify some corresponding zone.
-  -  In order to achieve this 2, I created a trie and populated it with postal codes. When populating, I also marked on the trie node the zone which we are adding the prefix for.  Then, I did a simple DFS traversal and stopped when an encountered node has only one single zone associated with it: this means the current prefix uniquely identifies a zone.
3. Populate the JP yaml with this data


### The impact of these changes
<!--
Are there any specific impacts from this change that you'd like to call out?
-->

We can now perform naive postal code validation based off purely the zone.

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->
For Shopify reviewers, you can compare the results to that of another rake task in `country-db`:

simply run
`rake "postal:codes:import[JP]"`
in country-db and compare the modified JP.yml to this

You will notice that this dataset is more complete

Potential question you might ask: why are there so many postal code prefixes for some zones?
That is because the dataset is such, and I believe this is entirely valid. Let's take an example:

Look at the zip prefixes for JP-02:
'03' and '018-550'

'018-550' seems suspicious, let's investigate. If you open the dataset I linked above, search for "018-55" and notice you will get postal codes in zone JP-02 and JP-05 (018-5511 more specifically). Putting these into google maps:

![image](https://github.com/user-attachments/assets/44cce80c-62b1-475c-9208-9eb9bb02f219)

and notice that they are also correspondingly in JP-02 (Aomori Prefecture) and JP-05 (Akita Prefecture):

![image](https://github.com/user-attachments/assets/d8bb2490-c71b-43d8-b49b-c0a1f2f472b8)

I would like for reviewers **_to test it this out themselves, please pick 5 zip prefixes that seem too long, and test it out yourselves following similar steps as me as written above_**

### Validation

1. I got a sample of 10k real Japanese addresses (For Shopifolk, I linked the methodology for this in the issue linked to this PR)

2. Created a jupyter notebook (`jp-prefix-validator.ipynb`) that will read the CSV, and validate the zip codes against the zip prefixes in JP.yml 

3. Compiled results (For Shopifolk, I reported the results of this validation in the issue linked to this PR) 

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
