### PR TITLE
ci: declare contents:read on CI Typescript workflow

### DIFF
--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `CI Typescript` workflow's single `build` job runs `pnpm install` + the build script inside `lang/typescript`. No GitHub API write, no cache directive, no comment-on-PR step.

This patch pins it to `permissions: contents: read` at workflow scope. Style matches the per-job permission block already declared in `npm-release.yml` (`id-token: write` + `contents: write` + `pull-requests: write` for the npm publish path).

With explicit scope:

- the workflow token can't be widened by a future change to the repo default
- the SLSA / OpenSSF Scorecard `Token-Permissions` check passes for this file
- third-party action exposure (`pnpm/action-setup`, `actions/setup-node`) is bounded to read

`ci.yml` is the other workflow without an explicit `permissions:` block, but it uses `ruby/setup-ruby` with `bundler-cache: true`, which interacts with the cache-save path and deserves a separate look.

No behavioural change.