### PR TITLE
Add/Update CODEOWNERS for Address team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# CODEOWNERS file for worldwide
+# This file defines code owners for specific files/patterns in this repository
+
+# Address team reviews all changes except Gemfile.lock and RBI files
+* @Shopify/address
+Gemfile.lock
+sorbet/rbi/gems/**


### PR DESCRIPTION
This PR adds/updates the CODEOWNERS file to ensure changes are reviewed by @Shopify/address.

## Context

This change is part of migrating away from CautionTapeBot to native GitHub features (CODEOWNERS). Previously, CautionTapeBot would automatically request reviews from the Address team for changes to this repository.

## Changes

- Creates/updates `.github/CODEOWNERS` file
- Adds rules requiring @Shopify/address review for all files except:
  - `Gemfile.lock`
  - `sorbet/rbi/gems/**`
- ✅ Team @Shopify/address has been granted **Write** permissions to this repository

## CautionTapeBot Rule Being Removed

This PR replaces the following CautionTapeBot rule in services-db:
- [AddressOwnedRepos](https://github.com/Shopify/services-db/blob/main/components/caution_tape_bot/app/models/caution_tape_bot/rules/address_owned_repos.rb) (watched 7 repositories including this one)

## CODEOWNERS Documentation

For more information about CODEOWNERS files, see: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

## Related

Part of: Shopify/services-db#29389