### PR TITLE
Patch CLDR subdivisions for IT-OT and IT-CI, bump v1.24.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ---
 
+## [1.24.2] - 2026-04-27
+- Update CLDR subdivision names for IT-OT (Gallura Nord-Est Sardegna) and IT-CI (Sulcis Iglesiente) in `:en`, `:it`, and `:de` only; other locales remain on stale upstream CLDR pending an upstream fix [#458](https://github.com/Shopify/worldwide/pull/458)
+
 ## [1.24.1] - 2026-04-15
 - Update zips_crossing_provinces in IE [#454](https://github.com/Shopify/worldwide/pull/454)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (1.24.1)
+    worldwide (1.24.2)
       activesupport (>= 7.0)
       i18n
       phonelib (~> 0.8)

--- a/data/cldr/locales/de/subdivisions.yml
+++ b/data/cldr/locales/de/subdivisions.yml
@@ -1967,7 +1967,7 @@ de:
     itcb: Provinz Campobasso
     itce: Provinz Caserta
     itch: Provinz Chieti
-    itci: Provinz Carbonia-Iglesias
+    itci: Provinz Sulcis Iglesiente
     itcl: Provinz Caltanissetta
     itcn: Provinz Cuneo
     itco: Provinz Como
@@ -2007,7 +2007,7 @@ de:
     itnu: Provinz Nuoro
     itog: Provinz Ogliastra
     itor: Provinz Oristano
-    itot: Provinz Olbia-Tempio
+    itot: Provinz Gallura Nord-Est Sardegna
     itpa: Provinz Palermo
     itpc: Provinz Piacenza
     itpd: Provinz Padua

--- a/data/cldr/locales/en/subdivisions.yml
+++ b/data/cldr/locales/en/subdivisions.yml
@@ -2446,7 +2446,7 @@ en:
     itcb: Campobasso
     itce: Caserta
     itch: Chieti
-    itci: Carbonia-Iglesias
+    itci: Sulcis Iglesiente
     itcl: Caltanissetta
     itcn: Cuneo
     itco: Como
@@ -2486,7 +2486,7 @@ en:
     itnu: Nuoro
     itog: Ogliastra
     itor: Oristano
-    itot: Olbia-Tempio
+    itot: Gallura Nord-Est Sardegna
     itpa: Palermo
     itpc: Piacenza
     itpd: Padua

--- a/data/cldr/locales/it/subdivisions.yml
+++ b/data/cldr/locales/it/subdivisions.yml
@@ -1990,7 +1990,7 @@ it:
     itcb: Campobasso
     itce: Caserta
     itch: Chieti
-    itci: Carbonia-Iglesias
+    itci: Sulcis Iglesiente
     itcl: Caltanissetta
     itcn: Cuneo
     itco: Como
@@ -2030,7 +2030,7 @@ it:
     itnu: Nuoro
     itog: Ogliastra
     itor: Oristano
-    itot: Olbia-Tempio
+    itot: Gallura Nord-Est Sardegna
     itpa: Palermo
     itpc: Piacenza
     itpd: Padova

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "1.24.1"
+  VERSION = "1.24.2"
 end

--- a/rake/cldr/patch.rb
+++ b/rake/cldr/patch.rb
@@ -195,7 +195,7 @@ module Worldwide
             [:itcb, "provincia di Campobasso", "Campobasso"],
             [:itce, "provincia di Caserta", "Caserta"],
             [:itch, "provincia di Chieti", "Chieti"],
-            [:itci, "provincia di Carbonia-Iglesias", "Carbonia-Iglesias"],
+            [:itci, "provincia di Carbonia-Iglesias", "Sulcis Iglesiente"],
             [:itcl, "provincia di Caltanissetta", "Caltanissetta"],
             [:itcn, "Provincia di Cuneo", "Cuneo"],
             [:itco, "provincia di Como", "Como"],
@@ -235,7 +235,7 @@ module Worldwide
             [:itnu, "provincia di Nuoro", "Nuoro"],
             [:itog, "provincia dell’Ogliastra", "Ogliastra"],
             [:itor, "provincia di Oristano", "Oristano"],
-            [:itot, "provincia di Olbia-Tempio", "Olbia-Tempio"],
+            [:itot, "provincia di Olbia-Tempio", "Gallura Nord-Est Sardegna"],
             [:itpa, "provincia di Palermo", "Palermo"],
             [:itpc, "provincia di Piacenza", "Piacenza"],
             [:itpd, "provincia di Padova", "Padova"],
@@ -307,6 +307,26 @@ module Worldwide
               end
             end
           end
+
+          # Italy restored two Sardinian provinces in June 2025 with new names:
+          #   IT-OT: Olbia-Tempio       -> Gallura Nord-Est Sardegna
+          #   IT-CI: Carbonia-Iglesias  -> Sulcis Iglesiente
+          # The :it patch above already covers Italian. We also patch :en (source
+          # for downstream English UIs) and :de (largest non-en/it consumer of
+          # IT addresses). Other locales remain on the stale upstream CLDR
+          # values pending an upstream fix; Shopify's translation platform only
+          # propagates files under data/regions, data/other/hand_translated, and
+          # data/other/timezones, so it cannot fan these out automatically.
+          # TODO: report upstream at https://unicode-org.atlassian.net/ and
+          # remove these patches once CLDR ships the new names.
+          patch_subdivisions(:en, [
+            [:itot, "Olbia-Tempio", "Gallura Nord-Est Sardegna"],
+            [:itci, "Carbonia-Iglesias", "Sulcis Iglesiente"],
+          ])
+          patch_subdivisions(:de, [
+            [:itot, "Provinz Olbia-Tempio", "Provinz Gallura Nord-Est Sardegna"],
+            [:itci, "Provinz Carbonia-Iglesias", "Provinz Sulcis Iglesiente"],
+          ])
 
           # Subdivisions of Japan in English
           #


### PR DESCRIPTION
## Summary

Italy restored two Sardinian provinces in June 2025 with new names. PR #451 updated `data/regions/IT.yml` accordingly, but `data/cldr/locales/*/subdivisions.yml` still carried the old names. Atlas (and any other consumer that resolves province labels through CLDR via `ShopifyI18n::Zone#name` → `I18n.t("subdivisions.itXX")`) silently overrode the corrected `country_db` values, so the country GraphQL endpoint kept returning `"Olbia-Tempio"` and `"Carbonia-Iglesias"`. **This PR unblocks Italy** by patching CLDR data so the new names flow through to atlas's admin/buyer surfaces.

## Changes

| Province | Old | New |
| --- | --- | --- |
| IT-OT | Olbia-Tempio | Gallura Nord-Est Sardegna |
| IT-CI | Carbonia-Iglesias | Sulcis Iglesiente |

Patches applied per-locale in `rake/cldr/patch.rb` (so future `cldr:data:import` runs re-apply on top of upstream):
- `:en` — source string for downstream English UIs.
- `:it` — Italian-speaking merchants on IT addresses.
- `:de` — largest non-en/it consumer of IT addresses; prefix-preserving form (`"Provinz Gallura Nord-Est Sardegna"`, `"Provinz Sulcis Iglesiente"`).

## Why only en/it/de

The translation-platform[bot] **does not** propagate CLDR subdivision data. Its `translation.yml` config only covers `data/regions/`, `data/other/hand_translated/`, and `data/other/timezones/` — every translation-platform[bot] commit on this repo confirms it. So we cannot lean on the automation to fan this out to the other 30+ target locales.

Choosing en/it/de targets the locales where:
1. We have a confident, locale-correct rendering (the existing prefix conventions are clear).
2. The merchant population most likely to read IT addresses is concentrated.

For all other locales, the old names remain. A `TODO` comment + reference to the upstream Unicode CLDR ticket pattern (`CLDR-14092`-style) is left in `patch.rb`. Once upstream ships the rename, the patches can be removed.

## Verification

Tophatted with atlas pinned to this branch (`gem "worldwide", path: ...`):

```
[en] OT="Gallura Nord-Est Sardegna"          CI="Sulcis Iglesiente"
[it] OT="Gallura Nord-Est Sardegna"          CI="Sulcis Iglesiente"
[de] OT="Provinz Gallura Nord-Est Sardegna"  CI="Provinz Sulcis Iglesiente"
```

Both the direct path (`ShopifyI18n::Territories.find_by_code("IT").zone(...).name`) and the full country endpoint path (`Types::CountryFormatter.build_formatted_country`) return the expected names.

## Test plan

- [x] `bundle exec rake test` (region + locale tests) — green
- [x] `bundle exec rubocop rake/cldr/patch.rb` — clean
- [x] Tophat atlas with local worldwide path: en/it/de all return new names from country GraphQL endpoint
- [x] Bumped to v1.24.2 + CHANGELOG entry

## Follow-ups

- Bump worldwide in shopify-i18n (separate PR).
- Report upstream to Unicode CLDR; remove these patches when upstream ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
