### PR TITLE
Update BR regex to split address1 properly

### DIFF
--- a/data/regions/BR.yml
+++ b/data/regions/BR.yml
@@ -29,7 +29,7 @@ format:
 format_extended:
   edit: "{country}_{firstName}{lastName}_{company}_{zip}_{streetName}{streetNumber}_{line2}{neighborhood}_{city}{province}_{phone}"
 address1_regex:
-  - "^(?<streetName>(?:[^\\d,\\s]+\\s)*[^\\d,\\s]+)(?:,? ?)(?<streetNumber>\\d+(?: ?[a-z])?)$"
+  - "^(?<streetName>(?:[^\\d,\\s]+\\s)*[^\\d,\\s]+)(?:,? ?)(?<streetNumber>\\d+(?: ?[a-z])?)(?:[,\\s]+(?<line2>.+))?$"
 additional_address_fields:
   - name: streetName
     required: true

--- a/lang/typescript/src/extended-address/splitAddress1.test.ts
+++ b/lang/typescript/src/extended-address/splitAddress1.test.ts
@@ -44,11 +44,6 @@ describe('splitAddress1', () => {
       address: '40 Baandersstraat',
       expected: {streetName: '40 Baandersstraat'},
     },
-    {
-      country: 'BR',
-      address: 'Main, 123, Apt 2',
-      expected: {streetName: 'Main, 123, Apt 2'},
-    },
   ])(
     'returns address1 as street name when no delimiter is present, tryRegexFallback is true, and address does not match regex',
     ({country, address, expected}) => {
@@ -386,6 +381,65 @@ describe('splitAddress1', () => {
     },
   ])(
     'returns full address object when not separated by delimiter, tryRegexFallback is true and address matches regex for BR',
+    ({address, expected}) => {
+      expect(splitAddress1('BR', address, true)).toEqual(expected);
+    },
+  );
+
+  test.each([
+    {
+      address: 'Praça Ramos de Azevedo, 123, Apto 45',
+      expected: {
+        streetName: 'Praça Ramos de Azevedo',
+        streetNumber: '123',
+        line2: 'Apto 45',
+      },
+    },
+    {
+      address: 'Rua Santo Antônio, 722, Apto 4',
+      expected: {
+        streetName: 'Rua Santo Antônio',
+        streetNumber: '722',
+        line2: 'Apto 4',
+      },
+    },
+    {
+      address: 'Rua Corumbá 47A, Bloco 2',
+      expected: {
+        streetName: 'Rua Corumbá',
+        streetNumber: '47A',
+        line2: 'Bloco 2',
+      },
+    },
+    {
+      // PayPal-style: BR canonical form collected as separate inputs but
+      // returned space-concatenated by the wallet API. The regex should
+      // recover the same structure.
+      address: 'Praça Ramos de Azevedo 123 Apto 45',
+      expected: {
+        streetName: 'Praça Ramos de Azevedo',
+        streetNumber: '123',
+        line2: 'Apto 45',
+      },
+    },
+    {
+      address: 'Rua Corumbá 47 A, Apto 12',
+      expected: {
+        streetName: 'Rua Corumbá',
+        streetNumber: '47 A',
+        line2: 'Apto 12',
+      },
+    },
+    {
+      address: 'Av. de São João, 123, Apto 4 - Bloco B',
+      expected: {
+        streetName: 'Av. de São João',
+        streetNumber: '123',
+        line2: 'Apto 4 - Bloco B',
+      },
+    },
+  ])(
+    'extracts the optional line2 component from 3-component BR addresses',
     ({address, expected}) => {
       expect(splitAddress1('BR', address, true)).toEqual(expected);
     },


### PR DESCRIPTION
### What are you trying to accomplish?

Today, BR's `splitAddress1` regex only matches 2-component canonical input (`<street>`, `<number>`). When given 3-component input (`<street>`, `<number>`, `<complement>` — common in autofill payloads from Chrome, password managers, and PayPal), the regex bails to the fallback and returns the entire string in `streetName`.

This adds an optional third capture group for line2 so 3-component inputs are parsed correctly. The change is in BR's region data only; no library code changes.

Backward compatibility: existing 2-component inputs continue to match the regex with no `line2` field — confirmed via existing test cases (all unchanged). Adding `line2` to the result is additive — consumers reading `streetName`/`streetNumber` are unaffected; consumers wanting `line2` can opt in.

Note: this leaves `combined_address_format` untouched. `line2` remains canonically in `address2`. The regex is for parsing flat natural-language strings (which mix all components); the canonical format is for structured serialization. The library already supports this asymmetry by design.

### What approach did you choose and why?
<!--
There are many ways to solve a problem. How did you approach this problem and why?
-->

...

### What should reviewers focus on?
<!--
Outline anything you'd like reviewers to pay extra attention to. List open questions for discussion.
-->

...

### The impact of these changes
<!--
Are there any specific impacts from this change that you'd like to call out?
-->

...

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

...

### Checklist

* [ ] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
