### PR TITLE
Update IE zips_crossing_provinces, cut v1.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - nil
 
 ---
+
+## [1.24.1] - 2026-04-15
+- Update zips_crossing_provinces in IE [#454](https://github.com/Shopify/worldwide/pull/454)
+
 ## [1.24.0] - 2026-04-13
 - Update IT Sardinian provinces and zip prefixes [#451](https://github.com/Shopify/worldwide/pull/451)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (1.24.0)
+    worldwide (1.24.1)
       activesupport (>= 7.0)
       i18n
       phonelib (~> 0.8)

--- a/data/regions/IE.yml
+++ b/data/regions/IE.yml
@@ -660,6 +660,9 @@ zips_crossing_provinces:
   R14:
   - KE
   - LS
+  R32:
+  - LS
+  - OY
   R42:
   - OY
   - TA

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "1.24.0"
+  VERSION = "1.24.1"
 end


### PR DESCRIPTION
### What are you trying to accomplish?
Postcode R32 TH50 is located in county of Offaly

Prefix R32 is specifically registered with county Laois, which multiple sources deems correect. 



### What approach did you choose and why?
Update the zips_crossing_provinces so R32 is considered valid in both OY and LS. 

Bump patch version. 

### Testing
Verified with temporary test that zip is considered valid for provinces OY, LS.

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
