### PR TITLE
Fix dependabot workflows blocked by missing DEPENDENCIES_GITHUB_USER secret

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,6 @@ registries:
     url: https://pkgs.shopify.io/basic/gems/ruby
     username: ${{secrets.RUBYGEMS_SERVER_PKGS_SHOPIFY_IO_USERNAME}}
     password: ${{secrets.RUBYGEMS_SERVER_PKGS_SHOPIFY_IO_PASSWORD}}
-  github-com:
-    type: git
-    url: https://github.com
-    username: ${{secrets.DEPENDENCIES_GITHUB_USER}}
-    password: ${{secrets.DEPENDENCIES_GITHUB_TOKEN}}
 updates:
   - package-ecosystem: bundler
     directory: "/"
@@ -17,7 +12,12 @@ updates:
       interval: daily
     open-pull-requests-limit: 100
     insecure-external-code-execution: allow
-    registries: "*"
+    registries:
+      - ruby-shopify
+  - package-ecosystem: npm_and_yarn
+    directory: "/lang/typescript"
+    schedule:
+      interval: weekly
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary

All dependabot update jobs were failing with:
```
Secret Not Found: DEPENDENCIES_GITHUB_USER
```

**Root cause**: `dependabot.yml` configured a `github-com` git registry referencing `${{secrets.DEPENDENCIES_GITHUB_USER}}` / `${{secrets.DEPENDENCIES_GITHUB_TOKEN}}`. These secrets were never provisioned in the repo. Since every dependabot job tries to fetch all registry credentials at startup, every job was failing — including unrelated ones like the `npm_and_yarn` vite update.

**Why the registry was unnecessary**: The only git-sourced GitHub dependency is `ruby-cldr` (`ruby-i18n/ruby-cldr`), a public repo. Dependabot can access public GitHub repos without explicit credentials.

## Changes

- Remove `github-com` registry (source of the credential error)
- Narrow bundler `registries` from `"*"` to only `ruby-shopify` (no longer references the removed registry)
- Add explicit `npm_and_yarn` config for `/lang/typescript` — dependabot was already auto-generating runs for vite updates; making it explicit is cleaner

## Affected runs (all now unblocked)

| Run | Error |
|-----|-------|
| `npm_and_yarn in /lang/typescript for vite` #25574807674 | Secret Not Found: DEPENDENCIES_GITHUB_USER |
| `bundler for nokogiri` #25559586480 | Secret Not Found: DEPENDENCIES_GITHUB_USER |
| `bundler for nokogiri` #25559267545 | Secret Not Found: DEPENDENCIES_GITHUB_USER |

🤖 Generated with [Claude Code](https://claude.com/claude-code)