### PR TITLE
dependabot: remove unnecessary registry to fix failing update jobs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,4 @@
 version: 2
-registries:
-  ruby-shopify:
-    type: rubygems-server
-    url: https://pkgs.shopify.io/basic/gems/ruby
-    username: ${{secrets.RUBYGEMS_SERVER_PKGS_SHOPIFY_IO_USERNAME}}
-    password: ${{secrets.RUBYGEMS_SERVER_PKGS_SHOPIFY_IO_PASSWORD}}
-  github-com:
-    type: git
-    url: https://github.com
-    username: ${{secrets.DEPENDENCIES_GITHUB_USER}}
-    password: ${{secrets.DEPENDENCIES_GITHUB_TOKEN}}
 updates:
   - package-ecosystem: bundler
     directory: "/"
@@ -17,7 +6,10 @@ updates:
       interval: daily
     open-pull-requests-limit: 100
     insecure-external-code-execution: allow
-    registries: "*"
+  - package-ecosystem: npm
+    directory: "/lang/typescript"
+    schedule:
+      interval: daily
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
## Problem

[Dependabot update jobs are failing ](https://github.com/Shopify/worldwide/actions/runs/25574807674/job/75079245836)at startup before any dependency resolution:

```
Error: fetching credentials: unexpected status code: 422:
  {"errors":[{"status":422,"title":"Secret Not Found","detail":"DEPENDENCIES_GITHUB_USER"}]}
```

The `dependabot.yml` configures a `github-com` git registry using `DEPENDENCIES_GITHUB_USER` / `DEPENDENCIES_GITHUB_TOKEN` secrets that don't exist in this repo. Dependabot fetches credentials for all configured registries at job startup, so every job fails — including `npm` jobs in `lang/typescript` that have nothing to do with GitHub-hosted gems.

## Why the registry is unnecessary

Dependabot accesses public GitHub repos via its own built-in token; no explicit `git` registry entry is needed.  Default behavior is to raise pull requests only to update dependencies stored in publicly accessible registries.

`registries` are only necessary [when accessing private package registries](https://docs.github.com/en/enterprise-cloud@latest/code-security/reference/supply-chain-security/dependabot-options-reference#registries--). Worldwide does not leverage any private packages, and so this config is not needed. 

**Precedent:** `Shopify/ruby-lsp` started with the exact same boilerplate (commit [`90afd3e`](https://github.com/Shopify/ruby-lsp/commit/90afd3e273)). Five days later, ["Simplified dependabot config"](https://github.com/Shopify/ruby-lsp/commit/9d708c826f) removed it. Their Dependabot runs have been clean ever since.

## Changes

- **Remove** all `registries`
- **Add** `npm` ecosystem for `lang/typescript` on a daily schedule — Dependabot was already auto-generating jobs for this directory; making it explicit gives us control