### PR TITLE
Remove optional ? in PT zip_regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ---
 
-## [1.24.3] - 2026-05-18
+## [1.25.1] - 2026-05-26
 - Update postal code expectations in Portugal to require seven digit postal code (XXXX-XXX) [#493](https://github.com/Shopify/worldwide/pull/493)
 
 ## [1.25.0] - 2026-05-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ---
 
 ## [1.24.3] - 2026-05-18
-- Update postal code expectations in Portugal to require seven digit postal code (XXXX-XXX)
+- Update postal code expectations in Portugal to require seven digit postal code (XXXX-XXX) [#493](https://github.com/Shopify/worldwide/pull/493)
 
 ## [1.24.2] - 2026-04-27
 - Update CLDR subdivision names for IT-OT (Gallura Nord-Est Sardegna) and IT-CI (Sulcis Iglesiente) in `:en`, `:it`, and `:de` only; other locales remain on stale upstream CLDR pending an upstream fix [#458](https://github.com/Shopify/worldwide/pull/458)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ---
 
+## [1.24.3] - 2026-05-18
+- Update postal code expectations in Portugal to require seven digit postal code (XXXX-XXX)
+
 ## [1.24.2] - 2026-04-27
 - Update CLDR subdivision names for IT-OT (Gallura Nord-Est Sardegna) and IT-CI (Sulcis Iglesiente) in `:en`, `:it`, and `:de` only; other locales remain on stale upstream CLDR pending an upstream fix [#458](https://github.com/Shopify/worldwide/pull/458)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (1.24.2)
+    worldwide (1.24.3)
       activesupport (>= 7.0)
       i18n
       phonelib (~> 0.8)

--- a/data/regions/PT.yml
+++ b/data/regions/PT.yml
@@ -8,7 +8,7 @@ tax_name: VAT
 tax_inclusive: true
 group: European Countries
 group_name: Europe
-zip_regex: "^(PT?-?)?\\d{4}(-?\\d{3})?$"
+zip_regex: "^(PT?-?)?\\d{4}-?\\d{3}$"
 zip_example: 2725-079
 phone_number_prefix: 351
 building_number_required: true

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "1.24.2"
+  VERSION = "1.24.3"
 end

--- a/test/worldwide/regions/pt_test.rb
+++ b/test/worldwide/regions/pt_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Worldwide
+  class PtTest < ActiveSupport::TestCase
+    setup do
+      @region = Worldwide.region(code: "PT")
+    end
+
+    test "seven digit postal codes are valid" do
+      assert @region.valid_zip?("1234-567")
+    end
+
+    test "hypen is optional in valid postal codes" do
+      assert @region.valid_zip?("1234567")
+    end
+
+    test "leading country code in postal code is valid" do
+      assert @region.valid_zip?("PT-1234-567")
+    end
+
+    test "four digit postal codes are invalid" do
+      assert_not @region.valid_zip?("1234")
+    end
+  end
+end


### PR DESCRIPTION
### What are you trying to accomplish?

Portugal postal code format should be XXXX-XXX, all numeric. Our current regex does not require the second set of three digits, despite it being the required format since 1998.

Contributes to https://github.com/shop/issues-checkout/issues/11587

### What approach did you choose and why?

- Remove the `?` part of the regex making the second set of digits optional.
- Leave the `?` that makes the `-` optional.

### What should reviewers focus on?

I don't think there's any way to flag these changes for a gradual rollout, but I'd be happy to hear otherwise.

### The impact of these changes

[After services start using the new gem version]
- Customers will be required to enter the full postal code
- Merchants touching old records will need to put in the full postal code. We expect Atlas to be able to provide the correct value.

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
