### PR TITLE
Un-deprecate IT province OT (Gallura Nord-Est Sardegna)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Security in case of vulnerabilities.
 
 ## [Unreleased]
+- Un-deprecate IT province OT (Gallura Nord-Est Sardegna), add name alternate and zip_prefixes[#450](https://github.com/Shopify/worldwide/pull/450)
 
 ---
 

--- a/data/regions/IT.yml
+++ b/data/regions/IT.yml
@@ -870,14 +870,21 @@ zones:
   - NU
   zip_prefixes:
   - '09064'
-- name: Olbia-Tempio
+- name: Gallura Nord-Est Sardegna
   code: OT
-  deprecated: true
+  name_alternates:
+  - Olbia-Tempio
   tax: 0.0
   tax_name: VAT
   neighboring_zones:
   - NU
   - SS
+  zip_prefixes:
+  - '0702*'
+  - '07030'
+  - '07038'
+  - '07051'
+  - '07052'
 - name: Oristano
   code: OR
   tax: 0.0


### PR DESCRIPTION
### What are you trying to accomplish?
Restores the Italian province of Gallura North-East Sardinia, which has been functional [since April 2025](https://en.wikipedia.org/wiki/Province_of_Gallura_North-East_Sardinia)

### What approach did you choose and why?
Removed the deprecation flag. 
Updated the province name; prior name Olbia-Tempio has not been in use since 2016. 
Updated the zip prefixes.  


### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
