### PR TITLE
Use Ukrainian VAT abbreviation for Ukraine tax name

### DIFF
--- a/data/regions/UA.yml
+++ b/data/regions/UA.yml
@@ -4,7 +4,7 @@ code: UA
 tax: 0.2
 currency: UAH
 unit_system: metric
-tax_name: PDV
+tax_name: ПДВ
 tax_inclusive: true
 group: European Countries
 group_name: Europe

--- a/test/worldwide/region_test.rb
+++ b/test/worldwide/region_test.rb
@@ -563,6 +563,7 @@ module Worldwide
 
     test "#tax_name returns values as expected" do
       assert_equal "HST", Worldwide.region(code: "CA").zone(code: "ON").tax_name
+      assert_equal "ПДВ", Worldwide.region(code: "UA").tax_name
     end
 
     test "#tax_rate returns values as expected" do


### PR DESCRIPTION
### What are you trying to accomplish?

Correct the Ukraine region tax name from the Latin transliteration `PDV` to the Ukrainian Cyrillic abbreviation `ПДВ`. The State Tax Service of Ukraine uses `ПДВ` for `податок на додану вартість`, including on its VAT registration guidance: https://tax.gov.ua/baneryi/onlayn-navchannya/reestratsiya-ta-oblik-yuridichnih-osib-ta-samozaynyatih-fizichnih-osib/reestratsiya-platnikiv-pdv/987813.html

### What approach did you choose and why?

Updated `data/regions/UA.yml` to use the native Ukrainian abbreviation and added a focused regression assertion in `RegionTest` so the value stays covered.

### What should reviewers focus on?

Whether `ПДВ` is the expected user-facing tax name for Ukraine in this data file.

### The impact of these changes

Consumers reading `Worldwide.region(code: "UA").tax_name` now receive the Ukrainian abbreviation used in official tax materials instead of a Latin transliteration.

### Testing

- `RBENV_VERSION=3.4.7 bundle exec ruby -Itest test/worldwide/region_test.rb`
- `RBENV_VERSION=3.4.7 bundle exec ruby -Itest test/worldwide/region_yml_consistency_test.rb`

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it is not needed)