### PR TITLE
Add iana_to_rails_time_zone mapping, bump v1.17.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ---
 
 ## [1.17.5] - 2025-07-31
-- Update Romania VAT rate from 19% to 21%
+- Update Romania VAT rate from 19% to 21% [#379](https://github.com/Shopify/worldwide/pull/379)
+- Add iana_to_rails_time_zone mapping for America/Coyhaique [#378](https://github.com/Shopify/worldwide/pull/378)
 
 ## [1.17.4] - 2025-07-02
 - Remove postal codes requirement for Romania [#375](https://github.com/Shopify/worldwide/pull/375)

--- a/data/iana_to_rails_time_zone.yml
+++ b/data/iana_to_rails_time_zone.yml
@@ -101,6 +101,7 @@ America/Ciudad_Juarez: America/Denver
 America/Coral_Harbour: America/Bogota
 America/Cordoba: America/Argentina/Buenos_Aires
 America/Costa_Rica: America/Mexico_City
+America/Coyhaique: America/Sao_Paulo
 America/Creston: America/Phoenix
 America/Cuiaba: America/Caracas
 America/Curacao: America/Puerto_Rico


### PR DESCRIPTION
### What are you trying to accomplish?
Add new timezone mapping for newest IANA timezone: America/Coyhaique. 

The timezone was added to IANA in march, [changelog](https://data.iana.org/time-zones/tzdb/NEWS).

Rails does not yet support the timezone, so we need to map it back to a supported tz. 

### What approach did you choose and why?
Mapped to another GMT-3:00 timezone, America/Sao_Paulo.

TZ reference: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones

### What should reviewers focus on?
<!--
Outline anything you'd like reviewers to pay extra attention to. List open questions for discussion.
-->

...

### The impact of these changes
Provides a mapping from IANA timezones to rails supported TZs. 

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

...

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
