### PR TITLE
Introducing district and subdistrict field labels and error strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ---
 
+ ## [1.25.0] - 2026-05-22
+  - Add district and subdistrict address fields, labels, and validation messages.
+
 ## [1.24.2] - 2026-04-27
 - Update CLDR subdivision names for IT-OT (Gallura Nord-Est Sardegna) and IT-CI (Sulcis Iglesiente) in `:en`, `:it`, and `:de` only; other locales remain on stale upstream CLDR pending an upstream fix [#458](https://github.com/Shopify/worldwide/pull/458)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (1.24.2)
+    worldwide (1.25.0)
       activesupport (>= 7.0)
       i18n
       phonelib (~> 0.8)

--- a/data/regions/BR/bg.yml
+++ b/data/regions/BR/bg.yml
@@ -17,3 +17,40 @@ bg:
           errors:
             blank_instructional: Изберете щат
             blank_informative: Липсва щат
+        district:
+          label:
+            default: Квартал
+            optional: Квартал (по избор)
+          errors:
+            blank_instructional: Въведете квартал
+            blank_informative: Липсва квартал
+            too_long_instructional: Кварталът е твърде дълъг (максимумът е %{limit}
+              знака)
+            too_long_informative: Кварталът е твърде дълъг
+            contains_emojis_instructional: Кварталът не може да съдържа емоджита
+            contains_emojis_informative: Кварталът не може да съдържа емоджита
+            contains_mathematical_symbols_instructional: Кварталът не може да съдържа
+              математически символи
+            contains_mathematical_symbols_informative: Кварталът не може да съдържа
+              математически символи
+            contains_restricted_characters_instructional: Кварталът може да съдържа
+              само букви, цифри, локални и специални знаци
+            contains_restricted_characters_informative: Кварталът не може да съдържа
+              неразрешени знаци
+            contains_too_many_words_instructional: Кварталът трябва да съдържа по-малко
+              от %{word_count} думи
+            contains_too_many_words_informative: Кварталът трябва да съдържа по-малко
+              от %{word_count} думи
+            contains_html_tags_instructional: Кварталът не може да съдържа HTML тагове
+            contains_html_tags_informative: Кварталът не може да съдържа HTML тагове
+            contains_url_instructional: Кварталът не може да съдържа URL адреси
+            contains_url_informative: Кварталът не може да съдържа URL адреси
+            unknown_for_city_instructional: Въведете валидно име на квартал за %{city}
+            unknown_for_city_informative: Въведете валидно име на квартал за %{city}
+            unknown_for_zip_instructional: Въведете валидно име на квартал за %{zip}
+            unknown_for_zip_informative: Въведете валидно име на квартал за %{zip}
+            unknown_for_address_instructional: Кварталът може да е грешен
+            unknown_for_address_informative: Кварталът може да е грешен
+          warnings:
+            contains_too_many_words: Препоръчително е кварталът да съдържа по-малко
+              от %{word_count} думи

--- a/data/regions/BR/cs.yml
+++ b/data/regions/BR/cs.yml
@@ -17,3 +17,41 @@ cs:
           errors:
             blank_instructional: Vyberte stát.
             blank_informative: Stát chybí.
+        district:
+          label:
+            default: Čtvrť
+            optional: Čtvrť (volitelné)
+          errors:
+            blank_instructional: Zadejte čtvrť
+            blank_informative: Chybí čtvrť
+            too_long_instructional: Název čtvrti je příliš dlouhý (maximum je %{limit}
+              znaků)
+            too_long_informative: Název čtvrti je příliš dlouhý
+            contains_emojis_instructional: Název čtvrti nesmí obsahovat emodži
+            contains_emojis_informative: Název čtvrti nesmí obsahovat emodži
+            contains_mathematical_symbols_instructional: Název čtvrti nesmí obsahovat
+              matematické symboly
+            contains_mathematical_symbols_informative: Název čtvrti nesmí obsahovat
+              matematické symboly
+            contains_restricted_characters_instructional: Název čtvrti smí obsahovat
+              pouze písmena, číslice, místní znaky a speciální znaky
+            contains_restricted_characters_informative: Název čtvrti nesmí obsahovat
+              nepovolené znaky
+            contains_too_many_words_instructional: Název čtvrti musí mít méně než
+              %{word_count} slov
+            contains_too_many_words_informative: Název čtvrti musí mít méně než %{word_count}
+              slov
+            contains_html_tags_instructional: Název čtvrti nesmí obsahovat značky
+              HTML
+            contains_html_tags_informative: Název čtvrti nesmí obsahovat značky HTML
+            contains_url_instructional: Název čtvrti nesmí obsahovat adresy URL
+            contains_url_informative: Název čtvrti nesmí obsahovat adresy URL
+            unknown_for_city_instructional: Zadejte platný název čtvrti pro %{city}
+            unknown_for_city_informative: Zadejte platný název čtvrti pro %{city}
+            unknown_for_zip_instructional: Zadejte platný název čtvrti pro %{zip}
+            unknown_for_zip_informative: Zadejte platný název čtvrti pro %{zip}
+            unknown_for_address_instructional: Název čtvrti je možná nesprávný
+            unknown_for_address_informative: Název čtvrti je možná nesprávný
+          warnings:
+            contains_too_many_words: Doporučujeme, aby název čtvrti obsahoval méně
+              než %{word_count} slov

--- a/data/regions/BR/da.yml
+++ b/data/regions/BR/da.yml
@@ -17,3 +17,41 @@ da:
           errors:
             blank_instructional: Vælg en stat
             blank_informative: Stat mangler
+        district:
+          label:
+            default: Kvarter
+            optional: Kvarter (valgfrit)
+          errors:
+            blank_instructional: Indtast et kvarter
+            blank_informative: Kvarter mangler
+            too_long_instructional: Kvarteret er for langt (maks. %{limit} tegn)
+            too_long_informative: Kvarteret er for langt
+            contains_emojis_instructional: Kvarteret kan ikke indeholde emojis
+            contains_emojis_informative: Kvarteret kan ikke indeholde emojis
+            contains_mathematical_symbols_instructional: Kvarteret kan ikke indeholde
+              matematiske symboler
+            contains_mathematical_symbols_informative: Kvarteret kan ikke indeholde
+              matematiske symboler
+            contains_restricted_characters_instructional: Kvarteret kan kun indeholde
+              bogstaver, tal, lokale tegn og specialtegn
+            contains_restricted_characters_informative: Kvarteret kan ikke indeholde
+              ikke-tilladte tegn
+            contains_too_many_words_instructional: Kvarteret skal have færre end %{word_count}
+              ord
+            contains_too_many_words_informative: Kvarteret skal have færre end %{word_count}
+              ord
+            contains_html_tags_instructional: Kvarteret kan ikke indeholde HTML-tags
+            contains_html_tags_informative: Kvarteret kan ikke indeholde HTML-tags
+            contains_url_instructional: Kvarteret kan ikke indeholde webadresser
+            contains_url_informative: Kvarteret kan ikke indeholde webadresser
+            unknown_for_city_instructional: Indtast et gyldigt navn på kvarter for
+              %{city}
+            unknown_for_city_informative: Indtast et gyldigt navn på kvarter for %{city}
+            unknown_for_zip_instructional: Indtast et gyldigt navn på kvarter for
+              %{zip}
+            unknown_for_zip_informative: Indtast et gyldigt navn på kvarter for %{zip}
+            unknown_for_address_instructional: Kvarteret er muligvis forkert
+            unknown_for_address_informative: Kvarteret er muligvis forkert
+          warnings:
+            contains_too_many_words: Det anbefales, at kvarteret har færre end %{word_count}
+              ord

--- a/data/regions/BR/de.yml
+++ b/data/regions/BR/de.yml
@@ -17,3 +17,43 @@ de:
           errors:
             blank_instructional: Staat auswählen
             blank_informative: Staat fehlt
+        district:
+          label:
+            default: Stadtteil
+            optional: Stadtteil (optional)
+          errors:
+            blank_instructional: Gib einen Stadtteil ein
+            blank_informative: Stadtteil fehlt
+            too_long_instructional: Stadtteil ist zu lang (maximal %{limit} Zeichen)
+            too_long_informative: Stadtteil ist zu lang
+            contains_emojis_instructional: Stadtteil darf keine Emojis enthalten
+            contains_emojis_informative: Stadtteil darf keine Emojis enthalten
+            contains_mathematical_symbols_instructional: Stadtteil darf keine mathematischen
+              Symbole enthalten
+            contains_mathematical_symbols_informative: Stadtteil darf keine mathematischen
+              Symbole enthalten
+            contains_restricted_characters_instructional: Stadtteil darf nur Buchstaben,
+              Zahlen, lokale Zeichen und Sonderzeichen enthalten
+            contains_restricted_characters_informative: Stadtteil darf keine unzulässigen
+              Zeichen enthalten
+            contains_too_many_words_instructional: Stadtteil muss aus weniger als
+              %{word_count} Wörtern bestehen
+            contains_too_many_words_informative: Stadtteil muss aus weniger als %{word_count}
+              Wörtern bestehen
+            contains_html_tags_instructional: Stadtteil darf keine HTML-Tags enthalten
+            contains_html_tags_informative: Stadtteil darf keine HTML-Tags enthalten
+            contains_url_instructional: Stadtteil darf keine URLs enthalten
+            contains_url_informative: Stadtteil darf keine URLs enthalten
+            unknown_for_city_instructional: Gib einen gültigen Stadtteilnamen für
+              %{city} ein
+            unknown_for_city_informative: Gib einen gültigen Stadtteilnamen für %{city}
+              ein
+            unknown_for_zip_instructional: Gib einen gültigen Stadtteilnamen für %{zip}
+              ein
+            unknown_for_zip_informative: Gib einen gültigen Stadtteilnamen für %{zip}
+              ein
+            unknown_for_address_instructional: Stadtteil ist möglicherweise falsch
+            unknown_for_address_informative: Stadtteil ist möglicherweise falsch
+          warnings:
+            contains_too_many_words: Stadtteil sollte aus weniger als %{word_count}
+              Wörtern bestehen

--- a/data/regions/BR/el.yml
+++ b/data/regions/BR/el.yml
@@ -17,3 +17,46 @@ el:
           errors:
             blank_instructional: Επιλέξτε έναν νομό
             blank_informative: Ο νομός λείπει
+        district:
+          label:
+            default: Συνοικία
+            optional: Συνοικία (προαιρετικό)
+          errors:
+            blank_instructional: Εισαγάγετε μια συνοικία
+            blank_informative: Λείπει η συνοικία
+            too_long_instructional: Η συνοικία είναι πολύ μεγάλη (το μέγιστο είναι
+              %{limit} χαρακτήρες)
+            too_long_informative: Η συνοικία είναι πολύ μεγάλη
+            contains_emojis_instructional: Η συνοικία δεν μπορεί να περιέχει emoji
+            contains_emojis_informative: Η συνοικία δεν μπορεί να περιέχει emoji
+            contains_mathematical_symbols_instructional: Η συνοικία δεν μπορεί να
+              περιέχει μαθηματικά σύμβολα
+            contains_mathematical_symbols_informative: Η συνοικία δεν μπορεί να περιέχει
+              μαθηματικά σύμβολα
+            contains_restricted_characters_instructional: Η συνοικία μπορεί να περιέχει
+              μόνο γράμματα, αριθμούς, τοπικούς χαρακτήρες και ειδικούς χαρακτήρες
+            contains_restricted_characters_informative: Η συνοικία δεν μπορεί να περιέχει
+              μη επιτρεπόμενους χαρακτήρες
+            contains_too_many_words_instructional: Η συνοικία πρέπει να έχει λιγότερες
+              από %{word_count} λέξεις
+            contains_too_many_words_informative: Η συνοικία πρέπει να έχει λιγότερες
+              από %{word_count} λέξεις
+            contains_html_tags_instructional: Η συνοικία δεν μπορεί να περιέχει ετικέτες
+              HTML
+            contains_html_tags_informative: Η συνοικία δεν μπορεί να περιέχει ετικέτες
+              HTML
+            contains_url_instructional: Η συνοικία δεν μπορεί να περιέχει URL
+            contains_url_informative: Η συνοικία δεν μπορεί να περιέχει URL
+            unknown_for_city_instructional: Εισαγάγετε ένα έγκυρο όνομα συνοικίας
+              για %{city}
+            unknown_for_city_informative: Εισαγάγετε ένα έγκυρο όνομα συνοικίας για
+              %{city}
+            unknown_for_zip_instructional: Εισαγάγετε ένα έγκυρο όνομα συνοικίας για
+              %{zip}
+            unknown_for_zip_informative: Εισαγάγετε ένα έγκυρο όνομα συνοικίας για
+              %{zip}
+            unknown_for_address_instructional: Η συνοικία ενδέχεται να είναι λανθασμένη
+            unknown_for_address_informative: Η συνοικία ενδέχεται να είναι λανθασμένη
+          warnings:
+            contains_too_many_words: Συνιστάται η συνοικία να έχει λιγότερες από %{word_count}
+              λέξεις

--- a/data/regions/BR/en.yml
+++ b/data/regions/BR/en.yml
@@ -17,3 +17,33 @@ en:
           errors:
             blank_instructional: Select a state
             blank_informative: State is missing
+        district:
+          label:
+            default: Neighborhood
+            optional: Neighborhood (optional)
+          errors:
+            blank_instructional: Enter a neighborhood
+            blank_informative: Neighborhood is missing
+            too_long_instructional: Neighborhood is too long (maximum is %{limit} characters)
+            too_long_informative: Neighborhood is too long
+            contains_emojis_instructional: Neighborhood can't contain emojis
+            contains_emojis_informative: Neighborhood can't contain emojis
+            contains_mathematical_symbols_instructional: Neighborhood can't contain mathematical symbols
+            contains_mathematical_symbols_informative: Neighborhood can't contain mathematical symbols
+            contains_restricted_characters_instructional: Neighborhood can only contain letters, numbers,
+              local characters, and special characters
+            contains_restricted_characters_informative: Neighborhood can't contain restricted characters
+            contains_too_many_words_instructional: Neighborhood must have fewer than %{word_count} words
+            contains_too_many_words_informative: Neighborhood must have fewer than %{word_count} words
+            contains_html_tags_instructional: Neighborhood can't contain HTML tags
+            contains_html_tags_informative: Neighborhood can't contain HTML tags
+            contains_url_instructional: Neighborhood can't contain URLs
+            contains_url_informative: Neighborhood can't contain URLs
+            unknown_for_city_instructional: Enter a valid neighborhood name for %{city}
+            unknown_for_city_informative: Enter a valid neighborhood name for %{city}
+            unknown_for_zip_instructional: Enter a valid neighborhood name for %{zip}
+            unknown_for_zip_informative: Enter a valid neighborhood name for %{zip}
+            unknown_for_address_instructional: Neighborhood may be incorrect
+            unknown_for_address_informative: Neighborhood may be incorrect
+          warnings:
+            contains_too_many_words: Neighborhood is recommended to have less than %{word_count} words

--- a/data/regions/BR/es.yml
+++ b/data/regions/BR/es.yml
@@ -17,3 +17,45 @@ es:
           errors:
             blank_instructional: Selecciona un estado.
             blank_informative: Falta el estado.
+        district:
+          label:
+            default: Barrio
+            optional: Barrio (opcional)
+          errors:
+            blank_instructional: Ingresa un barrio
+            blank_informative: Falta el barrio
+            too_long_instructional: El barrio es demasiado largo (el máximo es de
+              %{limit} caracteres)
+            too_long_informative: El barrio es demasiado largo
+            contains_emojis_instructional: El barrio no puede contener emojis
+            contains_emojis_informative: El barrio no puede contener emojis
+            contains_mathematical_symbols_instructional: El barrio no puede contener
+              símbolos matemáticos
+            contains_mathematical_symbols_informative: El barrio no puede contener
+              símbolos matemáticos
+            contains_restricted_characters_instructional: El barrio solo puede contener
+              letras, números, caracteres locales y caracteres especiales
+            contains_restricted_characters_informative: El barrio no puede contener
+              caracteres restringidos
+            contains_too_many_words_instructional: El barrio debe tener menos de %{word_count}
+              palabras
+            contains_too_many_words_informative: El barrio debe tener menos de %{word_count}
+              palabras
+            contains_html_tags_instructional: El barrio no puede contener etiquetas
+              HTML
+            contains_html_tags_informative: El barrio no puede contener etiquetas
+              HTML
+            contains_url_instructional: El barrio no puede contener URL
+            contains_url_informative: El barrio no puede contener URL
+            unknown_for_city_instructional: Ingresa un nombre de barrio válido para
+              %{city}
+            unknown_for_city_informative: Ingresa un nombre de barrio válido para
+              %{city}
+            unknown_for_zip_instructional: Ingresa un nombre de barrio válido para
+              %{zip}
+            unknown_for_zip_informative: Ingresa un nombre de barrio válido para %{zip}
+            unknown_for_address_instructional: El barrio podría ser incorrecto
+            unknown_for_address_informative: El barrio podría ser incorrecto
+          warnings:
+            contains_too_many_words: Se recomienda que el barrio tenga menos de %{word_count}
+              palabras

--- a/data/regions/BR/fi.yml
+++ b/data/regions/BR/fi.yml
@@ -17,3 +17,44 @@ fi:
           errors:
             blank_instructional: Valitse osavaltio
             blank_informative: Osavaltio puuttuu
+        district:
+          label:
+            default: Kaupunginosa
+            optional: Kaupunginosa (valinnainen)
+          errors:
+            blank_instructional: Anna kaupunginosa
+            blank_informative: Kaupunginosa puuttuu
+            too_long_instructional: Kaupunginosa on liian pitkä (enintään %{limit}
+              merkkiä)
+            too_long_informative: Kaupunginosa on liian pitkä
+            contains_emojis_instructional: Kaupunginosa ei voi sisältää emojeja
+            contains_emojis_informative: Kaupunginosa ei voi sisältää emojeja
+            contains_mathematical_symbols_instructional: Kaupunginosa ei voi sisältää
+              matemaattisia symboleja
+            contains_mathematical_symbols_informative: Kaupunginosa ei voi sisältää
+              matemaattisia symboleja
+            contains_restricted_characters_instructional: Kaupunginosa voi sisältää
+              vain kirjaimia, numeroita, paikallisia merkkejä ja erikoismerkkejä
+            contains_restricted_characters_informative: Kaupunginosa ei voi sisältää
+              kiellettyjä merkkejä
+            contains_too_many_words_instructional: Kaupunginosassa on oltava alle
+              %{word_count} sanaa
+            contains_too_many_words_informative: Kaupunginosassa on oltava alle %{word_count}
+              sanaa
+            contains_html_tags_instructional: Kaupunginosa ei voi sisältää HTML-tunnisteita
+            contains_html_tags_informative: Kaupunginosa ei voi sisältää HTML-tunnisteita
+            contains_url_instructional: Kaupunginosa ei voi sisältää URL-osoitteita
+            contains_url_informative: Kaupunginosa ei voi sisältää URL-osoitteita
+            unknown_for_city_instructional: Anna kelvollinen kaupunginosa kaupungille
+              %{city}
+            unknown_for_city_informative: Anna kelvollinen kaupunginosa kaupungille
+              %{city}
+            unknown_for_zip_instructional: Anna kelvollinen kaupunginosa postinumerolle
+              %{zip}
+            unknown_for_zip_informative: Anna kelvollinen kaupunginosa postinumerolle
+              %{zip}
+            unknown_for_address_instructional: Kaupunginosa saattaa olla virheellinen
+            unknown_for_address_informative: Kaupunginosa saattaa olla virheellinen
+          warnings:
+            contains_too_many_words: Kaupunginosassa suositellaan olevan alle %{word_count}
+              sanaa

--- a/data/regions/BR/fr.yml
+++ b/data/regions/BR/fr.yml
@@ -17,3 +17,47 @@ fr:
           errors:
             blank_instructional: Sélectionner un État
             blank_informative: L'État est manquant
+        district:
+          label:
+            default: Quartier
+            optional: Quartier (facultatif)
+          errors:
+            blank_instructional: Saisissez un quartier
+            blank_informative: Le quartier est manquant
+            too_long_instructional: Le quartier est trop long (maximum de %{limit}
+              caractères)
+            too_long_informative: Le quartier est trop long
+            contains_emojis_instructional: Le quartier ne peut pas contenir d’émojis
+            contains_emojis_informative: Le quartier ne peut pas contenir d’émojis
+            contains_mathematical_symbols_instructional: Le quartier ne peut pas contenir
+              de symboles mathématiques
+            contains_mathematical_symbols_informative: Le quartier ne peut pas contenir
+              de symboles mathématiques
+            contains_restricted_characters_instructional: Le quartier peut uniquement
+              contenir des lettres, des chiffres, des caractères locaux et des caractères
+              spéciaux
+            contains_restricted_characters_informative: Le quartier ne peut pas contenir
+              de caractères restreints
+            contains_too_many_words_instructional: Le quartier doit comporter moins
+              de %{word_count} mots
+            contains_too_many_words_informative: Le quartier doit comporter moins
+              de %{word_count} mots
+            contains_html_tags_instructional: Le quartier ne peut pas contenir de
+              balises HTML
+            contains_html_tags_informative: Le quartier ne peut pas contenir de balises
+              HTML
+            contains_url_instructional: Le quartier ne peut pas contenir d’URL
+            contains_url_informative: Le quartier ne peut pas contenir d’URL
+            unknown_for_city_instructional: Saisissez un nom de quartier valide pour
+              %{city}
+            unknown_for_city_informative: Saisissez un nom de quartier valide pour
+              %{city}
+            unknown_for_zip_instructional: Saisissez un nom de quartier valide pour
+              %{zip}
+            unknown_for_zip_informative: Saisissez un nom de quartier valide pour
+              %{zip}
+            unknown_for_address_instructional: Le quartier est peut-être incorrect
+            unknown_for_address_informative: Le quartier est peut-être incorrect
+          warnings:
+            contains_too_many_words: Il est recommandé que le quartier comporte moins
+              de %{word_count} mots

--- a/data/regions/BR/hi.yml
+++ b/data/regions/BR/hi.yml
@@ -17,3 +17,41 @@ hi:
           errors:
             blank_instructional: कोई राज्य चुनें
             blank_informative: राज्य का नाम गुम है
+        district:
+          label:
+            default: मोहल्ला
+            optional: मोहल्ला (वैकल्पिक)
+          errors:
+            blank_instructional: कोई मोहल्ला दर्ज करें.
+            blank_informative: मोहल्ला मौजूद नहीं है.
+            too_long_instructional: मोहल्ला बहुत लंबा है (अधिकतम %{limit} वर्ण होने
+              चाहिए).
+            too_long_informative: मोहल्ला बहुत लंबा है.
+            contains_emojis_instructional: मोहल्ले में इमोजी नहीं हो सकते.
+            contains_emojis_informative: मोहल्ले में इमोजी नहीं हो सकते.
+            contains_mathematical_symbols_instructional: मोहल्ले में गणितीय चिह्न
+              नहीं हो सकते.
+            contains_mathematical_symbols_informative: मोहल्ले में गणितीय चिह्न नहीं
+              हो सकते.
+            contains_restricted_characters_instructional: मोहल्ले में केवल अक्षर,
+              अंक, स्थानीय वर्ण और विशेष वर्ण हो सकते हैं.
+            contains_restricted_characters_informative: मोहल्ले में प्रतिबंधित वर्ण
+              नहीं हो सकते.
+            contains_too_many_words_instructional: मोहल्ले में %{word_count} से कम
+              शब्द होने चाहिए.
+            contains_too_many_words_informative: मोहल्ले में %{word_count} से कम शब्द
+              होने चाहिए.
+            contains_html_tags_instructional: मोहल्ले में HTML टैग नहीं हो सकते.
+            contains_html_tags_informative: मोहल्ले में HTML टैग नहीं हो सकते.
+            contains_url_instructional: मोहल्ले में URL नहीं हो सकते.
+            contains_url_informative: मोहल्ले में URL नहीं हो सकते.
+            unknown_for_city_instructional: "%{city} के लिए कोई मान्य मोहल्ला दर्ज
+              करें."
+            unknown_for_city_informative: "%{city} के लिए कोई मान्य मोहल्ला दर्ज करें."
+            unknown_for_zip_instructional: "%{zip} के लिए कोई मान्य मोहल्ला दर्ज करें."
+            unknown_for_zip_informative: "%{zip} के लिए कोई मान्य मोहल्ला दर्ज करें."
+            unknown_for_address_instructional: मोहल्ला गलत हो सकता है.
+            unknown_for_address_informative: मोहल्ला गलत हो सकता है.
+          warnings:
+            contains_too_many_words: सुझाव है कि मोहल्ले में %{word_count} से कम शब्द
+              हों.

--- a/data/regions/BR/hr.yml
+++ b/data/regions/BR/hr.yml
@@ -17,3 +17,39 @@ hr:
           errors:
             blank_instructional: Odaberite saveznu državu
             blank_informative: Nedostaje savezna država
+        district:
+          label:
+            default: Četvrt
+            optional: Četvrt (nije obavezno)
+          errors:
+            blank_instructional: Unesite četvrt
+            blank_informative: Nedostaje četvrt
+            too_long_instructional: 'Četvrt je preduga (maksimalan broj znakova: %{limit})'
+            too_long_informative: Četvrt je preduga
+            contains_emojis_instructional: Četvrt ne može sadržavati emojije
+            contains_emojis_informative: Četvrt ne može sadržavati emojije
+            contains_mathematical_symbols_instructional: Četvrt ne može sadržavati
+              matematičke simbole
+            contains_mathematical_symbols_informative: Četvrt ne može sadržavati matematičke
+              simbole
+            contains_restricted_characters_instructional: Četvrt može sadržavati samo
+              slova, brojeve, lokalne znakove i posebne znakove
+            contains_restricted_characters_informative: Četvrt ne može sadržavati
+              zabranjene znakove
+            contains_too_many_words_instructional: Četvrt mora imati manje od %{word_count}
+              riječi
+            contains_too_many_words_informative: Četvrt mora imati manje od %{word_count}
+              riječi
+            contains_html_tags_instructional: Četvrt ne može sadržavati HTML oznake
+            contains_html_tags_informative: Četvrt ne može sadržavati HTML oznake
+            contains_url_instructional: Četvrt ne može sadržavati URL-ove
+            contains_url_informative: Četvrt ne može sadržavati URL-ove
+            unknown_for_city_instructional: Unesite važeći naziv četvrti za %{city}
+            unknown_for_city_informative: Unesite važeći naziv četvrti za %{city}
+            unknown_for_zip_instructional: Unesite važeći naziv četvrti za %{zip}
+            unknown_for_zip_informative: Unesite važeći naziv četvrti za %{zip}
+            unknown_for_address_instructional: Četvrt je možda netočna
+            unknown_for_address_informative: Četvrt je možda netočna
+          warnings:
+            contains_too_many_words: Preporučuje se da naziv četvrti ima manje od
+              %{word_count} riječi

--- a/data/regions/BR/hu.yml
+++ b/data/regions/BR/hu.yml
@@ -17,3 +17,44 @@ hu:
           errors:
             blank_instructional: Válassz államot
             blank_informative: Az állam nincs megadva
+        district:
+          label:
+            default: Városrész
+            optional: Városrész (opcionális)
+          errors:
+            blank_instructional: Adjon meg egy városrészt
+            blank_informative: A városrész hiányzik
+            too_long_instructional: A városrész túl hosszú (legfeljebb %{limit} karakter
+              lehet)
+            too_long_informative: A városrész túl hosszú
+            contains_emojis_instructional: A városrész nem tartalmazhat emojikat
+            contains_emojis_informative: A városrész nem tartalmazhat emojikat
+            contains_mathematical_symbols_instructional: A városrész nem tartalmazhat
+              matematikai szimbólumokat
+            contains_mathematical_symbols_informative: A városrész nem tartalmazhat
+              matematikai szimbólumokat
+            contains_restricted_characters_instructional: A városrész csak betűket,
+              számokat, helyi karaktereket és speciális karaktereket tartalmazhat
+            contains_restricted_characters_informative: A városrész nem tartalmazhat
+              tiltott karaktereket
+            contains_too_many_words_instructional: A városrész nevének kevesebb mint
+              %{word_count} szóból kell állnia
+            contains_too_many_words_informative: A városrész nevének kevesebb mint
+              %{word_count} szóból kell állnia
+            contains_html_tags_instructional: A városrész nem tartalmazhat HTML-címkéket
+            contains_html_tags_informative: A városrész nem tartalmazhat HTML-címkéket
+            contains_url_instructional: A városrész nem tartalmazhat URL-eket
+            contains_url_informative: A városrész nem tartalmazhat URL-eket
+            unknown_for_city_instructional: 'Adjon meg egy érvényes városrésznevet
+              itt: %{city}'
+            unknown_for_city_informative: 'Adjon meg egy érvényes városrésznevet itt:
+              %{city}'
+            unknown_for_zip_instructional: 'Adjon meg egy érvényes városrésznevet
+              ehhez az irányítószámhoz: %{zip}'
+            unknown_for_zip_informative: 'Adjon meg egy érvényes városrésznevet ehhez
+              az irányítószámhoz: %{zip}'
+            unknown_for_address_instructional: Lehet, hogy a városrész hibás
+            unknown_for_address_informative: Lehet, hogy a városrész hibás
+          warnings:
+            contains_too_many_words: Javasoljuk, hogy a városrész neve kevesebb mint
+              %{word_count} szóból álljon

--- a/data/regions/BR/id.yml
+++ b/data/regions/BR/id.yml
@@ -17,3 +17,44 @@ id:
           errors:
             blank_instructional: Pilih negara bagian
             blank_informative: Nama negara bagian belum diisi
+        district:
+          label:
+            default: Lingkungan
+            optional: Lingkungan (opsional)
+          errors:
+            blank_instructional: Masukkan lingkungan
+            blank_informative: Lingkungan belum diisi
+            too_long_instructional: Lingkungan terlalu panjang (maksimal %{limit}
+              karakter)
+            too_long_informative: Lingkungan terlalu panjang
+            contains_emojis_instructional: Lingkungan tidak boleh berisi emoji
+            contains_emojis_informative: Lingkungan tidak boleh berisi emoji
+            contains_mathematical_symbols_instructional: Lingkungan tidak boleh berisi
+              simbol matematika
+            contains_mathematical_symbols_informative: Lingkungan tidak boleh berisi
+              simbol matematika
+            contains_restricted_characters_instructional: Lingkungan hanya boleh berisi
+              huruf, angka, karakter lokal, dan karakter khusus
+            contains_restricted_characters_informative: Lingkungan tidak boleh berisi
+              karakter yang dilarang
+            contains_too_many_words_instructional: Lingkungan harus kurang dari %{word_count}
+              kata
+            contains_too_many_words_informative: Lingkungan harus kurang dari %{word_count}
+              kata
+            contains_html_tags_instructional: Lingkungan tidak boleh berisi tag HTML
+            contains_html_tags_informative: Lingkungan tidak boleh berisi tag HTML
+            contains_url_instructional: Lingkungan tidak boleh berisi URL
+            contains_url_informative: Lingkungan tidak boleh berisi URL
+            unknown_for_city_instructional: Masukkan nama lingkungan yang valid untuk
+              %{city}
+            unknown_for_city_informative: Masukkan nama lingkungan yang valid untuk
+              %{city}
+            unknown_for_zip_instructional: Masukkan nama lingkungan yang valid untuk
+              %{zip}
+            unknown_for_zip_informative: Masukkan nama lingkungan yang valid untuk
+              %{zip}
+            unknown_for_address_instructional: Lingkungan mungkin salah
+            unknown_for_address_informative: Lingkungan mungkin salah
+          warnings:
+            contains_too_many_words: Lingkungan disarankan kurang dari %{word_count}
+              kata

--- a/data/regions/BR/it.yml
+++ b/data/regions/BR/it.yml
@@ -17,3 +17,44 @@ it:
           errors:
             blank_instructional: Seleziona uno stato
             blank_informative: Stato mancante
+        district:
+          label:
+            default: Quartiere
+            optional: Quartiere (facoltativo)
+          errors:
+            blank_instructional: Inserisci un quartiere
+            blank_informative: Manca il quartiere
+            too_long_instructional: Il quartiere è troppo lungo (massimo %{limit}
+              caratteri)
+            too_long_informative: Il quartiere è troppo lungo
+            contains_emojis_instructional: Il quartiere non può contenere emoji
+            contains_emojis_informative: Il quartiere non può contenere emoji
+            contains_mathematical_symbols_instructional: Il quartiere non può contenere
+              simboli matematici
+            contains_mathematical_symbols_informative: Il quartiere non può contenere
+              simboli matematici
+            contains_restricted_characters_instructional: Il quartiere può contenere
+              solo lettere, numeri, caratteri locali e caratteri speciali
+            contains_restricted_characters_informative: Il quartiere non può contenere
+              caratteri non consentiti
+            contains_too_many_words_instructional: Il quartiere deve avere meno di
+              %{word_count} parole
+            contains_too_many_words_informative: Il quartiere deve avere meno di %{word_count}
+              parole
+            contains_html_tags_instructional: Il quartiere non può contenere tag HTML
+            contains_html_tags_informative: Il quartiere non può contenere tag HTML
+            contains_url_instructional: Il quartiere non può contenere URL
+            contains_url_informative: Il quartiere non può contenere URL
+            unknown_for_city_instructional: Inserisci un nome di quartiere valido
+              per %{city}
+            unknown_for_city_informative: Inserisci un nome di quartiere valido per
+              %{city}
+            unknown_for_zip_instructional: Inserisci un nome di quartiere valido per
+              %{zip}
+            unknown_for_zip_informative: Inserisci un nome di quartiere valido per
+              %{zip}
+            unknown_for_address_instructional: Il quartiere potrebbe essere errato
+            unknown_for_address_informative: Il quartiere potrebbe essere errato
+          warnings:
+            contains_too_many_words: Si consiglia di inserire un quartiere con meno
+              di %{word_count} parole

--- a/data/regions/BR/ja.yml
+++ b/data/regions/BR/ja.yml
@@ -17,3 +17,32 @@ ja:
           errors:
             blank_instructional: 州を選択してください
             blank_informative: 州がありません
+        district:
+          label:
+            default: 地区
+            optional: 地区（オプション）
+          errors:
+            blank_instructional: 地区を入力してください
+            blank_informative: 地区が入力されていません
+            too_long_instructional: 地区が長すぎます（最大 %{limit} 文字）
+            too_long_informative: 地区が長すぎます
+            contains_emojis_instructional: 地区に絵文字を含めることはできません
+            contains_emojis_informative: 地区に絵文字を含めることはできません
+            contains_mathematical_symbols_instructional: 地区に算術記号を含めることはできません
+            contains_mathematical_symbols_informative: 地区に算術記号を含めることはできません
+            contains_restricted_characters_instructional: 地区には、文字、数字、現地の文字、特殊文字のみを使用できます
+            contains_restricted_characters_informative: 地区に制限された文字を含めることはできません
+            contains_too_many_words_instructional: 地区は %{word_count} 語未満にする必要があります
+            contains_too_many_words_informative: 地区は %{word_count} 語未満にする必要があります
+            contains_html_tags_instructional: 地区に HTML タグを含めることはできません
+            contains_html_tags_informative: 地区に HTML タグを含めることはできません
+            contains_url_instructional: 地区に URL を含めることはできません
+            contains_url_informative: 地区に URL を含めることはできません
+            unknown_for_city_instructional: "%{city} の有効な地区名を入力してください"
+            unknown_for_city_informative: "%{city} の有効な地区名を入力してください"
+            unknown_for_zip_instructional: "%{zip} の有効な地区名を入力してください"
+            unknown_for_zip_informative: "%{zip} の有効な地区名を入力してください"
+            unknown_for_address_instructional: 地区に誤りがある可能性があります
+            unknown_for_address_informative: 地区に誤りがある可能性があります
+          warnings:
+            contains_too_many_words: 地区は %{word_count} 語未満にすることをおすすめします

--- a/data/regions/BR/ko.yml
+++ b/data/regions/BR/ko.yml
@@ -17,3 +17,33 @@ ko:
           errors:
             blank_instructional: 주 선택
             blank_informative: 주가 누락되었습니다
+        district:
+          label:
+            default: 동/마을
+            optional: 동/마을(선택 사항)
+          errors:
+            blank_instructional: 동/마을을 입력하십시오.
+            blank_informative: 동/마을이 누락되었습니다.
+            too_long_instructional: 동/마을이 너무 깁니다(최대 %{limit}자).
+            too_long_informative: 동/마을이 너무 깁니다.
+            contains_emojis_instructional: 동/마을에는 이모지를 포함할 수 없습니다.
+            contains_emojis_informative: 동/마을에는 이모지를 포함할 수 없습니다.
+            contains_mathematical_symbols_instructional: 동/마을에는 수학 기호를 포함할 수 없습니다.
+            contains_mathematical_symbols_informative: 동/마을에는 수학 기호를 포함할 수 없습니다.
+            contains_restricted_characters_instructional: 동/마을에는 문자, 숫자, 현지 문자 및 특수
+              문자만 포함할 수 있습니다.
+            contains_restricted_characters_informative: 동/마을에는 제한된 문자를 포함할 수 없습니다.
+            contains_too_many_words_instructional: 동/마을은 %{word_count}단어 미만이어야 합니다.
+            contains_too_many_words_informative: 동/마을은 %{word_count}단어 미만이어야 합니다.
+            contains_html_tags_instructional: 동/마을에는 HTML 태그를 포함할 수 없습니다.
+            contains_html_tags_informative: 동/마을에는 HTML 태그를 포함할 수 없습니다.
+            contains_url_instructional: 동/마을에는 URL을 포함할 수 없습니다.
+            contains_url_informative: 동/마을에는 URL을 포함할 수 없습니다.
+            unknown_for_city_instructional: "%{city}의 유효한 동/마을 이름을 입력하십시오."
+            unknown_for_city_informative: "%{city}의 유효한 동/마을 이름을 입력하십시오."
+            unknown_for_zip_instructional: "%{zip}의 유효한 동/마을 이름을 입력하십시오."
+            unknown_for_zip_informative: "%{zip}의 유효한 동/마을 이름을 입력하십시오."
+            unknown_for_address_instructional: 동/마을이 올바르지 않을 수 있습니다.
+            unknown_for_address_informative: 동/마을이 올바르지 않을 수 있습니다.
+          warnings:
+            contains_too_many_words: 동/마을은 %{word_count}단어 미만으로 입력하는 것이 좋습니다.

--- a/data/regions/BR/lt.yml
+++ b/data/regions/BR/lt.yml
@@ -17,3 +17,40 @@ lt:
           errors:
             blank_instructional: Pasirinkite valstiją
             blank_informative: Trūksta valstijos
+        district:
+          label:
+            default: Rajonas
+            optional: Rajonas (pasirenkama)
+          errors:
+            blank_instructional: Įveskite rajoną
+            blank_informative: Nenurodytas rajonas
+            too_long_instructional: Rajono pavadinimas per ilgas (daugiausia %{limit}
+              simb.)
+            too_long_informative: Rajono pavadinimas per ilgas
+            contains_emojis_instructional: Rajono pavadinime negali būti jaustukų
+            contains_emojis_informative: Rajono pavadinime negali būti jaustukų
+            contains_mathematical_symbols_instructional: Rajono pavadinime negali
+              būti matematinių simbolių
+            contains_mathematical_symbols_informative: Rajono pavadinime negali būti
+              matematinių simbolių
+            contains_restricted_characters_instructional: Rajono pavadinime gali būti
+              tik raidės, skaičiai, vietiniai ir specialieji simboliai
+            contains_restricted_characters_informative: Rajono pavadinime negali būti
+              draudžiamų simbolių
+            contains_too_many_words_instructional: Rajono pavadinimą turi sudaryti
+              mažiau nei %{word_count} žodž.
+            contains_too_many_words_informative: Rajono pavadinimą turi sudaryti mažiau
+              nei %{word_count} žodž.
+            contains_html_tags_instructional: Rajono pavadinime negali būti HTML žymų
+            contains_html_tags_informative: Rajono pavadinime negali būti HTML žymų
+            contains_url_instructional: Rajono pavadinime negali būti URL
+            contains_url_informative: Rajono pavadinime negali būti URL
+            unknown_for_city_instructional: Įveskite tinkamą %{city} rajono pavadinimą
+            unknown_for_city_informative: Įveskite tinkamą %{city} rajono pavadinimą
+            unknown_for_zip_instructional: Įveskite tinkamą %{zip} rajono pavadinimą
+            unknown_for_zip_informative: Įveskite tinkamą %{zip} rajono pavadinimą
+            unknown_for_address_instructional: Rajonas gali būti nurodytas neteisingai
+            unknown_for_address_informative: Rajonas gali būti nurodytas neteisingai
+          warnings:
+            contains_too_many_words: Rekomenduojama, kad rajono pavadinimą sudarytų
+              mažiau nei %{word_count} žodž.

--- a/data/regions/BR/ms.yml
+++ b/data/regions/BR/ms.yml
@@ -17,3 +17,44 @@ ms:
           errors:
             blank_instructional: Pilih negeri
             blank_informative: Negeri tiada
+        district:
+          label:
+            default: Kejiranan
+            optional: Kejiranan (pilihan)
+          errors:
+            blank_instructional: Masukkan kejiranan
+            blank_informative: Kejiranan tiada
+            too_long_instructional: Kejiranan terlalu panjang (maksimum ialah %{limit}
+              aksara)
+            too_long_informative: Kejiranan terlalu panjang
+            contains_emojis_instructional: Kejiranan tidak boleh mengandungi emoji
+            contains_emojis_informative: Kejiranan tidak boleh mengandungi emoji
+            contains_mathematical_symbols_instructional: Kejiranan tidak boleh mengandungi
+              simbol matematik
+            contains_mathematical_symbols_informative: Kejiranan tidak boleh mengandungi
+              simbol matematik
+            contains_restricted_characters_instructional: Kejiranan hanya boleh mengandungi
+              huruf, nombor, aksara tempatan dan aksara khas
+            contains_restricted_characters_informative: Kejiranan tidak boleh mengandungi
+              aksara terhad
+            contains_too_many_words_instructional: Kejiranan mesti kurang daripada
+              %{word_count} perkataan
+            contains_too_many_words_informative: Kejiranan mesti kurang daripada %{word_count}
+              perkataan
+            contains_html_tags_instructional: Kejiranan tidak boleh mengandungi tag
+              HTML
+            contains_html_tags_informative: Kejiranan tidak boleh mengandungi tag
+              HTML
+            contains_url_instructional: Kejiranan tidak boleh mengandungi URL
+            contains_url_informative: Kejiranan tidak boleh mengandungi URL
+            unknown_for_city_instructional: Masukkan nama kejiranan yang sah untuk
+              %{city}
+            unknown_for_city_informative: Masukkan nama kejiranan yang sah untuk %{city}
+            unknown_for_zip_instructional: Masukkan nama kejiranan yang sah untuk
+              %{zip}
+            unknown_for_zip_informative: Masukkan nama kejiranan yang sah untuk %{zip}
+            unknown_for_address_instructional: Kejiranan mungkin tidak betul
+            unknown_for_address_informative: Kejiranan mungkin tidak betul
+          warnings:
+            contains_too_many_words: Kejiranan disyorkan mempunyai kurang daripada
+              %{word_count} perkataan

--- a/data/regions/BR/nb.yml
+++ b/data/regions/BR/nb.yml
@@ -17,3 +17,39 @@ nb:
           errors:
             blank_instructional: Velg en stat
             blank_informative: Stat mangler
+        district:
+          label:
+            default: Nabolag
+            optional: Nabolag (valgfritt)
+          errors:
+            blank_instructional: Angi et nabolag
+            blank_informative: Nabolag mangler
+            too_long_instructional: Nabolaget er for langt (maksimalt %{limit} tegn)
+            too_long_informative: Nabolaget er for langt
+            contains_emojis_instructional: Nabolag kan ikke inneholde emojier
+            contains_emojis_informative: Nabolag kan ikke inneholde emojier
+            contains_mathematical_symbols_instructional: Nabolag kan ikke inneholde
+              matematiske symboler
+            contains_mathematical_symbols_informative: Nabolag kan ikke inneholde
+              matematiske symboler
+            contains_restricted_characters_instructional: Nabolag kan bare inneholde
+              bokstaver, tall, lokale tegn og spesialtegn
+            contains_restricted_characters_informative: Nabolag kan ikke inneholde
+              ikke-tillatte tegn
+            contains_too_many_words_instructional: Nabolag må ha færre enn %{word_count}
+              ord
+            contains_too_many_words_informative: Nabolag må ha færre enn %{word_count}
+              ord
+            contains_html_tags_instructional: Nabolag kan ikke inneholde HTML-tagger
+            contains_html_tags_informative: Nabolag kan ikke inneholde HTML-tagger
+            contains_url_instructional: Nabolag kan ikke inneholde URL-adresser
+            contains_url_informative: Nabolag kan ikke inneholde URL-adresser
+            unknown_for_city_instructional: Angi et gyldig nabolag for %{city}
+            unknown_for_city_informative: Angi et gyldig nabolag for %{city}
+            unknown_for_zip_instructional: Angi et gyldig nabolag for %{zip}
+            unknown_for_zip_informative: Angi et gyldig nabolag for %{zip}
+            unknown_for_address_instructional: Nabolaget kan være feil
+            unknown_for_address_informative: Nabolaget kan være feil
+          warnings:
+            contains_too_many_words: Det anbefales at nabolaget har færre enn %{word_count}
+              ord

--- a/data/regions/BR/nl.yml
+++ b/data/regions/BR/nl.yml
@@ -17,3 +17,39 @@ nl:
           errors:
             blank_instructional: Selecteer een staat
             blank_informative: Staat ontbreekt
+        district:
+          label:
+            default: Wijk
+            optional: Wijk (optioneel)
+          errors:
+            blank_instructional: Voer een wijk in
+            blank_informative: Wijk ontbreekt
+            too_long_instructional: Wijk is te lang (maximaal %{limit} tekens)
+            too_long_informative: Wijk is te lang
+            contains_emojis_instructional: Wijk mag geen emoji's bevatten
+            contains_emojis_informative: Wijk mag geen emoji's bevatten
+            contains_mathematical_symbols_instructional: Wijk mag geen wiskundige
+              symbolen bevatten
+            contains_mathematical_symbols_informative: Wijk mag geen wiskundige symbolen
+              bevatten
+            contains_restricted_characters_instructional: Wijk mag alleen letters,
+              cijfers, lokale tekens en speciale tekens bevatten
+            contains_restricted_characters_informative: Wijk mag geen beperkte tekens
+              bevatten
+            contains_too_many_words_instructional: Wijk moet uit minder dan %{word_count}
+              woorden bestaan
+            contains_too_many_words_informative: Wijk moet uit minder dan %{word_count}
+              woorden bestaan
+            contains_html_tags_instructional: Wijk mag geen HTML-tags bevatten
+            contains_html_tags_informative: Wijk mag geen HTML-tags bevatten
+            contains_url_instructional: Wijk mag geen URL's bevatten
+            contains_url_informative: Wijk mag geen URL's bevatten
+            unknown_for_city_instructional: Voer een geldige wijknaam in voor %{city}
+            unknown_for_city_informative: Voer een geldige wijknaam in voor %{city}
+            unknown_for_zip_instructional: Voer een geldige wijknaam in voor %{zip}
+            unknown_for_zip_informative: Voer een geldige wijknaam in voor %{zip}
+            unknown_for_address_instructional: Wijk is mogelijk onjuist
+            unknown_for_address_informative: Wijk is mogelijk onjuist
+          warnings:
+            contains_too_many_words: Wijk bevat bij voorkeur minder dan %{word_count}
+              woorden

--- a/data/regions/BR/pl.yml
+++ b/data/regions/BR/pl.yml
@@ -17,3 +17,47 @@ pl:
           errors:
             blank_instructional: Wybierz stan
             blank_informative: Brakuje stanu
+        district:
+          label:
+            default: Dzielnica
+            optional: Dzielnica (opcjonalnie)
+          errors:
+            blank_instructional: Wprowadź dzielnicę
+            blank_informative: Brak dzielnicy
+            too_long_instructional: Nazwa dzielnicy jest za długa (maksymalnie %{limit}
+              znaków)
+            too_long_informative: Nazwa dzielnicy jest za długa
+            contains_emojis_instructional: Nazwa dzielnicy nie może zawierać emoji
+            contains_emojis_informative: Nazwa dzielnicy nie może zawierać emoji
+            contains_mathematical_symbols_instructional: Nazwa dzielnicy nie może
+              zawierać symboli matematycznych
+            contains_mathematical_symbols_informative: Nazwa dzielnicy nie może zawierać
+              symboli matematycznych
+            contains_restricted_characters_instructional: Nazwa dzielnicy może zawierać
+              tylko litery, cyfry, znaki lokalne i znaki specjalne
+            contains_restricted_characters_informative: Nazwa dzielnicy nie może zawierać
+              niedozwolonych znaków
+            contains_too_many_words_instructional: Liczba słów w nazwie dzielnicy
+              musi być mniejsza niż %{word_count}
+            contains_too_many_words_informative: Liczba słów w nazwie dzielnicy musi
+              być mniejsza niż %{word_count}
+            contains_html_tags_instructional: Nazwa dzielnicy nie może zawierać tagów
+              HTML
+            contains_html_tags_informative: Nazwa dzielnicy nie może zawierać tagów
+              HTML
+            contains_url_instructional: Nazwa dzielnicy nie może zawierać adresów
+              URL
+            contains_url_informative: Nazwa dzielnicy nie może zawierać adresów URL
+            unknown_for_city_instructional: 'Wprowadź prawidłową nazwę dzielnicy dla:
+              %{city}'
+            unknown_for_city_informative: 'Wprowadź prawidłową nazwę dzielnicy dla:
+              %{city}'
+            unknown_for_zip_instructional: 'Wprowadź prawidłową nazwę dzielnicy dla:
+              %{zip}'
+            unknown_for_zip_informative: 'Wprowadź prawidłową nazwę dzielnicy dla:
+              %{zip}'
+            unknown_for_address_instructional: Nazwa dzielnicy może być nieprawidłowa
+            unknown_for_address_informative: Nazwa dzielnicy może być nieprawidłowa
+          warnings:
+            contains_too_many_words: Zaleca się, aby liczba słów w nazwie dzielnicy
+              była mniejsza niż %{word_count}

--- a/data/regions/BR/pt-BR.yml
+++ b/data/regions/BR/pt-BR.yml
@@ -17,3 +17,40 @@ pt-BR:
           errors:
             blank_instructional: Selecione um estado
             blank_informative: Falta o estado
+        district:
+          label:
+            default: Bairro
+            optional: Bairro (opcional)
+          errors:
+            blank_instructional: Insira um bairro
+            blank_informative: Falta o bairro
+            too_long_instructional: O bairro é muito longo (o máximo é de %{limit}
+              caracteres)
+            too_long_informative: O bairro é muito longo
+            contains_emojis_instructional: O bairro não pode conter emojis
+            contains_emojis_informative: O bairro não pode conter emojis
+            contains_mathematical_symbols_instructional: O bairro não pode conter
+              símbolos matemáticos
+            contains_mathematical_symbols_informative: O bairro não pode conter símbolos
+              matemáticos
+            contains_restricted_characters_instructional: O bairro só pode conter
+              letras, números, caracteres locais e caracteres especiais
+            contains_restricted_characters_informative: O bairro não pode conter caracteres
+              restritos
+            contains_too_many_words_instructional: O bairro deve ter menos de %{word_count}
+              palavras
+            contains_too_many_words_informative: O bairro deve ter menos de %{word_count}
+              palavras
+            contains_html_tags_instructional: O bairro não pode conter tags HTML
+            contains_html_tags_informative: O bairro não pode conter tags HTML
+            contains_url_instructional: O bairro não pode conter URLs
+            contains_url_informative: O bairro não pode conter URLs
+            unknown_for_city_instructional: Insira um nome de bairro válido para %{city}
+            unknown_for_city_informative: Insira um nome de bairro válido para %{city}
+            unknown_for_zip_instructional: Insira um nome de bairro válido para %{zip}
+            unknown_for_zip_informative: Insira um nome de bairro válido para %{zip}
+            unknown_for_address_instructional: O bairro pode estar incorreto
+            unknown_for_address_informative: O bairro pode estar incorreto
+          warnings:
+            contains_too_many_words: Recomenda-se que o bairro tenha menos de %{word_count}
+              palavras

--- a/data/regions/BR/pt-PT.yml
+++ b/data/regions/BR/pt-PT.yml
@@ -17,3 +17,43 @@ pt-PT:
           errors:
             blank_instructional: Selecione um estado
             blank_informative: O estado está em falta
+        district:
+          label:
+            default: Bairro
+            optional: Bairro (opcional)
+          errors:
+            blank_instructional: Introduza um bairro
+            blank_informative: O bairro está em falta
+            too_long_instructional: O bairro é demasiado longo (o máximo é %{limit}
+              carateres)
+            too_long_informative: O bairro é demasiado longo
+            contains_emojis_instructional: O bairro não pode conter emojis
+            contains_emojis_informative: O bairro não pode conter emojis
+            contains_mathematical_symbols_instructional: O bairro não pode conter
+              símbolos matemáticos
+            contains_mathematical_symbols_informative: O bairro não pode conter símbolos
+              matemáticos
+            contains_restricted_characters_instructional: O bairro só pode conter
+              letras, números, carateres locais e carateres especiais
+            contains_restricted_characters_informative: O bairro não pode conter carateres
+              restritos
+            contains_too_many_words_instructional: O bairro tem de ter menos de %{word_count}
+              palavras
+            contains_too_many_words_informative: O bairro tem de ter menos de %{word_count}
+              palavras
+            contains_html_tags_instructional: O bairro não pode conter etiquetas HTML
+            contains_html_tags_informative: O bairro não pode conter etiquetas HTML
+            contains_url_instructional: O bairro não pode conter URL
+            contains_url_informative: O bairro não pode conter URL
+            unknown_for_city_instructional: Introduza um nome de bairro válido para
+              %{city}
+            unknown_for_city_informative: Introduza um nome de bairro válido para
+              %{city}
+            unknown_for_zip_instructional: Introduza um nome de bairro válido para
+              %{zip}
+            unknown_for_zip_informative: Introduza um nome de bairro válido para %{zip}
+            unknown_for_address_instructional: O bairro pode estar incorreto
+            unknown_for_address_informative: O bairro pode estar incorreto
+          warnings:
+            contains_too_many_words: Recomenda-se que o bairro tenha menos de %{word_count}
+              palavras

--- a/data/regions/BR/ro.yml
+++ b/data/regions/BR/ro.yml
@@ -17,3 +17,46 @@ ro:
           errors:
             blank_instructional: Selectează un stat
             blank_informative: Statul lipsește
+        district:
+          label:
+            default: Cartier
+            optional: Cartier (opțional)
+          errors:
+            blank_instructional: Introdu un cartier
+            blank_informative: Lipsește cartierul
+            too_long_instructional: Cartierul este prea lung (maximum este de %{limit}
+              caractere)
+            too_long_informative: Cartierul este prea lung
+            contains_emojis_instructional: Cartierul nu poate conține emoji-uri
+            contains_emojis_informative: Cartierul nu poate conține emoji-uri
+            contains_mathematical_symbols_instructional: Cartierul nu poate conține
+              simboluri matematice
+            contains_mathematical_symbols_informative: Cartierul nu poate conține
+              simboluri matematice
+            contains_restricted_characters_instructional: Cartierul poate conține
+              doar litere, cifre, caractere locale și caractere speciale
+            contains_restricted_characters_informative: Cartierul nu poate conține
+              caractere restricționate
+            contains_too_many_words_instructional: Cartierul trebuie să aibă mai puțin
+              de %{word_count} cuvinte
+            contains_too_many_words_informative: Cartierul trebuie să aibă mai puțin
+              de %{word_count} cuvinte
+            contains_html_tags_instructional: Cartierul nu poate conține etichete
+              HTML
+            contains_html_tags_informative: Cartierul nu poate conține etichete HTML
+            contains_url_instructional: Cartierul nu poate conține URL-uri
+            contains_url_informative: Cartierul nu poate conține URL-uri
+            unknown_for_city_instructional: Introdu un nume de cartier valid pentru
+              %{city}
+            unknown_for_city_informative: Introdu un nume de cartier valid pentru
+              %{city}
+            unknown_for_zip_instructional: Introdu un nume de cartier valid pentru
+              %{zip}
+            unknown_for_zip_informative: Introdu un nume de cartier valid pentru %{zip}
+            unknown_for_address_instructional: Este posibil ca acest cartier să fie
+              incorect
+            unknown_for_address_informative: Este posibil ca acest cartier să fie
+              incorect
+          warnings:
+            contains_too_many_words: Se recomandă ca acest cartier să aibă mai puțin
+              de %{word_count} cuvinte

--- a/data/regions/BR/ru.yml
+++ b/data/regions/BR/ru.yml
@@ -17,3 +17,44 @@ ru:
           errors:
             blank_instructional: Выберите штат
             blank_informative: Штат отсутствует
+        district:
+          label:
+            default: Район
+            optional: Район (необязательно)
+          errors:
+            blank_instructional: Введите район
+            blank_informative: Не указан район
+            too_long_instructional: Название района слишком длинное (максимум %{limit}
+              символов)
+            too_long_informative: Название района слишком длинное
+            contains_emojis_instructional: Название района не может содержать эмодзи
+            contains_emojis_informative: Название района не может содержать эмодзи
+            contains_mathematical_symbols_instructional: Название района не может
+              содержать математические символы
+            contains_mathematical_symbols_informative: Название района не может содержать
+              математические символы
+            contains_restricted_characters_instructional: Название района может содержать
+              только буквы, цифры, местные и специальные символы
+            contains_restricted_characters_informative: Название района не может содержать
+              запрещенные символы
+            contains_too_many_words_instructional: Название района должно содержать
+              менее %{word_count} слов
+            contains_too_many_words_informative: Название района должно содержать
+              менее %{word_count} слов
+            contains_html_tags_instructional: Название района не может содержать HTML-теги
+            contains_html_tags_informative: Название района не может содержать HTML-теги
+            contains_url_instructional: Название района не может содержать URL
+            contains_url_informative: Название района не может содержать URL
+            unknown_for_city_instructional: Введите правильное название района для
+              города %{city}
+            unknown_for_city_informative: Введите правильное название района для города
+              %{city}
+            unknown_for_zip_instructional: Введите правильное название района для
+              индекса %{zip}
+            unknown_for_zip_informative: Введите правильное название района для индекса
+              %{zip}
+            unknown_for_address_instructional: Возможно, район указан неверно
+            unknown_for_address_informative: Возможно, район указан неверно
+          warnings:
+            contains_too_many_words: Рекомендуется, чтобы название района содержало
+              менее %{word_count} слов

--- a/data/regions/BR/sk.yml
+++ b/data/regions/BR/sk.yml
@@ -17,3 +17,39 @@ sk:
           errors:
             blank_instructional: Vyberte štát
             blank_informative: Chýba štát
+        district:
+          label:
+            default: Štvrť
+            optional: Štvrť (voliteľné)
+          errors:
+            blank_instructional: Zadajte štvrť
+            blank_informative: Chýba štvrť
+            too_long_instructional: Štvrť je príliš dlhá (maximum je %{limit} znakov)
+            too_long_informative: Štvrť je príliš dlhá
+            contains_emojis_instructional: Štvrť nemôže obsahovať emoji
+            contains_emojis_informative: Štvrť nemôže obsahovať emoji
+            contains_mathematical_symbols_instructional: Štvrť nemôže obsahovať matematické
+              symboly
+            contains_mathematical_symbols_informative: Štvrť nemôže obsahovať matematické
+              symboly
+            contains_restricted_characters_instructional: Štvrť môže obsahovať len
+              písmená, číslice, lokálne a špeciálne znaky
+            contains_restricted_characters_informative: Štvrť nemôže obsahovať nepovolené
+              znaky
+            contains_too_many_words_instructional: Štvrť musí mať menej ako %{word_count}
+              slov
+            contains_too_many_words_informative: Štvrť musí mať menej ako %{word_count}
+              slov
+            contains_html_tags_instructional: Štvrť nemôže obsahovať značky HTML
+            contains_html_tags_informative: Štvrť nemôže obsahovať značky HTML
+            contains_url_instructional: Štvrť nemôže obsahovať adresy URL
+            contains_url_informative: Štvrť nemôže obsahovať adresy URL
+            unknown_for_city_instructional: Zadajte platný názov štvrte pre %{city}
+            unknown_for_city_informative: Zadajte platný názov štvrte pre %{city}
+            unknown_for_zip_instructional: Zadajte platný názov štvrte pre %{zip}
+            unknown_for_zip_informative: Zadajte platný názov štvrte pre %{zip}
+            unknown_for_address_instructional: Štvrť môže byť nesprávna
+            unknown_for_address_informative: Štvrť môže byť nesprávna
+          warnings:
+            contains_too_many_words: Odporúča sa, aby štvrť mala menej ako %{word_count}
+              slov

--- a/data/regions/BR/sl.yml
+++ b/data/regions/BR/sl.yml
@@ -17,3 +17,43 @@ sl:
           errors:
             blank_instructional: Izberite državo
             blank_informative: Manjka država
+        district:
+          label:
+            default: Soseska
+            optional: Soseska (izbirno)
+          errors:
+            blank_instructional: Vnesite sosesko
+            blank_informative: Manjka soseska
+            too_long_instructional: Soseska je predolga (dovoljenih je največ %{limit}
+              znakov)
+            too_long_informative: Soseska je predolga
+            contains_emojis_instructional: Soseska ne sme vsebovati emodžijev
+            contains_emojis_informative: Soseska ne sme vsebovati emodžijev
+            contains_mathematical_symbols_instructional: Soseska ne sme vsebovati
+              matematičnih simbolov
+            contains_mathematical_symbols_informative: Soseska ne sme vsebovati matematičnih
+              simbolov
+            contains_restricted_characters_instructional: Soseska lahko vsebuje le
+              črke, številke, lokalne znake in posebne znake
+            contains_restricted_characters_informative: Soseska ne sme vsebovati nedovoljenih
+              znakov
+            contains_too_many_words_instructional: Soseska mora vsebovati manj kot
+              %{word_count} besed
+            contains_too_many_words_informative: Soseska mora vsebovati manj kot %{word_count}
+              besed
+            contains_html_tags_instructional: Soseska ne sme vsebovati oznak HTML
+            contains_html_tags_informative: Soseska ne sme vsebovati oznak HTML
+            contains_url_instructional: Soseska ne sme vsebovati URL-naslovov
+            contains_url_informative: Soseska ne sme vsebovati URL-naslovov
+            unknown_for_city_instructional: Vnesite veljavno ime soseske za mesto
+              %{city}
+            unknown_for_city_informative: Vnesite veljavno ime soseske za mesto %{city}
+            unknown_for_zip_instructional: Vnesite veljavno ime soseske za poštno
+              številko %{zip}
+            unknown_for_zip_informative: Vnesite veljavno ime soseske za poštno številko
+              %{zip}
+            unknown_for_address_instructional: Soseska je morda napačna
+            unknown_for_address_informative: Soseska je morda napačna
+          warnings:
+            contains_too_many_words: Priporočamo, da soseska vsebuje manj kot %{word_count}
+              besed

--- a/data/regions/BR/sv.yml
+++ b/data/regions/BR/sv.yml
@@ -17,3 +17,39 @@ sv:
           errors:
             blank_instructional: Välj en stat
             blank_informative: Stat saknas
+        district:
+          label:
+            default: Stadsdel
+            optional: Stadsdel (valfritt)
+          errors:
+            blank_instructional: Ange en stadsdel
+            blank_informative: Stadsdel saknas
+            too_long_instructional: Stadsdelen är för lång (max %{limit} tecken)
+            too_long_informative: Stadsdelen är för lång
+            contains_emojis_instructional: Stadsdelen kan inte innehålla emojis
+            contains_emojis_informative: Stadsdelen kan inte innehålla emojis
+            contains_mathematical_symbols_instructional: Stadsdelen kan inte innehålla
+              matematiska symboler
+            contains_mathematical_symbols_informative: Stadsdelen kan inte innehålla
+              matematiska symboler
+            contains_restricted_characters_instructional: Stadsdelen kan endast innehålla
+              bokstäver, siffror, lokala tecken och specialtecken
+            contains_restricted_characters_informative: Stadsdelen kan inte innehålla
+              otillåtna tecken
+            contains_too_many_words_instructional: Stadsdelen måste ha färre än %{word_count}
+              ord
+            contains_too_many_words_informative: Stadsdelen måste ha färre än %{word_count}
+              ord
+            contains_html_tags_instructional: Stadsdelen kan inte innehålla HTML-taggar
+            contains_html_tags_informative: Stadsdelen kan inte innehålla HTML-taggar
+            contains_url_instructional: Stadsdelen kan inte innehålla URL:er
+            contains_url_informative: Stadsdelen kan inte innehålla URL:er
+            unknown_for_city_instructional: Ange en giltig stadsdel för %{city}
+            unknown_for_city_informative: Ange en giltig stadsdel för %{city}
+            unknown_for_zip_instructional: Ange en giltig stadsdel för %{zip}
+            unknown_for_zip_informative: Ange en giltig stadsdel för %{zip}
+            unknown_for_address_instructional: Stadsdelen kan vara felaktig
+            unknown_for_address_informative: Stadsdelen kan vara felaktig
+          warnings:
+            contains_too_many_words: Stadsdelen rekommenderas ha färre än %{word_count}
+              ord

--- a/data/regions/BR/th.yml
+++ b/data/regions/BR/th.yml
@@ -17,3 +17,35 @@ th:
           errors:
             blank_instructional: เลือกรัฐ
             blank_informative: ไม่พบรัฐ
+        district:
+          label:
+            default: ย่าน
+            optional: ย่าน (ไม่บังคับ)
+          errors:
+            blank_instructional: โปรดป้อนย่าน
+            blank_informative: ไม่ได้ระบุย่าน
+            too_long_instructional: ย่านยาวเกินไป (สูงสุด %{limit} ตัวอักษร)
+            too_long_informative: ย่านยาวเกินไป
+            contains_emojis_instructional: ย่านต้องไม่มีอีโมจิ
+            contains_emojis_informative: ย่านต้องไม่มีอีโมจิ
+            contains_mathematical_symbols_instructional: ย่านต้องไม่มีสัญลักษณ์ทางคณิตศาสตร์
+            contains_mathematical_symbols_informative: ย่านต้องไม่มีสัญลักษณ์ทางคณิตศาสตร์
+            contains_restricted_characters_instructional: ย่านต้องมีเฉพาะตัวอักษร
+              ตัวเลข ตัวอักษรท้องถิ่น และอักขระพิเศษเท่านั้น
+            contains_restricted_characters_informative: ย่านต้องไม่มีอักขระที่ถูกจำกัด
+            contains_too_many_words_instructional: ย่านต้องมีน้อยกว่า %{word_count}
+              คำ
+            contains_too_many_words_informative: ย่านต้องมีน้อยกว่า %{word_count}
+              คำ
+            contains_html_tags_instructional: ย่านต้องไม่มีแท็ก HTML
+            contains_html_tags_informative: ย่านต้องไม่มีแท็ก HTML
+            contains_url_instructional: ย่านต้องไม่มี URL
+            contains_url_informative: ย่านต้องไม่มี URL
+            unknown_for_city_instructional: โปรดป้อนชื่อย่านที่ถูกต้องสำหรับ %{city}
+            unknown_for_city_informative: โปรดป้อนชื่อย่านที่ถูกต้องสำหรับ %{city}
+            unknown_for_zip_instructional: โปรดป้อนชื่อย่านที่ถูกต้องสำหรับ %{zip}
+            unknown_for_zip_informative: โปรดป้อนชื่อย่านที่ถูกต้องสำหรับ %{zip}
+            unknown_for_address_instructional: ย่านอาจไม่ถูกต้อง
+            unknown_for_address_informative: ย่านอาจไม่ถูกต้อง
+          warnings:
+            contains_too_many_words: ขอแนะนำให้ย่านมีน้อยกว่า %{word_count} คำ

--- a/data/regions/BR/tr.yml
+++ b/data/regions/BR/tr.yml
@@ -17,3 +17,40 @@ tr:
           errors:
             blank_instructional: Eyalet seçin
             blank_informative: Eyalet eksik
+        district:
+          label:
+            default: Mahalle
+            optional: Mahalle (isteğe bağlı)
+          errors:
+            blank_instructional: Bir mahalle girin
+            blank_informative: Mahalle eksik
+            too_long_instructional: Mahalle çok uzun (maksimum %{limit} karakter)
+            too_long_informative: Mahalle çok uzun
+            contains_emojis_instructional: Mahalle emoji içeremez
+            contains_emojis_informative: Mahalle emoji içeremez
+            contains_mathematical_symbols_instructional: Mahalle matematiksel semboller
+              içeremez
+            contains_mathematical_symbols_informative: Mahalle matematiksel semboller
+              içeremez
+            contains_restricted_characters_instructional: Mahalle yalnızca harf, sayı,
+              yerel karakter ve özel karakter içerebilir
+            contains_restricted_characters_informative: Mahalle kısıtlanmış karakterler
+              içeremez
+            contains_too_many_words_instructional: Mahalle %{word_count} kelimeden
+              az olmalıdır
+            contains_too_many_words_informative: Mahalle %{word_count} kelimeden az
+              olmalıdır
+            contains_html_tags_instructional: Mahalle HTML etiketleri içeremez
+            contains_html_tags_informative: Mahalle HTML etiketleri içeremez
+            contains_url_instructional: Mahalle URL içeremez
+            contains_url_informative: Mahalle URL içeremez
+            unknown_for_city_instructional: "%{city} için geçerli bir mahalle adı
+              girin"
+            unknown_for_city_informative: "%{city} için geçerli bir mahalle adı girin"
+            unknown_for_zip_instructional: "%{zip} için geçerli bir mahalle adı girin"
+            unknown_for_zip_informative: "%{zip} için geçerli bir mahalle adı girin"
+            unknown_for_address_instructional: Mahalle yanlış olabilir
+            unknown_for_address_informative: Mahalle yanlış olabilir
+          warnings:
+            contains_too_many_words: Mahallenin %{word_count} kelimeden az olması
+              önerilir

--- a/data/regions/BR/vi.yml
+++ b/data/regions/BR/vi.yml
@@ -17,3 +17,39 @@ vi:
           errors:
             blank_instructional: Chọn tiểu bang
             blank_informative: Thiếu tiểu bang
+        district:
+          label:
+            default: Khu phố
+            optional: Khu phố (tùy chọn)
+          errors:
+            blank_instructional: Nhập khu phố
+            blank_informative: Thiếu khu phố
+            too_long_instructional: Khu phố quá dài (tối đa %{limit} ký tự)
+            too_long_informative: Khu phố quá dài
+            contains_emojis_instructional: Khu phố không được chứa biểu tượng cảm
+              xúc
+            contains_emojis_informative: Khu phố không được chứa biểu tượng cảm xúc
+            contains_mathematical_symbols_instructional: Khu phố không được chứa ký
+              hiệu toán học
+            contains_mathematical_symbols_informative: Khu phố không được chứa ký
+              hiệu toán học
+            contains_restricted_characters_instructional: Khu phố chỉ có thể chứa
+              chữ cái, số, ký tự địa phương và ký tự đặc biệt
+            contains_restricted_characters_informative: Khu phố không được chứa ký
+              tự bị hạn chế
+            contains_too_many_words_instructional: Khu phố phải có ít hơn %{word_count}
+              từ
+            contains_too_many_words_informative: Khu phố phải có ít hơn %{word_count}
+              từ
+            contains_html_tags_instructional: Khu phố không được chứa thẻ HTML
+            contains_html_tags_informative: Khu phố không được chứa thẻ HTML
+            contains_url_instructional: Khu phố không được chứa URL
+            contains_url_informative: Khu phố không được chứa URL
+            unknown_for_city_instructional: Nhập tên khu phố hợp lệ cho %{city}
+            unknown_for_city_informative: Nhập tên khu phố hợp lệ cho %{city}
+            unknown_for_zip_instructional: Nhập tên khu phố hợp lệ cho %{zip}
+            unknown_for_zip_informative: Nhập tên khu phố hợp lệ cho %{zip}
+            unknown_for_address_instructional: Khu phố có thể không chính xác
+            unknown_for_address_informative: Khu phố có thể không chính xác
+          warnings:
+            contains_too_many_words: Khu phố nên có ít hơn %{word_count} từ

--- a/data/regions/BR/zh-CN.yml
+++ b/data/regions/BR/zh-CN.yml
@@ -17,3 +17,32 @@ zh-CN:
           errors:
             blank_instructional: 选择州
             blank_informative: 缺少州
+        district:
+          label:
+            default: 街区
+            optional: 街区（可选）
+          errors:
+            blank_instructional: 输入街区
+            blank_informative: 缺少街区
+            too_long_instructional: 街区太长（最多 %{limit} 个字符）
+            too_long_informative: 街区太长
+            contains_emojis_instructional: 街区不能包含表情符号
+            contains_emojis_informative: 街区不能包含表情符号
+            contains_mathematical_symbols_instructional: 街区不能包含数学符号
+            contains_mathematical_symbols_informative: 街区不能包含数学符号
+            contains_restricted_characters_instructional: 街区只能包含字母、数字、本地字符和特殊字符
+            contains_restricted_characters_informative: 街区不能包含受限字符
+            contains_too_many_words_instructional: 街区必须少于 %{word_count} 个词
+            contains_too_many_words_informative: 街区必须少于 %{word_count} 个词
+            contains_html_tags_instructional: 街区不能包含 HTML 标签
+            contains_html_tags_informative: 街区不能包含 HTML 标签
+            contains_url_instructional: 街区不能包含 URL
+            contains_url_informative: 街区不能包含 URL
+            unknown_for_city_instructional: 为 %{city} 输入有效的街区名称
+            unknown_for_city_informative: 为 %{city} 输入有效的街区名称
+            unknown_for_zip_instructional: 为 %{zip} 输入有效的街区名称
+            unknown_for_zip_informative: 为 %{zip} 输入有效的街区名称
+            unknown_for_address_instructional: 街区可能不正确
+            unknown_for_address_informative: 街区可能不正确
+          warnings:
+            contains_too_many_words: 建议街区少于 %{word_count} 个词

--- a/data/regions/BR/zh-TW.yml
+++ b/data/regions/BR/zh-TW.yml
@@ -17,3 +17,32 @@ zh-TW:
           errors:
             blank_instructional: 請選取州別
             blank_informative: 缺少州別
+        district:
+          label:
+            default: 鄰里
+            optional: 鄰里 (選填)
+          errors:
+            blank_instructional: 輸入鄰里
+            blank_informative: 遺漏鄰里
+            too_long_instructional: 鄰里名稱過長 (最多 %{limit} 個字元)
+            too_long_informative: 鄰里名稱過長
+            contains_emojis_instructional: 鄰里不能包含表情符號
+            contains_emojis_informative: 鄰里不能包含表情符號
+            contains_mathematical_symbols_instructional: 鄰里不能包含數學符號
+            contains_mathematical_symbols_informative: 鄰里不能包含數學符號
+            contains_restricted_characters_instructional: 鄰里僅能包含字母、數字、當地字元和特殊字元
+            contains_restricted_characters_informative: 鄰里不能包含受限字元
+            contains_too_many_words_instructional: 鄰里名稱必須少於 %{word_count} 個字
+            contains_too_many_words_informative: 鄰里名稱必須少於 %{word_count} 個字
+            contains_html_tags_instructional: 鄰里不能包含 HTML 標籤
+            contains_html_tags_informative: 鄰里不能包含 HTML 標籤
+            contains_url_instructional: 鄰里不能包含網址
+            contains_url_informative: 鄰里不能包含網址
+            unknown_for_city_instructional: 輸入 %{city} 的有效鄰里名稱
+            unknown_for_city_informative: 輸入 %{city} 的有效鄰里名稱
+            unknown_for_zip_instructional: 輸入 %{zip} 的有效鄰里名稱
+            unknown_for_zip_informative: 輸入 %{zip} 的有效鄰里名稱
+            unknown_for_address_instructional: 鄰里可能不正確
+            unknown_for_address_informative: 鄰里可能不正確
+          warnings:
+            contains_too_many_words: 鄰里名稱建議少於 %{word_count} 個字

--- a/data/regions/KW/bg.yml
+++ b/data/regions/KW/bg.yml
@@ -47,3 +47,39 @@ bg:
           warnings:
             contains_too_many_words: Препоръчително е „Блок“ да не съдържа повече
               от %{word_count} думи
+        district:
+          label:
+            default: Блок
+            optional: Блок (по избор)
+          errors:
+            blank_instructional: Въведете блок
+            blank_informative: Липсва блок
+            too_long_instructional: Блокът е твърде дълъг (максимум %{limit} знака)
+            too_long_informative: Блокът е твърде дълъг
+            contains_emojis_instructional: Блокът не може да съдържа емоджита
+            contains_emojis_informative: Блокът не може да съдържа емоджита
+            contains_mathematical_symbols_instructional: Блокът не може да съдържа
+              математически символи
+            contains_mathematical_symbols_informative: Блокът не може да съдържа математически
+              символи
+            contains_restricted_characters_instructional: Блокът може да съдържа само
+              букви, цифри, локални и специални символи
+            contains_restricted_characters_informative: Блокът не може да съдържа
+              забранени символи
+            contains_too_many_words_instructional: Блокът трябва да съдържа по-малко
+              от %{word_count} думи
+            contains_too_many_words_informative: Блокът трябва да съдържа по-малко
+              от %{word_count} думи
+            contains_html_tags_instructional: Блокът не може да съдържа HTML
+            contains_html_tags_informative: Блокът не може да съдържа HTML
+            contains_url_instructional: Блокът не може да съдържа URL
+            contains_url_informative: Блокът не може да съдържа URL
+            unknown_for_city_instructional: Въведете валиден блок за %{city}
+            unknown_for_city_informative: Блокът не е валиден за %{city}
+            unknown_for_zip_instructional: Въведете валиден блок за %{zip}
+            unknown_for_zip_informative: Блокът не е валиден за %{zip}
+            unknown_for_address_instructional: Блокът може да е грешен
+            unknown_for_address_informative: Блокът може да е грешен
+          warnings:
+            contains_too_many_words: Препоръчително е блокът да съдържа по-малко от
+              %{word_count} думи

--- a/data/regions/KW/bg.yml
+++ b/data/regions/KW/bg.yml
@@ -54,7 +54,7 @@ bg:
           errors:
             blank_instructional: Въведете блок
             blank_informative: Липсва блок
-            too_long_instructional: Блокът е твърде дълъг (максимум %{limit} знака)
+            too_long_instructional: Блокът е твърде дълъг (максимумът е %{limit} знака)
             too_long_informative: Блокът е твърде дълъг
             contains_emojis_instructional: Блокът не може да съдържа емоджита
             contains_emojis_informative: Блокът не може да съдържа емоджита
@@ -63,17 +63,17 @@ bg:
             contains_mathematical_symbols_informative: Блокът не може да съдържа математически
               символи
             contains_restricted_characters_instructional: Блокът може да съдържа само
-              букви, цифри, локални и специални символи
+              букви, цифри, локални и специални знаци
             contains_restricted_characters_informative: Блокът не може да съдържа
-              забранени символи
+              неразрешени знаци
             contains_too_many_words_instructional: Блокът трябва да съдържа по-малко
               от %{word_count} думи
             contains_too_many_words_informative: Блокът трябва да съдържа по-малко
               от %{word_count} думи
             contains_html_tags_instructional: Блокът не може да съдържа HTML
             contains_html_tags_informative: Блокът не може да съдържа HTML
-            contains_url_instructional: Блокът не може да съдържа URL
-            contains_url_informative: Блокът не може да съдържа URL
+            contains_url_instructional: Блокът не може да съдържа URL адрес
+            contains_url_informative: Блокът не може да съдържа URL адрес
             unknown_for_city_instructional: Въведете валиден блок за %{city}
             unknown_for_city_informative: Блокът не е валиден за %{city}
             unknown_for_zip_instructional: Въведете валиден блок за %{zip}

--- a/data/regions/KW/cs.yml
+++ b/data/regions/KW/cs.yml
@@ -47,3 +47,39 @@ cs:
           warnings:
             contains_too_many_words: 'Doporučuje se, aby název bloku obsahoval méně
               než tento počet slov: %{word_count}.'
+        district:
+          label:
+            default: Blok
+            optional: Blok (nepovinné)
+          errors:
+            blank_instructional: Zadejte blok
+            blank_informative: Chybí blok
+            too_long_instructional: Blok je příliš dlouhý (maximálně %{limit} znaků)
+            too_long_informative: Blok je příliš dlouhý
+            contains_emojis_instructional: Blok nemůže obsahovat emotikony
+            contains_emojis_informative: Blok nemůže obsahovat emotikony
+            contains_mathematical_symbols_instructional: Blok nemůže obsahovat matematické
+              symboly
+            contains_mathematical_symbols_informative: Blok nemůže obsahovat matematické
+              symboly
+            contains_restricted_characters_instructional: Blok může obsahovat pouze
+              písmena, číslice, místní a speciální znaky
+            contains_restricted_characters_informative: Blok nesmí obsahovat nepovolené
+              znaky
+            contains_too_many_words_instructional: Blok musí mít méně než %{word_count}
+              slov
+            contains_too_many_words_informative: Blok musí mít méně než %{word_count}
+              slov
+            contains_html_tags_instructional: Blok nemůže obsahovat HTML
+            contains_html_tags_informative: Blok nemůže obsahovat HTML
+            contains_url_instructional: Blok nemůže obsahovat URL
+            contains_url_informative: Blok nemůže obsahovat URL
+            unknown_for_city_instructional: Zadejte platný blok pro %{city}
+            unknown_for_city_informative: Blok pro %{city} není platný
+            unknown_for_zip_instructional: Zadejte platný blok pro %{zip}
+            unknown_for_zip_informative: Blok pro %{zip} není platný
+            unknown_for_address_instructional: Blok může být nesprávný
+            unknown_for_address_informative: Blok může být nesprávný
+          warnings:
+            contains_too_many_words: Doporučujeme, aby blok obsahoval méně než %{word_count}
+              slov

--- a/data/regions/KW/cs.yml
+++ b/data/regions/KW/cs.yml
@@ -50,36 +50,36 @@ cs:
         district:
           label:
             default: Blok
-            optional: Blok (nepovinné)
+            optional: Blok (volitelné)
           errors:
             blank_instructional: Zadejte blok
             blank_informative: Chybí blok
-            too_long_instructional: Blok je příliš dlouhý (maximálně %{limit} znaků)
+            too_long_instructional: Blok je příliš dlouhý (maximum je %{limit} znaků)
             too_long_informative: Blok je příliš dlouhý
-            contains_emojis_instructional: Blok nemůže obsahovat emotikony
-            contains_emojis_informative: Blok nemůže obsahovat emotikony
-            contains_mathematical_symbols_instructional: Blok nemůže obsahovat matematické
+            contains_emojis_instructional: Blok nesmí obsahovat emodži
+            contains_emojis_informative: Blok nesmí obsahovat emodži
+            contains_mathematical_symbols_instructional: Blok nesmí obsahovat matematické
               symboly
-            contains_mathematical_symbols_informative: Blok nemůže obsahovat matematické
+            contains_mathematical_symbols_informative: Blok nesmí obsahovat matematické
               symboly
-            contains_restricted_characters_instructional: Blok může obsahovat pouze
-              písmena, číslice, místní a speciální znaky
+            contains_restricted_characters_instructional: Blok smí obsahovat pouze
+              písmena, číslice, místní znaky a speciální znaky
             contains_restricted_characters_informative: Blok nesmí obsahovat nepovolené
               znaky
             contains_too_many_words_instructional: Blok musí mít méně než %{word_count}
               slov
             contains_too_many_words_informative: Blok musí mít méně než %{word_count}
               slov
-            contains_html_tags_instructional: Blok nemůže obsahovat HTML
-            contains_html_tags_informative: Blok nemůže obsahovat HTML
-            contains_url_instructional: Blok nemůže obsahovat URL
-            contains_url_informative: Blok nemůže obsahovat URL
+            contains_html_tags_instructional: Blok nesmí obsahovat HTML
+            contains_html_tags_informative: Blok nesmí obsahovat HTML
+            contains_url_instructional: Blok nesmí obsahovat adresu URL
+            contains_url_informative: Blok nesmí obsahovat adresu URL
             unknown_for_city_instructional: Zadejte platný blok pro %{city}
-            unknown_for_city_informative: Blok pro %{city} není platný
+            unknown_for_city_informative: Blok není pro %{city} platný
             unknown_for_zip_instructional: Zadejte platný blok pro %{zip}
-            unknown_for_zip_informative: Blok pro %{zip} není platný
-            unknown_for_address_instructional: Blok může být nesprávný
-            unknown_for_address_informative: Blok může být nesprávný
+            unknown_for_zip_informative: Blok není pro %{zip} platný
+            unknown_for_address_instructional: Blok je možná nesprávný
+            unknown_for_address_informative: Blok je možná nesprávný
           warnings:
             contains_too_many_words: Doporučujeme, aby blok obsahoval méně než %{word_count}
               slov

--- a/data/regions/KW/da.yml
+++ b/data/regions/KW/da.yml
@@ -43,3 +43,38 @@ da:
             unknown_for_address_informative: Blok kan være forkert
           warnings:
             contains_too_many_words: Det anbefales, at blok indeholder færre end %{word_count} ord
+        district:
+          label:
+            default: Blok
+            optional: Blok (valgfrit)
+          errors:
+            blank_instructional: Angiv en blok
+            blank_informative: Blok mangler
+            too_long_instructional: Blok er for lang (maks. %{limit} tegn)
+            too_long_informative: Blok er for lang
+            contains_emojis_instructional: Blok kan ikke indeholde emojis
+            contains_emojis_informative: Blok kan ikke indeholde emojis
+            contains_mathematical_symbols_instructional: Blok kan ikke indeholde matematiske
+              symboler
+            contains_mathematical_symbols_informative: Blok kan ikke indeholde matematiske
+              symboler
+            contains_restricted_characters_instructional: Blok kan kun indeholde bogstaver,
+              tal, lokale tegn og specialtegn
+            contains_restricted_characters_informative: Blok kan ikke indeholde ikke-tilladte
+              tegn
+            contains_too_many_words_instructional: Blok skal have færre end %{word_count}
+              ord
+            contains_too_many_words_informative: Blok skal have færre end %{word_count}
+              ord
+            contains_html_tags_instructional: Blok kan ikke indeholde HTML
+            contains_html_tags_informative: Blok kan ikke indeholde HTML
+            contains_url_instructional: Blok kan ikke indeholde en webadresse
+            contains_url_informative: Blok kan ikke indeholde en webadresse
+            unknown_for_city_instructional: Angiv en gyldig blok for %{city}
+            unknown_for_city_informative: Blok er ikke gyldig for %{city}
+            unknown_for_zip_instructional: Angiv en gyldig blok for %{zip}
+            unknown_for_zip_informative: Blok er ikke gyldig for %{zip}
+            unknown_for_address_instructional: Blok kan være forkert
+            unknown_for_address_informative: Blok kan være forkert
+          warnings:
+            contains_too_many_words: Blok bør have færre end %{word_count} ord

--- a/data/regions/KW/da.yml
+++ b/data/regions/KW/da.yml
@@ -48,33 +48,34 @@ da:
             default: Blok
             optional: Blok (valgfrit)
           errors:
-            blank_instructional: Angiv en blok
+            blank_instructional: Indtast en blok
             blank_informative: Blok mangler
-            too_long_instructional: Blok er for lang (maks. %{limit} tegn)
-            too_long_informative: Blok er for lang
-            contains_emojis_instructional: Blok kan ikke indeholde emojis
-            contains_emojis_informative: Blok kan ikke indeholde emojis
-            contains_mathematical_symbols_instructional: Blok kan ikke indeholde matematiske
-              symboler
-            contains_mathematical_symbols_informative: Blok kan ikke indeholde matematiske
-              symboler
-            contains_restricted_characters_instructional: Blok kan kun indeholde bogstaver,
-              tal, lokale tegn og specialtegn
-            contains_restricted_characters_informative: Blok kan ikke indeholde ikke-tilladte
-              tegn
-            contains_too_many_words_instructional: Blok skal have færre end %{word_count}
+            too_long_instructional: Blokken er for lang (maks. %{limit} tegn)
+            too_long_informative: Blokken er for lang
+            contains_emojis_instructional: Blokken kan ikke indeholde emojis
+            contains_emojis_informative: Blokken kan ikke indeholde emojis
+            contains_mathematical_symbols_instructional: Blokken kan ikke indeholde
+              matematiske symboler
+            contains_mathematical_symbols_informative: Blokken kan ikke indeholde
+              matematiske symboler
+            contains_restricted_characters_instructional: Blokken kan kun indeholde
+              bogstaver, tal, lokale tegn og specialtegn
+            contains_restricted_characters_informative: Blokken kan ikke indeholde
+              ikke-tilladte tegn
+            contains_too_many_words_instructional: Blokken skal have færre end %{word_count}
               ord
-            contains_too_many_words_informative: Blok skal have færre end %{word_count}
+            contains_too_many_words_informative: Blokken skal have færre end %{word_count}
               ord
-            contains_html_tags_instructional: Blok kan ikke indeholde HTML
-            contains_html_tags_informative: Blok kan ikke indeholde HTML
-            contains_url_instructional: Blok kan ikke indeholde en webadresse
-            contains_url_informative: Blok kan ikke indeholde en webadresse
-            unknown_for_city_instructional: Angiv en gyldig blok for %{city}
-            unknown_for_city_informative: Blok er ikke gyldig for %{city}
-            unknown_for_zip_instructional: Angiv en gyldig blok for %{zip}
-            unknown_for_zip_informative: Blok er ikke gyldig for %{zip}
-            unknown_for_address_instructional: Blok kan være forkert
-            unknown_for_address_informative: Blok kan være forkert
+            contains_html_tags_instructional: Blokken kan ikke indeholde HTML
+            contains_html_tags_informative: Blokken kan ikke indeholde HTML
+            contains_url_instructional: Blokken kan ikke indeholde en webadresse
+            contains_url_informative: Blokken kan ikke indeholde en webadresse
+            unknown_for_city_instructional: Indtast en gyldig blok for %{city}
+            unknown_for_city_informative: Blokken er ikke gyldig for %{city}
+            unknown_for_zip_instructional: Indtast en gyldig blok for %{zip}
+            unknown_for_zip_informative: Blokken er ikke gyldig for %{zip}
+            unknown_for_address_instructional: Blokken er muligvis forkert
+            unknown_for_address_informative: Blokken er muligvis forkert
           warnings:
-            contains_too_many_words: Blok bør have færre end %{word_count} ord
+            contains_too_many_words: Det anbefales, at blokken har færre end %{word_count}
+              ord

--- a/data/regions/KW/de.yml
+++ b/data/regions/KW/de.yml
@@ -46,3 +46,39 @@ de:
           warnings:
             contains_too_many_words: Es wird empfohlen, dass der Block weniger als
               %{word_count} Wörter enthält
+        district:
+          label:
+            default: Block
+            optional: Block (optional)
+          errors:
+            blank_instructional: Gib einen Block ein
+            blank_informative: Block fehlt
+            too_long_instructional: Block ist zu lang (maximal %{limit} Zeichen)
+            too_long_informative: Block ist zu lang
+            contains_emojis_instructional: Block darf keine Emojis enthalten
+            contains_emojis_informative: Block darf keine Emojis enthalten
+            contains_mathematical_symbols_instructional: Block darf keine mathematischen
+              Symbole enthalten
+            contains_mathematical_symbols_informative: Block darf keine mathematischen
+              Symbole enthalten
+            contains_restricted_characters_instructional: Block darf nur Buchstaben,
+              Zahlen, lokale Zeichen und Sonderzeichen enthalten
+            contains_restricted_characters_informative: Block darf keine unzulässigen
+              Zeichen enthalten
+            contains_too_many_words_instructional: Block muss aus weniger als %{word_count}
+              Wörtern bestehen
+            contains_too_many_words_informative: Block muss aus weniger als %{word_count}
+              Wörtern bestehen
+            contains_html_tags_instructional: Block darf kein HTML enthalten
+            contains_html_tags_informative: Block darf kein HTML enthalten
+            contains_url_instructional: Block darf keine URL enthalten
+            contains_url_informative: Block darf keine URL enthalten
+            unknown_for_city_instructional: Gib einen gültigen Block für %{city} ein
+            unknown_for_city_informative: Block ist für %{city} ungültig
+            unknown_for_zip_instructional: Gib einen gültigen Block für %{zip} ein
+            unknown_for_zip_informative: Block ist für %{zip} ungültig
+            unknown_for_address_instructional: Block ist möglicherweise falsch
+            unknown_for_address_informative: Block ist möglicherweise falsch
+          warnings:
+            contains_too_many_words: Block sollte aus weniger als %{word_count} Wörtern
+              bestehen

--- a/data/regions/KW/el.yml
+++ b/data/regions/KW/el.yml
@@ -64,7 +64,7 @@ el:
             default: Οικοδομικό τετράγωνο
             optional: Οικοδομικό τετράγωνο (προαιρετικό)
           errors:
-            blank_instructional: Καταχωρίστε οικοδομικό τετράγωνο
+            blank_instructional: Εισαγάγετε ένα οικοδομικό τετράγωνο
             blank_informative: Λείπει το οικοδομικό τετράγωνο
             too_long_instructional: Το οικοδομικό τετράγωνο είναι πολύ μεγάλο (το
               μέγιστο είναι %{limit} χαρακτήρες)
@@ -78,7 +78,8 @@ el:
             contains_mathematical_symbols_informative: Το οικοδομικό τετράγωνο δεν
               μπορεί να περιέχει μαθηματικά σύμβολα
             contains_restricted_characters_instructional: Το οικοδομικό τετράγωνο
-              μπορεί να περιέχει μόνο γράμματα, αριθμούς, τοπικούς και ειδικούς χαρακτήρες
+              μπορεί να περιέχει μόνο γράμματα, αριθμούς, τοπικούς χαρακτήρες και
+              ειδικούς χαρακτήρες
             contains_restricted_characters_informative: Το οικοδομικό τετράγωνο δεν
               μπορεί να περιέχει μη επιτρεπόμενους χαρακτήρες
             contains_too_many_words_instructional: Το οικοδομικό τετράγωνο πρέπει
@@ -93,18 +94,18 @@ el:
               URL
             contains_url_informative: Το οικοδομικό τετράγωνο δεν μπορεί να περιέχει
               URL
-            unknown_for_city_instructional: Καταχωρίστε ένα έγκυρο οικοδομικό τετράγωνο
+            unknown_for_city_instructional: Εισαγάγετε ένα έγκυρο οικοδομικό τετράγωνο
               για %{city}
             unknown_for_city_informative: Το οικοδομικό τετράγωνο δεν είναι έγκυρο
               για %{city}
-            unknown_for_zip_instructional: Καταχωρίστε ένα έγκυρο οικοδομικό τετράγωνο
-              για τον Τ.Κ. %{zip}
+            unknown_for_zip_instructional: Εισαγάγετε ένα έγκυρο οικοδομικό τετράγωνο
+              για %{zip}
             unknown_for_zip_informative: Το οικοδομικό τετράγωνο δεν είναι έγκυρο
-              για τον Τ.Κ. %{zip}
+              για %{zip}
             unknown_for_address_instructional: Το οικοδομικό τετράγωνο ενδέχεται να
-              είναι εσφαλμένο
+              είναι λανθασμένο
             unknown_for_address_informative: Το οικοδομικό τετράγωνο ενδέχεται να
-              είναι εσφαλμένο
+              είναι λανθασμένο
           warnings:
             contains_too_many_words: Συνιστάται το οικοδομικό τετράγωνο να έχει λιγότερες
               από %{word_count} λέξεις

--- a/data/regions/KW/el.yml
+++ b/data/regions/KW/el.yml
@@ -59,3 +59,52 @@ el:
           warnings:
             contains_too_many_words: Το οικοδομικό τετράγωνο συνιστάται να έχει λιγότερες
               από %{word_count} λέξεις
+        district:
+          label:
+            default: Οικοδομικό τετράγωνο
+            optional: Οικοδομικό τετράγωνο (προαιρετικό)
+          errors:
+            blank_instructional: Καταχωρίστε οικοδομικό τετράγωνο
+            blank_informative: Λείπει το οικοδομικό τετράγωνο
+            too_long_instructional: Το οικοδομικό τετράγωνο είναι πολύ μεγάλο (το
+              μέγιστο είναι %{limit} χαρακτήρες)
+            too_long_informative: Το οικοδομικό τετράγωνο είναι πολύ μεγάλο
+            contains_emojis_instructional: Το οικοδομικό τετράγωνο δεν μπορεί να περιέχει
+              emoji
+            contains_emojis_informative: Το οικοδομικό τετράγωνο δεν μπορεί να περιέχει
+              emoji
+            contains_mathematical_symbols_instructional: Το οικοδομικό τετράγωνο δεν
+              μπορεί να περιέχει μαθηματικά σύμβολα
+            contains_mathematical_symbols_informative: Το οικοδομικό τετράγωνο δεν
+              μπορεί να περιέχει μαθηματικά σύμβολα
+            contains_restricted_characters_instructional: Το οικοδομικό τετράγωνο
+              μπορεί να περιέχει μόνο γράμματα, αριθμούς, τοπικούς και ειδικούς χαρακτήρες
+            contains_restricted_characters_informative: Το οικοδομικό τετράγωνο δεν
+              μπορεί να περιέχει μη επιτρεπόμενους χαρακτήρες
+            contains_too_many_words_instructional: Το οικοδομικό τετράγωνο πρέπει
+              να έχει λιγότερες από %{word_count} λέξεις
+            contains_too_many_words_informative: Το οικοδομικό τετράγωνο πρέπει να
+              έχει λιγότερες από %{word_count} λέξεις
+            contains_html_tags_instructional: Το οικοδομικό τετράγωνο δεν μπορεί να
+              περιέχει HTML
+            contains_html_tags_informative: Το οικοδομικό τετράγωνο δεν μπορεί να
+              περιέχει HTML
+            contains_url_instructional: Το οικοδομικό τετράγωνο δεν μπορεί να περιέχει
+              URL
+            contains_url_informative: Το οικοδομικό τετράγωνο δεν μπορεί να περιέχει
+              URL
+            unknown_for_city_instructional: Καταχωρίστε ένα έγκυρο οικοδομικό τετράγωνο
+              για %{city}
+            unknown_for_city_informative: Το οικοδομικό τετράγωνο δεν είναι έγκυρο
+              για %{city}
+            unknown_for_zip_instructional: Καταχωρίστε ένα έγκυρο οικοδομικό τετράγωνο
+              για τον Τ.Κ. %{zip}
+            unknown_for_zip_informative: Το οικοδομικό τετράγωνο δεν είναι έγκυρο
+              για τον Τ.Κ. %{zip}
+            unknown_for_address_instructional: Το οικοδομικό τετράγωνο ενδέχεται να
+              είναι εσφαλμένο
+            unknown_for_address_informative: Το οικοδομικό τετράγωνο ενδέχεται να
+              είναι εσφαλμένο
+          warnings:
+            contains_too_many_words: Συνιστάται το οικοδομικό τετράγωνο να έχει λιγότερες
+              από %{word_count} λέξεις

--- a/data/regions/KW/en.yml
+++ b/data/regions/KW/en.yml
@@ -40,3 +40,33 @@ en:
             unknown_for_address_informative: Block may be incorrect
           warnings:
             contains_too_many_words: Block is recommended to have less than %{word_count} words
+        district:
+          label:
+            default: Block
+            optional: Block (optional)
+          errors:
+            blank_instructional: Enter a block
+            blank_informative: Block is missing
+            too_long_instructional: Block is too long (maximum is %{limit} characters)
+            too_long_informative: Block is too long
+            contains_emojis_instructional: Block can't contain emojis
+            contains_emojis_informative: Block can't contain emojis
+            contains_mathematical_symbols_instructional: Block can't contain mathematical symbols
+            contains_mathematical_symbols_informative: Block can't contain mathematical symbols
+            contains_restricted_characters_instructional: Block can only contain letters, numbers, local characters, and
+              special characters
+            contains_restricted_characters_informative: Block can't contain restricted characters
+            contains_too_many_words_instructional: Block must have fewer than %{word_count} words
+            contains_too_many_words_informative: Block must have fewer than %{word_count} words
+            contains_html_tags_instructional: Block can't contain HTML
+            contains_html_tags_informative: Block can't contain HTML
+            contains_url_instructional: Block can't contain a URL
+            contains_url_informative: Block can't contain a URL
+            unknown_for_city_instructional: Enter a valid block for %{city}
+            unknown_for_city_informative: Block isn't valid for %{city}
+            unknown_for_zip_instructional: Enter a valid block for %{zip}
+            unknown_for_zip_informative: Block isn't valid for %{zip}
+            unknown_for_address_instructional: Block may be incorrect
+            unknown_for_address_informative: Block may be incorrect
+          warnings:
+            contains_too_many_words: Block is recommended to have less than %{word_count} words

--- a/data/regions/KW/es.yml
+++ b/data/regions/KW/es.yml
@@ -53,3 +53,40 @@ es:
           warnings:
             contains_too_many_words: Se recomienda que el nombre del bloque tenga
               menos de %{word_count} palabras.
+        district:
+          label:
+            default: Bloque
+            optional: Bloque (opcional)
+          errors:
+            blank_instructional: Ingresa un bloque
+            blank_informative: Falta el bloque
+            too_long_instructional: El bloque es demasiado largo (el máximo es de
+              %{limit} caracteres)
+            too_long_informative: El bloque es demasiado largo
+            contains_emojis_instructional: El bloque no puede contener emojis
+            contains_emojis_informative: El bloque no puede contener emojis
+            contains_mathematical_symbols_instructional: El bloque no puede contener
+              símbolos matemáticos
+            contains_mathematical_symbols_informative: El bloque no puede contener
+              símbolos matemáticos
+            contains_restricted_characters_instructional: El bloque solo puede contener
+              letras, números, caracteres locales y caracteres especiales
+            contains_restricted_characters_informative: El bloque no puede contener
+              caracteres restringidos
+            contains_too_many_words_instructional: El bloque debe tener menos de %{word_count}
+              palabras
+            contains_too_many_words_informative: El bloque debe tener menos de %{word_count}
+              palabras
+            contains_html_tags_instructional: El bloque no puede contener HTML
+            contains_html_tags_informative: El bloque no puede contener HTML
+            contains_url_instructional: El bloque no puede contener una URL
+            contains_url_informative: El bloque no puede contener una URL
+            unknown_for_city_instructional: Ingresa un bloque válido para %{city}
+            unknown_for_city_informative: El bloque no es válido para %{city}
+            unknown_for_zip_instructional: Ingresa un bloque válido para %{zip}
+            unknown_for_zip_informative: El bloque no es válido para %{zip}
+            unknown_for_address_instructional: El bloque podría ser incorrecto
+            unknown_for_address_informative: El bloque podría ser incorrecto
+          warnings:
+            contains_too_many_words: Se recomienda que el bloque tenga menos de %{word_count}
+              palabras

--- a/data/regions/KW/fi.yml
+++ b/data/regions/KW/fi.yml
@@ -58,15 +58,15 @@ fi:
             blank_informative: Kortteli puuttuu
             too_long_instructional: Kortteli on liian pitkä (enintään %{limit} merkkiä)
             too_long_informative: Kortteli on liian pitkä
-            contains_emojis_instructional: Kortteli ei voi sisältää emojeita
-            contains_emojis_informative: Kortteli ei voi sisältää emojeita
+            contains_emojis_instructional: Kortteli ei voi sisältää emojeja
+            contains_emojis_informative: Kortteli ei voi sisältää emojeja
             contains_mathematical_symbols_instructional: Kortteli ei voi sisältää
-              matemaattisia symboleita
+              matemaattisia symboleja
             contains_mathematical_symbols_informative: Kortteli ei voi sisältää matemaattisia
-              symboleita
+              symboleja
             contains_restricted_characters_instructional: Kortteli voi sisältää vain
               kirjaimia, numeroita, paikallisia merkkejä ja erikoismerkkejä
-            contains_restricted_characters_informative: Kortteli ei voi sisältää rajoitettuja
+            contains_restricted_characters_informative: Kortteli ei voi sisältää kiellettyjä
               merkkejä
             contains_too_many_words_instructional: Korttelissa on oltava alle %{word_count}
               sanaa

--- a/data/regions/KW/fi.yml
+++ b/data/regions/KW/fi.yml
@@ -49,3 +49,43 @@ fi:
           warnings:
             contains_too_many_words: Korttelin pituudeksi suositellaan alle %{word_count}
               sanaa
+        district:
+          label:
+            default: Kortteli
+            optional: Kortteli (valinnainen)
+          errors:
+            blank_instructional: Anna kortteli
+            blank_informative: Kortteli puuttuu
+            too_long_instructional: Kortteli on liian pitkä (enintään %{limit} merkkiä)
+            too_long_informative: Kortteli on liian pitkä
+            contains_emojis_instructional: Kortteli ei voi sisältää emojeita
+            contains_emojis_informative: Kortteli ei voi sisältää emojeita
+            contains_mathematical_symbols_instructional: Kortteli ei voi sisältää
+              matemaattisia symboleita
+            contains_mathematical_symbols_informative: Kortteli ei voi sisältää matemaattisia
+              symboleita
+            contains_restricted_characters_instructional: Kortteli voi sisältää vain
+              kirjaimia, numeroita, paikallisia merkkejä ja erikoismerkkejä
+            contains_restricted_characters_informative: Kortteli ei voi sisältää rajoitettuja
+              merkkejä
+            contains_too_many_words_instructional: Korttelissa on oltava alle %{word_count}
+              sanaa
+            contains_too_many_words_informative: Korttelissa on oltava alle %{word_count}
+              sanaa
+            contains_html_tags_instructional: Kortteli ei voi sisältää HTML:ää
+            contains_html_tags_informative: Kortteli ei voi sisältää HTML:ää
+            contains_url_instructional: Kortteli ei voi sisältää URL-osoitetta
+            contains_url_informative: Kortteli ei voi sisältää URL-osoitetta
+            unknown_for_city_instructional: Anna kelvollinen kortteli kaupungille
+              %{city}
+            unknown_for_city_informative: Kortteli ei ole kelvollinen kaupungille
+              %{city}
+            unknown_for_zip_instructional: Anna kelvollinen kortteli postinumerolle
+              %{zip}
+            unknown_for_zip_informative: Kortteli ei ole kelvollinen postinumerolle
+              %{zip}
+            unknown_for_address_instructional: Kortteli saattaa olla virheellinen
+            unknown_for_address_informative: Kortteli saattaa olla virheellinen
+          warnings:
+            contains_too_many_words: Korttelissa suositellaan olevan alle %{word_count}
+              sanaa

--- a/data/regions/KW/fr.yml
+++ b/data/regions/KW/fr.yml
@@ -57,25 +57,26 @@ fr:
           errors:
             blank_instructional: Saisissez un bloc
             blank_informative: Le bloc est manquant
-            too_long_instructional: Le bloc est trop long (%{limit} caractères maximum)
+            too_long_instructional: Le bloc est trop long (maximum de %{limit} caractères)
             too_long_informative: Le bloc est trop long
-            contains_emojis_instructional: Le bloc ne peut pas contenir d’emojis
-            contains_emojis_informative: Le bloc ne peut pas contenir d’emojis
+            contains_emojis_instructional: Le bloc ne peut pas contenir d’émojis
+            contains_emojis_informative: Le bloc ne peut pas contenir d’émojis
             contains_mathematical_symbols_instructional: Le bloc ne peut pas contenir
               de symboles mathématiques
             contains_mathematical_symbols_informative: Le bloc ne peut pas contenir
               de symboles mathématiques
-            contains_restricted_characters_instructional: Le bloc ne peut contenir
-              que des lettres, des chiffres, des caractères locaux et des caractères
+            contains_restricted_characters_instructional: Le bloc peut uniquement
+              contenir des lettres, des chiffres, des caractères locaux et des caractères
               spéciaux
             contains_restricted_characters_informative: Le bloc ne peut pas contenir
               de caractères restreints
-            contains_too_many_words_instructional: Le bloc doit contenir moins de
+            contains_too_many_words_instructional: Le bloc doit comporter moins de
               %{word_count} mots
-            contains_too_many_words_informative: Le bloc doit contenir moins de %{word_count}
+            contains_too_many_words_informative: Le bloc doit comporter moins de %{word_count}
               mots
-            contains_html_tags_instructional: Le bloc ne peut pas contenir de HTML
-            contains_html_tags_informative: Le bloc ne peut pas contenir de HTML
+            contains_html_tags_instructional: Le bloc ne peut pas contenir de code
+              HTML
+            contains_html_tags_informative: Le bloc ne peut pas contenir de code HTML
             contains_url_instructional: Le bloc ne peut pas contenir d’URL
             contains_url_informative: Le bloc ne peut pas contenir d’URL
             unknown_for_city_instructional: Saisissez un bloc valide pour %{city}
@@ -85,5 +86,5 @@ fr:
             unknown_for_address_instructional: Le bloc est peut-être incorrect
             unknown_for_address_informative: Le bloc est peut-être incorrect
           warnings:
-            contains_too_many_words: Il est recommandé que le bloc contienne moins
+            contains_too_many_words: Il est recommandé que le bloc comporte moins
               de %{word_count} mots

--- a/data/regions/KW/fr.yml
+++ b/data/regions/KW/fr.yml
@@ -50,3 +50,40 @@ fr:
           warnings:
             contains_too_many_words: Il est conseillé que le nom d’îlot comporte moins
               de %{word_count} mots
+        district:
+          label:
+            default: Bloc
+            optional: Bloc (facultatif)
+          errors:
+            blank_instructional: Saisissez un bloc
+            blank_informative: Le bloc est manquant
+            too_long_instructional: Le bloc est trop long (%{limit} caractères maximum)
+            too_long_informative: Le bloc est trop long
+            contains_emojis_instructional: Le bloc ne peut pas contenir d’emojis
+            contains_emojis_informative: Le bloc ne peut pas contenir d’emojis
+            contains_mathematical_symbols_instructional: Le bloc ne peut pas contenir
+              de symboles mathématiques
+            contains_mathematical_symbols_informative: Le bloc ne peut pas contenir
+              de symboles mathématiques
+            contains_restricted_characters_instructional: Le bloc ne peut contenir
+              que des lettres, des chiffres, des caractères locaux et des caractères
+              spéciaux
+            contains_restricted_characters_informative: Le bloc ne peut pas contenir
+              de caractères restreints
+            contains_too_many_words_instructional: Le bloc doit contenir moins de
+              %{word_count} mots
+            contains_too_many_words_informative: Le bloc doit contenir moins de %{word_count}
+              mots
+            contains_html_tags_instructional: Le bloc ne peut pas contenir de HTML
+            contains_html_tags_informative: Le bloc ne peut pas contenir de HTML
+            contains_url_instructional: Le bloc ne peut pas contenir d’URL
+            contains_url_informative: Le bloc ne peut pas contenir d’URL
+            unknown_for_city_instructional: Saisissez un bloc valide pour %{city}
+            unknown_for_city_informative: Le bloc n’est pas valide pour %{city}
+            unknown_for_zip_instructional: Saisissez un bloc valide pour %{zip}
+            unknown_for_zip_informative: Le bloc n’est pas valide pour %{zip}
+            unknown_for_address_instructional: Le bloc est peut-être incorrect
+            unknown_for_address_informative: Le bloc est peut-être incorrect
+          warnings:
+            contains_too_many_words: Il est recommandé que le bloc contienne moins
+              de %{word_count} mots

--- a/data/regions/KW/hi.yml
+++ b/data/regions/KW/hi.yml
@@ -48,3 +48,40 @@ hi:
           warnings:
             contains_too_many_words: इस बात का सुझाव दिया जाता है कि ब्लॉक के नाम
               में %{word_count} से कम शब्द होने चाहिए
+        district:
+          label:
+            default: ब्लॉक
+            optional: ब्लॉक (वैकल्पिक)
+          errors:
+            blank_instructional: कोई ब्लॉक दर्ज करें
+            blank_informative: ब्लॉक मौजूद नहीं है
+            too_long_instructional: ब्लॉक बहुत लंबा है (अधिकतम %{limit} वर्ण होने
+              चाहिए)
+            too_long_informative: ब्लॉक बहुत लंबा है
+            contains_emojis_instructional: ब्लॉक में इमोजी नहीं हो सकते
+            contains_emojis_informative: ब्लॉक में इमोजी नहीं हो सकते
+            contains_mathematical_symbols_instructional: ब्लॉक में गणितीय चिह्न नहीं
+              हो सकते
+            contains_mathematical_symbols_informative: ब्लॉक में गणितीय चिह्न नहीं
+              हो सकते
+            contains_restricted_characters_instructional: ब्लॉक में केवल अक्षर, संख्याएं,
+              स्थानीय वर्ण और विशेष वर्ण शामिल हो सकते हैं
+            contains_restricted_characters_informative: ब्लॉक में प्रतिबंधित वर्ण
+              नहीं हो सकते
+            contains_too_many_words_instructional: ब्लॉक में %{word_count} से कम शब्द
+              होने चाहिए
+            contains_too_many_words_informative: ब्लॉक में %{word_count} से कम शब्द
+              होने चाहिए
+            contains_html_tags_instructional: ब्लॉक में HTML नहीं हो सकता
+            contains_html_tags_informative: ब्लॉक में HTML नहीं हो सकता
+            contains_url_instructional: ब्लॉक में कोई URL नहीं हो सकता
+            contains_url_informative: ब्लॉक में कोई URL नहीं हो सकता
+            unknown_for_city_instructional: "%{city} के लिए एक मान्य ब्लॉक दर्ज करें"
+            unknown_for_city_informative: ब्लॉक, %{city} के लिए मान्य नहीं है
+            unknown_for_zip_instructional: "%{zip} के लिए एक मान्य ब्लॉक दर्ज करें"
+            unknown_for_zip_informative: ब्लॉक, %{zip} के लिए मान्य नहीं है
+            unknown_for_address_instructional: ब्लॉक गलत हो सकता है
+            unknown_for_address_informative: ब्लॉक गलत हो सकता है
+          warnings:
+            contains_too_many_words: यह सुझाव दिया जाता है कि ब्लॉक में %{word_count}
+              से कम शब्द हों

--- a/data/regions/KW/hi.yml
+++ b/data/regions/KW/hi.yml
@@ -53,35 +53,35 @@ hi:
             default: ब्लॉक
             optional: ब्लॉक (वैकल्पिक)
           errors:
-            blank_instructional: कोई ब्लॉक दर्ज करें
-            blank_informative: ब्लॉक मौजूद नहीं है
+            blank_instructional: कोई ब्लॉक दर्ज करें.
+            blank_informative: ब्लॉक मौजूद नहीं है.
             too_long_instructional: ब्लॉक बहुत लंबा है (अधिकतम %{limit} वर्ण होने
-              चाहिए)
-            too_long_informative: ब्लॉक बहुत लंबा है
-            contains_emojis_instructional: ब्लॉक में इमोजी नहीं हो सकते
-            contains_emojis_informative: ब्लॉक में इमोजी नहीं हो सकते
+              चाहिए).
+            too_long_informative: ब्लॉक बहुत लंबा है.
+            contains_emojis_instructional: ब्लॉक में इमोजी नहीं हो सकते.
+            contains_emojis_informative: ब्लॉक में इमोजी नहीं हो सकते.
             contains_mathematical_symbols_instructional: ब्लॉक में गणितीय चिह्न नहीं
-              हो सकते
+              हो सकते.
             contains_mathematical_symbols_informative: ब्लॉक में गणितीय चिह्न नहीं
-              हो सकते
-            contains_restricted_characters_instructional: ब्लॉक में केवल अक्षर, संख्याएं,
-              स्थानीय वर्ण और विशेष वर्ण शामिल हो सकते हैं
+              हो सकते.
+            contains_restricted_characters_instructional: ब्लॉक में केवल अक्षर, अंक,
+              स्थानीय वर्ण और विशेष वर्ण हो सकते हैं.
             contains_restricted_characters_informative: ब्लॉक में प्रतिबंधित वर्ण
-              नहीं हो सकते
+              नहीं हो सकते.
             contains_too_many_words_instructional: ब्लॉक में %{word_count} से कम शब्द
-              होने चाहिए
+              होने चाहिए.
             contains_too_many_words_informative: ब्लॉक में %{word_count} से कम शब्द
-              होने चाहिए
-            contains_html_tags_instructional: ब्लॉक में HTML नहीं हो सकता
-            contains_html_tags_informative: ब्लॉक में HTML नहीं हो सकता
-            contains_url_instructional: ब्लॉक में कोई URL नहीं हो सकता
-            contains_url_informative: ब्लॉक में कोई URL नहीं हो सकता
-            unknown_for_city_instructional: "%{city} के लिए एक मान्य ब्लॉक दर्ज करें"
-            unknown_for_city_informative: ब्लॉक, %{city} के लिए मान्य नहीं है
-            unknown_for_zip_instructional: "%{zip} के लिए एक मान्य ब्लॉक दर्ज करें"
-            unknown_for_zip_informative: ब्लॉक, %{zip} के लिए मान्य नहीं है
-            unknown_for_address_instructional: ब्लॉक गलत हो सकता है
-            unknown_for_address_informative: ब्लॉक गलत हो सकता है
+              होने चाहिए.
+            contains_html_tags_instructional: ब्लॉक में HTML नहीं हो सकता.
+            contains_html_tags_informative: ब्लॉक में HTML नहीं हो सकता.
+            contains_url_instructional: ब्लॉक में कोई URL नहीं हो सकता.
+            contains_url_informative: ब्लॉक में कोई URL नहीं हो सकता.
+            unknown_for_city_instructional: "%{city} के लिए कोई मान्य ब्लॉक दर्ज करें."
+            unknown_for_city_informative: "%{city} के लिए ब्लॉक मान्य नहीं है."
+            unknown_for_zip_instructional: "%{zip} के लिए कोई मान्य ब्लॉक दर्ज करें."
+            unknown_for_zip_informative: "%{zip} के लिए ब्लॉक मान्य नहीं है."
+            unknown_for_address_instructional: ब्लॉक गलत हो सकता है.
+            unknown_for_address_informative: ब्लॉक गलत हो सकता है.
           warnings:
-            contains_too_many_words: यह सुझाव दिया जाता है कि ब्लॉक में %{word_count}
-              से कम शब्द हों
+            contains_too_many_words: सुझाव है कि ब्लॉक में %{word_count} से कम शब्द
+              हों.

--- a/data/regions/KW/hr.yml
+++ b/data/regions/KW/hr.yml
@@ -47,3 +47,39 @@ hr:
           warnings:
             contains_too_many_words: Preporučujemo da naziv bloka sadrži manje od
               %{word_count} riječ/i
+        district:
+          label:
+            default: Blok
+            optional: Blok (neobavezno)
+          errors:
+            blank_instructional: Unesite blok
+            blank_informative: Nedostaje blok
+            too_long_instructional: 'Blok je predug (najviše znakova: %{limit})'
+            too_long_informative: Blok je predug
+            contains_emojis_instructional: Blok ne može sadržavati emojije
+            contains_emojis_informative: Blok ne može sadržavati emojije
+            contains_mathematical_symbols_instructional: Blok ne može sadržavati matematičke
+              simbole
+            contains_mathematical_symbols_informative: Blok ne može sadržavati matematičke
+              simbole
+            contains_restricted_characters_instructional: Blok može sadržavati samo
+              slova, brojeve, lokalne znakove i posebne znakove
+            contains_restricted_characters_informative: Blok ne može sadržavati nedopuštene
+              znakove
+            contains_too_many_words_instructional: Blok mora imati manje od %{word_count}
+              riječi
+            contains_too_many_words_informative: Blok mora imati manje od %{word_count}
+              riječi
+            contains_html_tags_instructional: Blok ne može sadržavati HTML
+            contains_html_tags_informative: Blok ne može sadržavati HTML
+            contains_url_instructional: Blok ne može sadržavati URL
+            contains_url_informative: Blok ne može sadržavati URL
+            unknown_for_city_instructional: Unesite važeći blok za grad %{city}
+            unknown_for_city_informative: Blok nije važeći za grad %{city}
+            unknown_for_zip_instructional: Unesite važeći blok za poštanski broj %{zip}
+            unknown_for_zip_informative: Blok nije važeći za poštanski broj %{zip}
+            unknown_for_address_instructional: Blok je možda netočan
+            unknown_for_address_informative: Blok je možda netočan
+          warnings:
+            contains_too_many_words: Preporučuje se da blok ima manje od %{word_count}
+              riječi

--- a/data/regions/KW/hr.yml
+++ b/data/regions/KW/hr.yml
@@ -50,11 +50,11 @@ hr:
         district:
           label:
             default: Blok
-            optional: Blok (neobavezno)
+            optional: Blok (nije obavezno)
           errors:
             blank_instructional: Unesite blok
             blank_informative: Nedostaje blok
-            too_long_instructional: 'Blok je predug (najviše znakova: %{limit})'
+            too_long_instructional: 'Blok je predug (maksimalan broj znakova: %{limit})'
             too_long_informative: Blok je predug
             contains_emojis_instructional: Blok ne može sadržavati emojije
             contains_emojis_informative: Blok ne može sadržavati emojije
@@ -64,7 +64,7 @@ hr:
               simbole
             contains_restricted_characters_instructional: Blok može sadržavati samo
               slova, brojeve, lokalne znakove i posebne znakove
-            contains_restricted_characters_informative: Blok ne može sadržavati nedopuštene
+            contains_restricted_characters_informative: Blok ne može sadržavati zabranjene
               znakove
             contains_too_many_words_instructional: Blok mora imati manje od %{word_count}
               riječi
@@ -74,12 +74,12 @@ hr:
             contains_html_tags_informative: Blok ne može sadržavati HTML
             contains_url_instructional: Blok ne može sadržavati URL
             contains_url_informative: Blok ne može sadržavati URL
-            unknown_for_city_instructional: Unesite važeći blok za grad %{city}
-            unknown_for_city_informative: Blok nije važeći za grad %{city}
-            unknown_for_zip_instructional: Unesite važeći blok za poštanski broj %{zip}
-            unknown_for_zip_informative: Blok nije važeći za poštanski broj %{zip}
+            unknown_for_city_instructional: Unesite važeći blok za %{city}
+            unknown_for_city_informative: Blok nije važeći za %{city}
+            unknown_for_zip_instructional: Unesite važeći blok za %{zip}
+            unknown_for_zip_informative: Blok nije važeći za %{zip}
             unknown_for_address_instructional: Blok je možda netočan
             unknown_for_address_informative: Blok je možda netočan
           warnings:
-            contains_too_many_words: Preporučuje se da blok ima manje od %{word_count}
+            contains_too_many_words: Preporučuje se da naziv bloka ima manje od %{word_count}
               riječi

--- a/data/regions/KW/hu.yml
+++ b/data/regions/KW/hu.yml
@@ -49,3 +49,42 @@ hu:
           warnings:
             contains_too_many_words: A tömb nevének javasolt hossza kevesebb mint
               %{word_count} szó
+        district:
+          label:
+            default: Tömb
+            optional: Tömb (opcionális)
+          errors:
+            blank_instructional: Adjon meg egy tömböt
+            blank_informative: A tömb hiányzik
+            too_long_instructional: A tömb túl hosszú (legfeljebb %{limit} karakter
+              lehet)
+            too_long_informative: A tömb túl hosszú
+            contains_emojis_instructional: A tömb nem tartalmazhat emojikat
+            contains_emojis_informative: A tömb nem tartalmazhat emojikat
+            contains_mathematical_symbols_instructional: A tömb nem tartalmazhat matematikai
+              szimbólumokat
+            contains_mathematical_symbols_informative: A tömb nem tartalmazhat matematikai
+              szimbólumokat
+            contains_restricted_characters_instructional: A tömb csak betűket, számokat,
+              helyi karaktereket és speciális karaktereket tartalmazhat
+            contains_restricted_characters_informative: A tömb nem tartalmazhat tiltott
+              karaktereket
+            contains_too_many_words_instructional: A tömb kevesebb mint %{word_count}
+              szóból állhat
+            contains_too_many_words_informative: A tömb kevesebb mint %{word_count}
+              szóból állhat
+            contains_html_tags_instructional: A tömb nem tartalmazhat HTML-t
+            contains_html_tags_informative: A tömb nem tartalmazhat HTML-t
+            contains_url_instructional: A tömb nem tartalmazhat URL-t
+            contains_url_informative: A tömb nem tartalmazhat URL-t
+            unknown_for_city_instructional: 'Adjon meg egy érvényes tömböt a következőhöz:
+              %{city}'
+            unknown_for_city_informative: 'A tömb nem érvényes a következőhöz: %{city}'
+            unknown_for_zip_instructional: 'Adjon meg egy érvényes tömböt a következőhöz:
+              %{zip}'
+            unknown_for_zip_informative: 'A tömb nem érvényes a következőhöz: %{zip}'
+            unknown_for_address_instructional: A tömb helytelen lehet
+            unknown_for_address_informative: A tömb helytelen lehet
+          warnings:
+            contains_too_many_words: Javasoljuk, hogy a tömb kevesebb mint %{word_count}
+              szóból álljon

--- a/data/regions/KW/hu.yml
+++ b/data/regions/KW/hu.yml
@@ -69,22 +69,22 @@ hu:
               helyi karaktereket és speciális karaktereket tartalmazhat
             contains_restricted_characters_informative: A tömb nem tartalmazhat tiltott
               karaktereket
-            contains_too_many_words_instructional: A tömb kevesebb mint %{word_count}
-              szóból állhat
-            contains_too_many_words_informative: A tömb kevesebb mint %{word_count}
-              szóból állhat
+            contains_too_many_words_instructional: A tömb nevének kevesebb mint %{word_count}
+              szóból kell állnia
+            contains_too_many_words_informative: A tömb nevének kevesebb mint %{word_count}
+              szóból kell állnia
             contains_html_tags_instructional: A tömb nem tartalmazhat HTML-t
             contains_html_tags_informative: A tömb nem tartalmazhat HTML-t
             contains_url_instructional: A tömb nem tartalmazhat URL-t
             contains_url_informative: A tömb nem tartalmazhat URL-t
-            unknown_for_city_instructional: 'Adjon meg egy érvényes tömböt a következőhöz:
-              %{city}'
-            unknown_for_city_informative: 'A tömb nem érvényes a következőhöz: %{city}'
-            unknown_for_zip_instructional: 'Adjon meg egy érvényes tömböt a következőhöz:
+            unknown_for_city_instructional: 'Adjon meg egy érvényes tömböt itt: %{city}'
+            unknown_for_city_informative: 'A tömb nem érvényes itt: %{city}'
+            unknown_for_zip_instructional: 'Adjon meg egy érvényes tömböt ehhez az
+              irányítószámhoz: %{zip}'
+            unknown_for_zip_informative: 'A tömb nem érvényes ehhez az irányítószámhoz:
               %{zip}'
-            unknown_for_zip_informative: 'A tömb nem érvényes a következőhöz: %{zip}'
-            unknown_for_address_instructional: A tömb helytelen lehet
-            unknown_for_address_informative: A tömb helytelen lehet
+            unknown_for_address_instructional: Lehet, hogy a tömb hibás
+            unknown_for_address_informative: Lehet, hogy a tömb hibás
           warnings:
-            contains_too_many_words: Javasoljuk, hogy a tömb kevesebb mint %{word_count}
+            contains_too_many_words: Javasoljuk, hogy a tömb neve kevesebb mint %{word_count}
               szóból álljon

--- a/data/regions/KW/id.yml
+++ b/data/regions/KW/id.yml
@@ -64,7 +64,7 @@ id:
             contains_restricted_characters_instructional: Blok hanya boleh berisi
               huruf, angka, karakter lokal, dan karakter khusus
             contains_restricted_characters_informative: Blok tidak boleh berisi karakter
-              yang dibatasi
+              yang dilarang
             contains_too_many_words_instructional: Blok harus kurang dari %{word_count}
               kata
             contains_too_many_words_informative: Blok harus kurang dari %{word_count}

--- a/data/regions/KW/id.yml
+++ b/data/regions/KW/id.yml
@@ -46,3 +46,38 @@ id:
           warnings:
             contains_too_many_words: Nama blok sebaiknya berisi kurang dari %{word_count}
               kata
+        district:
+          label:
+            default: Blok
+            optional: Blok (opsional)
+          errors:
+            blank_instructional: Masukkan blok
+            blank_informative: Blok belum diisi
+            too_long_instructional: Blok terlalu panjang (maksimal %{limit} karakter)
+            too_long_informative: Blok terlalu panjang
+            contains_emojis_instructional: Blok tidak boleh berisi emoji
+            contains_emojis_informative: Blok tidak boleh berisi emoji
+            contains_mathematical_symbols_instructional: Blok tidak boleh berisi simbol
+              matematika
+            contains_mathematical_symbols_informative: Blok tidak boleh berisi simbol
+              matematika
+            contains_restricted_characters_instructional: Blok hanya boleh berisi
+              huruf, angka, karakter lokal, dan karakter khusus
+            contains_restricted_characters_informative: Blok tidak boleh berisi karakter
+              yang dibatasi
+            contains_too_many_words_instructional: Blok harus kurang dari %{word_count}
+              kata
+            contains_too_many_words_informative: Blok harus kurang dari %{word_count}
+              kata
+            contains_html_tags_instructional: Blok tidak boleh berisi HTML
+            contains_html_tags_informative: Blok tidak boleh berisi HTML
+            contains_url_instructional: Blok tidak boleh berisi URL
+            contains_url_informative: Blok tidak boleh berisi URL
+            unknown_for_city_instructional: Masukkan blok yang valid untuk %{city}
+            unknown_for_city_informative: Blok tidak valid untuk %{city}
+            unknown_for_zip_instructional: Masukkan blok yang valid untuk %{zip}
+            unknown_for_zip_informative: Blok tidak valid untuk %{zip}
+            unknown_for_address_instructional: Blok mungkin salah
+            unknown_for_address_informative: Blok mungkin salah
+          warnings:
+            contains_too_many_words: Blok disarankan kurang dari %{word_count} kata

--- a/data/regions/KW/it.yml
+++ b/data/regions/KW/it.yml
@@ -53,7 +53,7 @@ it:
             optional: Blocco (facoltativo)
           errors:
             blank_instructional: Inserisci un blocco
-            blank_informative: Blocco mancante
+            blank_informative: Manca il blocco
             too_long_instructional: Il blocco è troppo lungo (massimo %{limit} caratteri)
             too_long_informative: Il blocco è troppo lungo
             contains_emojis_instructional: Il blocco non può contenere emoji
@@ -66,10 +66,10 @@ it:
               solo lettere, numeri, caratteri locali e caratteri speciali
             contains_restricted_characters_informative: Il blocco non può contenere
               caratteri non consentiti
-            contains_too_many_words_instructional: Il blocco deve contenere meno di
-              %{word_count} parole
-            contains_too_many_words_informative: Il blocco deve contenere meno di
-              %{word_count} parole
+            contains_too_many_words_instructional: Il blocco deve avere meno di %{word_count}
+              parole
+            contains_too_many_words_informative: Il blocco deve avere meno di %{word_count}
+              parole
             contains_html_tags_instructional: Il blocco non può contenere HTML
             contains_html_tags_informative: Il blocco non può contenere HTML
             contains_url_instructional: Il blocco non può contenere un URL
@@ -81,5 +81,5 @@ it:
             unknown_for_address_instructional: Il blocco potrebbe essere errato
             unknown_for_address_informative: Il blocco potrebbe essere errato
           warnings:
-            contains_too_many_words: È consigliabile che il blocco contenga meno di
+            contains_too_many_words: Si consiglia di inserire un blocco con meno di
               %{word_count} parole

--- a/data/regions/KW/it.yml
+++ b/data/regions/KW/it.yml
@@ -47,3 +47,39 @@ it:
           warnings:
             contains_too_many_words: Il campo Isolato deve contenere meno di %{word_count}
               parole
+        district:
+          label:
+            default: Blocco
+            optional: Blocco (facoltativo)
+          errors:
+            blank_instructional: Inserisci un blocco
+            blank_informative: Blocco mancante
+            too_long_instructional: Il blocco è troppo lungo (massimo %{limit} caratteri)
+            too_long_informative: Il blocco è troppo lungo
+            contains_emojis_instructional: Il blocco non può contenere emoji
+            contains_emojis_informative: Il blocco non può contenere emoji
+            contains_mathematical_symbols_instructional: Il blocco non può contenere
+              simboli matematici
+            contains_mathematical_symbols_informative: Il blocco non può contenere
+              simboli matematici
+            contains_restricted_characters_instructional: Il blocco può contenere
+              solo lettere, numeri, caratteri locali e caratteri speciali
+            contains_restricted_characters_informative: Il blocco non può contenere
+              caratteri non consentiti
+            contains_too_many_words_instructional: Il blocco deve contenere meno di
+              %{word_count} parole
+            contains_too_many_words_informative: Il blocco deve contenere meno di
+              %{word_count} parole
+            contains_html_tags_instructional: Il blocco non può contenere HTML
+            contains_html_tags_informative: Il blocco non può contenere HTML
+            contains_url_instructional: Il blocco non può contenere un URL
+            contains_url_informative: Il blocco non può contenere un URL
+            unknown_for_city_instructional: Inserisci un blocco valido per %{city}
+            unknown_for_city_informative: Il blocco non è valido per %{city}
+            unknown_for_zip_instructional: Inserisci un blocco valido per %{zip}
+            unknown_for_zip_informative: Il blocco non è valido per %{zip}
+            unknown_for_address_instructional: Il blocco potrebbe essere errato
+            unknown_for_address_informative: Il blocco potrebbe essere errato
+          warnings:
+            contains_too_many_words: È consigliabile che il blocco contenga meno di
+              %{word_count} parole

--- a/data/regions/KW/ja.yml
+++ b/data/regions/KW/ja.yml
@@ -42,16 +42,16 @@ ja:
         district:
           label:
             default: ブロック
-            optional: ブロック (オプション)
+            optional: ブロック（オプション）
           errors:
             blank_instructional: ブロックを入力してください
             blank_informative: ブロックが入力されていません
-            too_long_instructional: ブロックが長すぎます (最大 %{limit} 文字)
+            too_long_instructional: ブロックが長すぎます（最大 %{limit} 文字）
             too_long_informative: ブロックが長すぎます
             contains_emojis_instructional: ブロックに絵文字を含めることはできません
             contains_emojis_informative: ブロックに絵文字を含めることはできません
-            contains_mathematical_symbols_instructional: ブロックに数学記号を含めることはできません
-            contains_mathematical_symbols_informative: ブロックに数学記号を含めることはできません
+            contains_mathematical_symbols_instructional: ブロックに算術記号を含めることはできません
+            contains_mathematical_symbols_informative: ブロックに算術記号を含めることはできません
             contains_restricted_characters_instructional: ブロックには、文字、数字、現地の文字、特殊文字のみを使用できます
             contains_restricted_characters_informative: ブロックに制限された文字を含めることはできません
             contains_too_many_words_instructional: ブロックは %{word_count} 語未満にする必要があります
@@ -60,11 +60,11 @@ ja:
             contains_html_tags_informative: ブロックに HTML を含めることはできません
             contains_url_instructional: ブロックに URL を含めることはできません
             contains_url_informative: ブロックに URL を含めることはできません
-            unknown_for_city_instructional: "%{city} に有効なブロックを入力してください"
-            unknown_for_city_informative: ブロックは %{city} には無効です
-            unknown_for_zip_instructional: "%{zip} に有効なブロックを入力してください"
-            unknown_for_zip_informative: ブロックは %{zip} には無効です
-            unknown_for_address_instructional: ブロックが間違っている可能性があります
-            unknown_for_address_informative: ブロックが間違っている可能性があります
+            unknown_for_city_instructional: "%{city} の有効なブロックを入力してください"
+            unknown_for_city_informative: "%{city} のブロックは無効です"
+            unknown_for_zip_instructional: "%{zip} の有効なブロックを入力してください"
+            unknown_for_zip_informative: "%{zip} のブロックは無効です"
+            unknown_for_address_instructional: ブロックに誤りがある可能性があります
+            unknown_for_address_informative: ブロックに誤りがある可能性があります
           warnings:
             contains_too_many_words: ブロックは %{word_count} 語未満にすることをおすすめします

--- a/data/regions/KW/ja.yml
+++ b/data/regions/KW/ja.yml
@@ -39,3 +39,32 @@ ja:
             unknown_for_address_informative: ブロックが正しくない可能性があります
           warnings:
             contains_too_many_words: ブロックは%{word_count}文字未満が推奨されています
+        district:
+          label:
+            default: ブロック
+            optional: ブロック (オプション)
+          errors:
+            blank_instructional: ブロックを入力してください
+            blank_informative: ブロックが入力されていません
+            too_long_instructional: ブロックが長すぎます (最大 %{limit} 文字)
+            too_long_informative: ブロックが長すぎます
+            contains_emojis_instructional: ブロックに絵文字を含めることはできません
+            contains_emojis_informative: ブロックに絵文字を含めることはできません
+            contains_mathematical_symbols_instructional: ブロックに数学記号を含めることはできません
+            contains_mathematical_symbols_informative: ブロックに数学記号を含めることはできません
+            contains_restricted_characters_instructional: ブロックには、文字、数字、現地の文字、特殊文字のみを使用できます
+            contains_restricted_characters_informative: ブロックに制限された文字を含めることはできません
+            contains_too_many_words_instructional: ブロックは %{word_count} 語未満にする必要があります
+            contains_too_many_words_informative: ブロックは %{word_count} 語未満にする必要があります
+            contains_html_tags_instructional: ブロックに HTML を含めることはできません
+            contains_html_tags_informative: ブロックに HTML を含めることはできません
+            contains_url_instructional: ブロックに URL を含めることはできません
+            contains_url_informative: ブロックに URL を含めることはできません
+            unknown_for_city_instructional: "%{city} に有効なブロックを入力してください"
+            unknown_for_city_informative: ブロックは %{city} には無効です
+            unknown_for_zip_instructional: "%{zip} に有効なブロックを入力してください"
+            unknown_for_zip_informative: ブロックは %{zip} には無効です
+            unknown_for_address_instructional: ブロックが間違っている可能性があります
+            unknown_for_address_informative: ブロックが間違っている可能性があります
+          warnings:
+            contains_too_many_words: ブロックは %{word_count} 語未満にすることをおすすめします

--- a/data/regions/KW/ko.yml
+++ b/data/regions/KW/ko.yml
@@ -49,26 +49,24 @@ ko:
             blank_informative: 블록이 누락되었습니다.
             too_long_instructional: 블록이 너무 깁니다(최대 %{limit}자).
             too_long_informative: 블록이 너무 깁니다.
-            contains_emojis_instructional: 블록에는 이모티콘을 포함할 수 없습니다.
-            contains_emojis_informative: 블록에는 이모티콘을 포함할 수 없습니다.
+            contains_emojis_instructional: 블록에는 이모지를 포함할 수 없습니다.
+            contains_emojis_informative: 블록에는 이모지를 포함할 수 없습니다.
             contains_mathematical_symbols_instructional: 블록에는 수학 기호를 포함할 수 없습니다.
             contains_mathematical_symbols_informative: 블록에는 수학 기호를 포함할 수 없습니다.
-            contains_restricted_characters_instructional: 블록에는 문자, 숫자, 현지 문자, 특수 문자만
-              포함할 수 있습니다.
+            contains_restricted_characters_instructional: 블록에는 문자, 숫자, 현지 문자 및 특수
+              문자만 포함할 수 있습니다.
             contains_restricted_characters_informative: 블록에는 제한된 문자를 포함할 수 없습니다.
-            contains_too_many_words_instructional: 블록은 %{word_count}개 미만의 단어로 구성되어야
-              합니다.
-            contains_too_many_words_informative: 블록은 %{word_count}개 미만의 단어로 구성되어야
-              합니다.
+            contains_too_many_words_instructional: 블록은 %{word_count}단어 미만이어야 합니다.
+            contains_too_many_words_informative: 블록은 %{word_count}단어 미만이어야 합니다.
             contains_html_tags_instructional: 블록에는 HTML을 포함할 수 없습니다.
             contains_html_tags_informative: 블록에는 HTML을 포함할 수 없습니다.
             contains_url_instructional: 블록에는 URL을 포함할 수 없습니다.
             contains_url_informative: 블록에는 URL을 포함할 수 없습니다.
             unknown_for_city_instructional: "%{city}의 유효한 블록을 입력하십시오."
-            unknown_for_city_informative: "%{city}에 유효한 블록이 아닙니다."
+            unknown_for_city_informative: 블록이 %{city}에 유효하지 않습니다.
             unknown_for_zip_instructional: "%{zip}의 유효한 블록을 입력하십시오."
-            unknown_for_zip_informative: "%{zip}에 유효한 블록이 아닙니다."
+            unknown_for_zip_informative: 블록이 %{zip}에 유효하지 않습니다.
             unknown_for_address_instructional: 블록이 올바르지 않을 수 있습니다.
             unknown_for_address_informative: 블록이 올바르지 않을 수 있습니다.
           warnings:
-            contains_too_many_words: 블록은 %{word_count}개 미만의 단어로 구성하는 것이 좋습니다.
+            contains_too_many_words: 블록은 %{word_count}단어 미만으로 입력하는 것이 좋습니다.

--- a/data/regions/KW/ko.yml
+++ b/data/regions/KW/ko.yml
@@ -40,3 +40,35 @@ ko:
             unknown_for_address_informative: 블록이 잘못되었을 수 있습니다
           warnings:
             contains_too_many_words: 블록에는 %{word_count}개 미만의 단어를 사용하는 것이 좋습니다
+        district:
+          label:
+            default: 블록
+            optional: 블록(선택 사항)
+          errors:
+            blank_instructional: 블록을 입력하십시오.
+            blank_informative: 블록이 누락되었습니다.
+            too_long_instructional: 블록이 너무 깁니다(최대 %{limit}자).
+            too_long_informative: 블록이 너무 깁니다.
+            contains_emojis_instructional: 블록에는 이모티콘을 포함할 수 없습니다.
+            contains_emojis_informative: 블록에는 이모티콘을 포함할 수 없습니다.
+            contains_mathematical_symbols_instructional: 블록에는 수학 기호를 포함할 수 없습니다.
+            contains_mathematical_symbols_informative: 블록에는 수학 기호를 포함할 수 없습니다.
+            contains_restricted_characters_instructional: 블록에는 문자, 숫자, 현지 문자, 특수 문자만
+              포함할 수 있습니다.
+            contains_restricted_characters_informative: 블록에는 제한된 문자를 포함할 수 없습니다.
+            contains_too_many_words_instructional: 블록은 %{word_count}개 미만의 단어로 구성되어야
+              합니다.
+            contains_too_many_words_informative: 블록은 %{word_count}개 미만의 단어로 구성되어야
+              합니다.
+            contains_html_tags_instructional: 블록에는 HTML을 포함할 수 없습니다.
+            contains_html_tags_informative: 블록에는 HTML을 포함할 수 없습니다.
+            contains_url_instructional: 블록에는 URL을 포함할 수 없습니다.
+            contains_url_informative: 블록에는 URL을 포함할 수 없습니다.
+            unknown_for_city_instructional: "%{city}의 유효한 블록을 입력하십시오."
+            unknown_for_city_informative: "%{city}에 유효한 블록이 아닙니다."
+            unknown_for_zip_instructional: "%{zip}의 유효한 블록을 입력하십시오."
+            unknown_for_zip_informative: "%{zip}에 유효한 블록이 아닙니다."
+            unknown_for_address_instructional: 블록이 올바르지 않을 수 있습니다.
+            unknown_for_address_informative: 블록이 올바르지 않을 수 있습니다.
+          warnings:
+            contains_too_many_words: 블록은 %{word_count}개 미만의 단어로 구성하는 것이 좋습니다.

--- a/data/regions/KW/lt.yml
+++ b/data/regions/KW/lt.yml
@@ -55,3 +55,40 @@ lt:
           warnings:
             contains_too_many_words: Patartina, kad kvartalo pavadinimą sudarytų mažiau
               nei %{word_count} žodžiai (-ių, -is)
+        district:
+          label:
+            default: Kvartalas
+            optional: Kvartalas (neprivaloma)
+          errors:
+            blank_instructional: Įveskite kvartalą
+            blank_informative: Nenurodytas kvartalas
+            too_long_instructional: Kvartalo pavadinimas per ilgas (daugiausia %{limit}
+              simbolių)
+            too_long_informative: Kvartalo pavadinimas per ilgas
+            contains_emojis_instructional: Kvartalo pavadinime negali būti jaustukų
+            contains_emojis_informative: Kvartalo pavadinime negali būti jaustukų
+            contains_mathematical_symbols_instructional: Kvartalo pavadinime negali
+              būti matematinių simbolių
+            contains_mathematical_symbols_informative: Kvartalo pavadinime negali
+              būti matematinių simbolių
+            contains_restricted_characters_instructional: Kvartalo pavadinime gali
+              būti tik raidės, skaičiai, vietiniai ir specialieji simboliai
+            contains_restricted_characters_informative: Kvartalo pavadinime negali
+              būti draudžiamų simbolių
+            contains_too_many_words_instructional: Kvartalo pavadinimą turi sudaryti
+              mažiau nei %{word_count} žodžių
+            contains_too_many_words_informative: Kvartalo pavadinimą turi sudaryti
+              mažiau nei %{word_count} žodžių
+            contains_html_tags_instructional: Kvartalo pavadinime negali būti HTML
+            contains_html_tags_informative: Kvartalo pavadinime negali būti HTML
+            contains_url_instructional: Kvartalo pavadinime negali būti URL
+            contains_url_informative: Kvartalo pavadinime negali būti URL
+            unknown_for_city_instructional: Įveskite tinkamą %{city} miesto kvartalą
+            unknown_for_city_informative: Kvartalas netinkamas miestui %{city}
+            unknown_for_zip_instructional: Įveskite tinkamą kvartalą pašto kodui %{zip}
+            unknown_for_zip_informative: Kvartalas netinkamas pašto kodui %{zip}
+            unknown_for_address_instructional: Kvartalas gali būti nurodytas neteisingai
+            unknown_for_address_informative: Kvartalas gali būti nurodytas neteisingai
+          warnings:
+            contains_too_many_words: Rekomenduojama, kad kvartalo pavadinimą sudarytų
+              mažiau nei %{word_count} žodžių

--- a/data/regions/KW/lt.yml
+++ b/data/regions/KW/lt.yml
@@ -58,12 +58,12 @@ lt:
         district:
           label:
             default: Kvartalas
-            optional: Kvartalas (neprivaloma)
+            optional: Kvartalas (pasirenkama)
           errors:
             blank_instructional: Įveskite kvartalą
             blank_informative: Nenurodytas kvartalas
             too_long_instructional: Kvartalo pavadinimas per ilgas (daugiausia %{limit}
-              simbolių)
+              simb.)
             too_long_informative: Kvartalo pavadinimas per ilgas
             contains_emojis_instructional: Kvartalo pavadinime negali būti jaustukų
             contains_emojis_informative: Kvartalo pavadinime negali būti jaustukų
@@ -76,19 +76,19 @@ lt:
             contains_restricted_characters_informative: Kvartalo pavadinime negali
               būti draudžiamų simbolių
             contains_too_many_words_instructional: Kvartalo pavadinimą turi sudaryti
-              mažiau nei %{word_count} žodžių
+              mažiau nei %{word_count} žodž.
             contains_too_many_words_informative: Kvartalo pavadinimą turi sudaryti
-              mažiau nei %{word_count} žodžių
+              mažiau nei %{word_count} žodž.
             contains_html_tags_instructional: Kvartalo pavadinime negali būti HTML
             contains_html_tags_informative: Kvartalo pavadinime negali būti HTML
             contains_url_instructional: Kvartalo pavadinime negali būti URL
             contains_url_informative: Kvartalo pavadinime negali būti URL
-            unknown_for_city_instructional: Įveskite tinkamą %{city} miesto kvartalą
-            unknown_for_city_informative: Kvartalas netinkamas miestui %{city}
-            unknown_for_zip_instructional: Įveskite tinkamą kvartalą pašto kodui %{zip}
-            unknown_for_zip_informative: Kvartalas netinkamas pašto kodui %{zip}
+            unknown_for_city_instructional: Įveskite tinkamą %{city} kvartalą
+            unknown_for_city_informative: Kvartalas netinkamas %{city}
+            unknown_for_zip_instructional: Įveskite tinkamą %{zip} kvartalą
+            unknown_for_zip_informative: Kvartalas netinkamas %{zip}
             unknown_for_address_instructional: Kvartalas gali būti nurodytas neteisingai
             unknown_for_address_informative: Kvartalas gali būti nurodytas neteisingai
           warnings:
             contains_too_many_words: Rekomenduojama, kad kvartalo pavadinimą sudarytų
-              mažiau nei %{word_count} žodžių
+              mažiau nei %{word_count} žodž.

--- a/data/regions/KW/ms.yml
+++ b/data/regions/KW/ms.yml
@@ -82,5 +82,5 @@ ms:
             unknown_for_address_instructional: Blok mungkin tidak betul
             unknown_for_address_informative: Blok mungkin tidak betul
           warnings:
-            contains_too_many_words: Blok disyorkan agar kurang daripada %{word_count}
+            contains_too_many_words: Blok disyorkan mempunyai kurang daripada %{word_count}
               perkataan

--- a/data/regions/KW/ms.yml
+++ b/data/regions/KW/ms.yml
@@ -47,3 +47,40 @@ ms:
           warnings:
             contains_too_many_words: Blok disyorkan untuk mengandungi kurang daripada
               %{word_count} perkataan
+        district:
+          label:
+            default: Blok
+            optional: Blok (pilihan)
+          errors:
+            blank_instructional: Masukkan blok
+            blank_informative: Blok tiada
+            too_long_instructional: Blok terlalu panjang (maksimum ialah %{limit}
+              aksara)
+            too_long_informative: Blok terlalu panjang
+            contains_emojis_instructional: Blok tidak boleh mengandungi emoji
+            contains_emojis_informative: Blok tidak boleh mengandungi emoji
+            contains_mathematical_symbols_instructional: Blok tidak boleh mengandungi
+              simbol matematik
+            contains_mathematical_symbols_informative: Blok tidak boleh mengandungi
+              simbol matematik
+            contains_restricted_characters_instructional: Blok hanya boleh mengandungi
+              huruf, nombor, aksara tempatan dan aksara khas
+            contains_restricted_characters_informative: Blok tidak boleh mengandungi
+              aksara terhad
+            contains_too_many_words_instructional: Blok mesti kurang daripada %{word_count}
+              perkataan
+            contains_too_many_words_informative: Blok mesti kurang daripada %{word_count}
+              perkataan
+            contains_html_tags_instructional: Blok tidak boleh mengandungi HTML
+            contains_html_tags_informative: Blok tidak boleh mengandungi HTML
+            contains_url_instructional: Blok tidak boleh mengandungi URL
+            contains_url_informative: Blok tidak boleh mengandungi URL
+            unknown_for_city_instructional: Masukkan blok yang sah untuk %{city}
+            unknown_for_city_informative: Blok tidak sah untuk %{city}
+            unknown_for_zip_instructional: Masukkan blok yang sah untuk %{zip}
+            unknown_for_zip_informative: Blok tidak sah untuk %{zip}
+            unknown_for_address_instructional: Blok mungkin tidak betul
+            unknown_for_address_informative: Blok mungkin tidak betul
+          warnings:
+            contains_too_many_words: Blok disyorkan agar kurang daripada %{word_count}
+              perkataan

--- a/data/regions/KW/nb.yml
+++ b/data/regions/KW/nb.yml
@@ -46,3 +46,39 @@ nb:
           warnings:
             contains_too_many_words: Vi anbefaler at blokken inneholder færre enn
               %{word_count} ord
+        district:
+          label:
+            default: Blokk
+            optional: Blokk (valgfritt)
+          errors:
+            blank_instructional: Angi en blokk
+            blank_informative: Blokk mangler
+            too_long_instructional: Blokk er for lang (maks %{limit} tegn)
+            too_long_informative: Blokk er for lang
+            contains_emojis_instructional: Blokk kan ikke inneholde emojier
+            contains_emojis_informative: Blokk kan ikke inneholde emojier
+            contains_mathematical_symbols_instructional: Blokk kan ikke inneholde
+              matematiske symboler
+            contains_mathematical_symbols_informative: Blokk kan ikke inneholde matematiske
+              symboler
+            contains_restricted_characters_instructional: Blokk kan bare inneholde
+              bokstaver, tall, lokale tegn og spesialtegn
+            contains_restricted_characters_informative: Blokk kan ikke inneholde begrensede
+              tegn
+            contains_too_many_words_instructional: Blokk må ha færre enn %{word_count}
+              ord
+            contains_too_many_words_informative: Blokk må ha færre enn %{word_count}
+              ord
+            contains_html_tags_instructional: Blokk kan ikke inneholde HTML
+            contains_html_tags_informative: Blokk kan ikke inneholde HTML
+            contains_url_instructional: Blokk kan ikke inneholde en URL-adresse
+            contains_url_informative: Blokk kan ikke inneholde en URL-adresse
+            unknown_for_city_instructional: Angi en gyldig blokk for %{city}
+            unknown_for_city_informative: Blokk er ikke gyldig for %{city}
+            unknown_for_zip_instructional: Angi en gyldig blokk for %{zip}
+            unknown_for_zip_informative: Blokk er ikke gyldig for %{zip}
+            unknown_for_address_instructional: Blokk kan være feil
+            unknown_for_address_informative: Blokk kan være feil
+          warnings:
+            contains_too_many_words: Det anbefales at blokk har færre enn %{word_count}
+              ord

--- a/data/regions/KW/nb.yml
+++ b/data/regions/KW/nb.yml
@@ -53,8 +53,8 @@ nb:
           errors:
             blank_instructional: Angi en blokk
             blank_informative: Blokk mangler
-            too_long_instructional: Blokk er for lang (maks %{limit} tegn)
-            too_long_informative: Blokk er for lang
+            too_long_instructional: Blokken er for lang (maksimalt %{limit} tegn)
+            too_long_informative: Blokken er for lang
             contains_emojis_instructional: Blokk kan ikke inneholde emojier
             contains_emojis_informative: Blokk kan ikke inneholde emojier
             contains_mathematical_symbols_instructional: Blokk kan ikke inneholde
@@ -63,7 +63,7 @@ nb:
               symboler
             contains_restricted_characters_instructional: Blokk kan bare inneholde
               bokstaver, tall, lokale tegn og spesialtegn
-            contains_restricted_characters_informative: Blokk kan ikke inneholde begrensede
+            contains_restricted_characters_informative: Blokk kan ikke inneholde ikke-tillatte
               tegn
             contains_too_many_words_instructional: Blokk må ha færre enn %{word_count}
               ord
@@ -77,8 +77,8 @@ nb:
             unknown_for_city_informative: Blokk er ikke gyldig for %{city}
             unknown_for_zip_instructional: Angi en gyldig blokk for %{zip}
             unknown_for_zip_informative: Blokk er ikke gyldig for %{zip}
-            unknown_for_address_instructional: Blokk kan være feil
-            unknown_for_address_informative: Blokk kan være feil
+            unknown_for_address_instructional: Blokken kan være feil
+            unknown_for_address_informative: Blokken kan være feil
           warnings:
-            contains_too_many_words: Det anbefales at blokk har færre enn %{word_count}
+            contains_too_many_words: Det anbefales at blokken har færre enn %{word_count}
               ord

--- a/data/regions/KW/nl.yml
+++ b/data/regions/KW/nl.yml
@@ -63,12 +63,12 @@ nl:
               bevatten
             contains_restricted_characters_instructional: Blok mag alleen letters,
               cijfers, lokale tekens en speciale tekens bevatten
-            contains_restricted_characters_informative: Blok mag geen niet-toegestane
-              tekens bevatten
-            contains_too_many_words_instructional: Blok moet minder dan %{word_count}
-              woorden bevatten
-            contains_too_many_words_informative: Blok moet minder dan %{word_count}
-              woorden bevatten
+            contains_restricted_characters_informative: Blok mag geen beperkte tekens
+              bevatten
+            contains_too_many_words_instructional: Blok moet uit minder dan %{word_count}
+              woorden bestaan
+            contains_too_many_words_informative: Blok moet uit minder dan %{word_count}
+              woorden bestaan
             contains_html_tags_instructional: Blok mag geen HTML bevatten
             contains_html_tags_informative: Blok mag geen HTML bevatten
             contains_url_instructional: Blok mag geen URL bevatten

--- a/data/regions/KW/nl.yml
+++ b/data/regions/KW/nl.yml
@@ -46,3 +46,39 @@ nl:
           warnings:
             contains_too_many_words: Geef minder dan %{word_count} woorden op voor
               het blok
+        district:
+          label:
+            default: Blok
+            optional: Blok (optioneel)
+          errors:
+            blank_instructional: Voer een blok in
+            blank_informative: Blok ontbreekt
+            too_long_instructional: Blok is te lang (maximaal %{limit} tekens)
+            too_long_informative: Blok is te lang
+            contains_emojis_instructional: Blok mag geen emoji's bevatten
+            contains_emojis_informative: Blok mag geen emoji's bevatten
+            contains_mathematical_symbols_instructional: Blok mag geen wiskundige
+              symbolen bevatten
+            contains_mathematical_symbols_informative: Blok mag geen wiskundige symbolen
+              bevatten
+            contains_restricted_characters_instructional: Blok mag alleen letters,
+              cijfers, lokale tekens en speciale tekens bevatten
+            contains_restricted_characters_informative: Blok mag geen niet-toegestane
+              tekens bevatten
+            contains_too_many_words_instructional: Blok moet minder dan %{word_count}
+              woorden bevatten
+            contains_too_many_words_informative: Blok moet minder dan %{word_count}
+              woorden bevatten
+            contains_html_tags_instructional: Blok mag geen HTML bevatten
+            contains_html_tags_informative: Blok mag geen HTML bevatten
+            contains_url_instructional: Blok mag geen URL bevatten
+            contains_url_informative: Blok mag geen URL bevatten
+            unknown_for_city_instructional: Voer een geldig blok in voor %{city}
+            unknown_for_city_informative: Blok is niet geldig voor %{city}
+            unknown_for_zip_instructional: Voer een geldig blok in voor %{zip}
+            unknown_for_zip_informative: Blok is niet geldig voor %{zip}
+            unknown_for_address_instructional: Blok is mogelijk onjuist
+            unknown_for_address_informative: Blok is mogelijk onjuist
+          warnings:
+            contains_too_many_words: Blok bevat bij voorkeur minder dan %{word_count}
+              woorden

--- a/data/regions/KW/pl.yml
+++ b/data/regions/KW/pl.yml
@@ -53,35 +53,34 @@ pl:
             optional: Blok (opcjonalnie)
           errors:
             blank_instructional: Wprowadź blok
-            blank_informative: Brakuje bloku
-            too_long_instructional: Blok jest za długi (maksymalnie %{limit} znaków)
-            too_long_informative: Blok jest za długi
-            contains_emojis_instructional: Blok nie może zawierać emoji
-            contains_emojis_informative: Blok nie może zawierać emoji
-            contains_mathematical_symbols_instructional: Blok nie może zawierać symboli
-              matematycznych
-            contains_mathematical_symbols_informative: Blok nie może zawierać symboli
-              matematycznych
-            contains_restricted_characters_instructional: Blok może zawierać tylko
-              litery, cyfry, znaki lokalne i znaki specjalne
-            contains_restricted_characters_informative: Blok nie może zawierać niedozwolonych
-              znaków
-            contains_too_many_words_instructional: Blok musi zawierać mniej niż %{word_count}
-              słów
-            contains_too_many_words_informative: Blok musi zawierać mniej niż %{word_count}
-              słów
-            contains_html_tags_instructional: Blok nie może zawierać kodu HTML
-            contains_html_tags_informative: Blok nie może zawierać kodu HTML
-            contains_url_instructional: Blok nie może zawierać adresu URL
-            contains_url_informative: Blok nie może zawierać adresu URL
-            unknown_for_city_instructional: Wprowadź prawidłowy blok dla miasta %{city}
-            unknown_for_city_informative: Blok jest nieprawidłowy dla miasta %{city}
-            unknown_for_zip_instructional: Wprowadź prawidłowy blok dla kodu pocztowego
-              %{zip}
-            unknown_for_zip_informative: Blok jest nieprawidłowy dla kodu pocztowego
-              %{zip}
+            blank_informative: Brak bloku
+            too_long_instructional: Nazwa bloku jest za długa (maksymalnie %{limit}
+              znaków)
+            too_long_informative: Nazwa bloku jest za długa
+            contains_emojis_instructional: Nazwa bloku nie może zawierać emoji
+            contains_emojis_informative: Nazwa bloku nie może zawierać emoji
+            contains_mathematical_symbols_instructional: Nazwa bloku nie może zawierać
+              symboli matematycznych
+            contains_mathematical_symbols_informative: Nazwa bloku nie może zawierać
+              symboli matematycznych
+            contains_restricted_characters_instructional: Nazwa bloku może zawierać
+              tylko litery, cyfry, znaki lokalne i znaki specjalne
+            contains_restricted_characters_informative: Nazwa bloku nie może zawierać
+              niedozwolonych znaków
+            contains_too_many_words_instructional: Liczba słów w nazwie bloku musi
+              być mniejsza niż %{word_count}
+            contains_too_many_words_informative: Liczba słów w nazwie bloku musi być
+              mniejsza niż %{word_count}
+            contains_html_tags_instructional: Nazwa bloku nie może zawierać kodu HTML
+            contains_html_tags_informative: Nazwa bloku nie może zawierać kodu HTML
+            contains_url_instructional: Nazwa bloku nie może zawierać adresu URL
+            contains_url_informative: Nazwa bloku nie może zawierać adresu URL
+            unknown_for_city_instructional: 'Wprowadź prawidłowy blok dla: %{city}'
+            unknown_for_city_informative: 'Blok jest nieprawidłowy dla: %{city}'
+            unknown_for_zip_instructional: 'Wprowadź prawidłowy blok dla: %{zip}'
+            unknown_for_zip_informative: 'Blok jest nieprawidłowy dla: %{zip}'
             unknown_for_address_instructional: Blok może być nieprawidłowy
             unknown_for_address_informative: Blok może być nieprawidłowy
           warnings:
-            contains_too_many_words: Zaleca się, aby blok zawierał mniej niż %{word_count}
-              słów
+            contains_too_many_words: Zaleca się, aby liczba słów w nazwie bloku była
+              mniejsza niż %{word_count}

--- a/data/regions/KW/pl.yml
+++ b/data/regions/KW/pl.yml
@@ -47,3 +47,41 @@ pl:
           warnings:
             contains_too_many_words: Zaleca się, aby blok zawierał mniej niż %{word_count}
               słów (słowa)
+        district:
+          label:
+            default: Blok
+            optional: Blok (opcjonalnie)
+          errors:
+            blank_instructional: Wprowadź blok
+            blank_informative: Brakuje bloku
+            too_long_instructional: Blok jest za długi (maksymalnie %{limit} znaków)
+            too_long_informative: Blok jest za długi
+            contains_emojis_instructional: Blok nie może zawierać emoji
+            contains_emojis_informative: Blok nie może zawierać emoji
+            contains_mathematical_symbols_instructional: Blok nie może zawierać symboli
+              matematycznych
+            contains_mathematical_symbols_informative: Blok nie może zawierać symboli
+              matematycznych
+            contains_restricted_characters_instructional: Blok może zawierać tylko
+              litery, cyfry, znaki lokalne i znaki specjalne
+            contains_restricted_characters_informative: Blok nie może zawierać niedozwolonych
+              znaków
+            contains_too_many_words_instructional: Blok musi zawierać mniej niż %{word_count}
+              słów
+            contains_too_many_words_informative: Blok musi zawierać mniej niż %{word_count}
+              słów
+            contains_html_tags_instructional: Blok nie może zawierać kodu HTML
+            contains_html_tags_informative: Blok nie może zawierać kodu HTML
+            contains_url_instructional: Blok nie może zawierać adresu URL
+            contains_url_informative: Blok nie może zawierać adresu URL
+            unknown_for_city_instructional: Wprowadź prawidłowy blok dla miasta %{city}
+            unknown_for_city_informative: Blok jest nieprawidłowy dla miasta %{city}
+            unknown_for_zip_instructional: Wprowadź prawidłowy blok dla kodu pocztowego
+              %{zip}
+            unknown_for_zip_informative: Blok jest nieprawidłowy dla kodu pocztowego
+              %{zip}
+            unknown_for_address_instructional: Blok może być nieprawidłowy
+            unknown_for_address_informative: Blok może być nieprawidłowy
+          warnings:
+            contains_too_many_words: Zaleca się, aby blok zawierał mniej niż %{word_count}
+              słów

--- a/data/regions/KW/pt-BR.yml
+++ b/data/regions/KW/pt-BR.yml
@@ -47,3 +47,40 @@ pt-BR:
           warnings:
             contains_too_many_words: É recomendável que o bloco tenha menos de %{word_count}
               palavras
+        district:
+          label:
+            default: Bloco
+            optional: Bloco (opcional)
+          errors:
+            blank_instructional: Insira um bloco
+            blank_informative: Falta o bloco
+            too_long_instructional: O bloco é muito longo (o máximo é de %{limit}
+              caracteres)
+            too_long_informative: O bloco é muito longo
+            contains_emojis_instructional: O bloco não pode conter emojis
+            contains_emojis_informative: O bloco não pode conter emojis
+            contains_mathematical_symbols_instructional: O bloco não pode conter símbolos
+              matemáticos
+            contains_mathematical_symbols_informative: O bloco não pode conter símbolos
+              matemáticos
+            contains_restricted_characters_instructional: O bloco só pode conter letras,
+              números, caracteres locais e caracteres especiais
+            contains_restricted_characters_informative: O bloco não pode conter caracteres
+              restritos
+            contains_too_many_words_instructional: O bloco deve ter menos de %{word_count}
+              palavras
+            contains_too_many_words_informative: O bloco deve ter menos de %{word_count}
+              palavras
+            contains_html_tags_instructional: O bloco não pode conter HTML
+            contains_html_tags_informative: O bloco não pode conter HTML
+            contains_url_instructional: O bloco não pode conter um URL
+            contains_url_informative: O bloco não pode conter um URL
+            unknown_for_city_instructional: Insira um bloco válido para %{city}
+            unknown_for_city_informative: O bloco não é válido para %{city}
+            unknown_for_zip_instructional: Insira um bloco válido para %{zip}
+            unknown_for_zip_informative: O bloco não é válido para %{zip}
+            unknown_for_address_instructional: O bloco pode estar incorreto
+            unknown_for_address_informative: O bloco pode estar incorreto
+          warnings:
+            contains_too_many_words: Recomenda-se que o bloco tenha menos de %{word_count}
+              palavras

--- a/data/regions/KW/pt-BR.yml
+++ b/data/regions/KW/pt-BR.yml
@@ -73,8 +73,8 @@ pt-BR:
               palavras
             contains_html_tags_instructional: O bloco não pode conter HTML
             contains_html_tags_informative: O bloco não pode conter HTML
-            contains_url_instructional: O bloco não pode conter um URL
-            contains_url_informative: O bloco não pode conter um URL
+            contains_url_instructional: O bloco não pode conter uma URL
+            contains_url_informative: O bloco não pode conter uma URL
             unknown_for_city_instructional: Insira um bloco válido para %{city}
             unknown_for_city_informative: O bloco não é válido para %{city}
             unknown_for_zip_instructional: Insira um bloco válido para %{zip}

--- a/data/regions/KW/pt-PT.yml
+++ b/data/regions/KW/pt-PT.yml
@@ -52,9 +52,9 @@ pt-PT:
             default: Bloco
             optional: Bloco (opcional)
           errors:
-            blank_instructional: Insira um bloco
-            blank_informative: Falta o bloco
-            too_long_instructional: O bloco é demasiado longo (o máximo é de %{limit}
+            blank_instructional: Introduza um bloco
+            blank_informative: O bloco está em falta
+            too_long_instructional: O bloco é demasiado longo (o máximo é %{limit}
               carateres)
             too_long_informative: O bloco é demasiado longo
             contains_emojis_instructional: O bloco não pode conter emojis
@@ -63,8 +63,8 @@ pt-PT:
               matemáticos
             contains_mathematical_symbols_informative: O bloco não pode conter símbolos
               matemáticos
-            contains_restricted_characters_instructional: O bloco apenas pode conter
-              letras, números, carateres locais e carateres especiais
+            contains_restricted_characters_instructional: O bloco só pode conter letras,
+              números, carateres locais e carateres especiais
             contains_restricted_characters_informative: O bloco não pode conter carateres
               restritos
             contains_too_many_words_instructional: O bloco tem de ter menos de %{word_count}
@@ -75,9 +75,9 @@ pt-PT:
             contains_html_tags_informative: O bloco não pode conter HTML
             contains_url_instructional: O bloco não pode conter um URL
             contains_url_informative: O bloco não pode conter um URL
-            unknown_for_city_instructional: Insira um bloco válido para %{city}
+            unknown_for_city_instructional: Introduza um bloco válido para %{city}
             unknown_for_city_informative: O bloco não é válido para %{city}
-            unknown_for_zip_instructional: Insira um bloco válido para %{zip}
+            unknown_for_zip_instructional: Introduza um bloco válido para %{zip}
             unknown_for_zip_informative: O bloco não é válido para %{zip}
             unknown_for_address_instructional: O bloco pode estar incorreto
             unknown_for_address_informative: O bloco pode estar incorreto

--- a/data/regions/KW/pt-PT.yml
+++ b/data/regions/KW/pt-PT.yml
@@ -47,3 +47,40 @@ pt-PT:
           warnings:
             contains_too_many_words: É recomendável que o bloco tenha menos de %{word_count}
               palavras
+        district:
+          label:
+            default: Bloco
+            optional: Bloco (opcional)
+          errors:
+            blank_instructional: Insira um bloco
+            blank_informative: Falta o bloco
+            too_long_instructional: O bloco é demasiado longo (o máximo é de %{limit}
+              carateres)
+            too_long_informative: O bloco é demasiado longo
+            contains_emojis_instructional: O bloco não pode conter emojis
+            contains_emojis_informative: O bloco não pode conter emojis
+            contains_mathematical_symbols_instructional: O bloco não pode conter símbolos
+              matemáticos
+            contains_mathematical_symbols_informative: O bloco não pode conter símbolos
+              matemáticos
+            contains_restricted_characters_instructional: O bloco apenas pode conter
+              letras, números, carateres locais e carateres especiais
+            contains_restricted_characters_informative: O bloco não pode conter carateres
+              restritos
+            contains_too_many_words_instructional: O bloco tem de ter menos de %{word_count}
+              palavras
+            contains_too_many_words_informative: O bloco tem de ter menos de %{word_count}
+              palavras
+            contains_html_tags_instructional: O bloco não pode conter HTML
+            contains_html_tags_informative: O bloco não pode conter HTML
+            contains_url_instructional: O bloco não pode conter um URL
+            contains_url_informative: O bloco não pode conter um URL
+            unknown_for_city_instructional: Insira um bloco válido para %{city}
+            unknown_for_city_informative: O bloco não é válido para %{city}
+            unknown_for_zip_instructional: Insira um bloco válido para %{zip}
+            unknown_for_zip_informative: O bloco não é válido para %{zip}
+            unknown_for_address_instructional: O bloco pode estar incorreto
+            unknown_for_address_informative: O bloco pode estar incorreto
+          warnings:
+            contains_too_many_words: Recomenda-se que o bloco tenha menos de %{word_count}
+              palavras

--- a/data/regions/KW/ro.yml
+++ b/data/regions/KW/ro.yml
@@ -60,38 +60,38 @@ ro:
               mai mult de %{word_count} cuvinte
         district:
           label:
-            default: Cartier
-            optional: Cartier (opțional)
+            default: Bloc
+            optional: Bloc (opțional)
           errors:
-            blank_instructional: Introduceți un cartier
-            blank_informative: Cartierul lipsește
-            too_long_instructional: Cartierul este prea lung (maximul este de %{limit}
+            blank_instructional: Introdu un bloc
+            blank_informative: Lipsește blocul
+            too_long_instructional: Blocul este prea lung (maximum este de %{limit}
               caractere)
-            too_long_informative: Cartierul este prea lung
-            contains_emojis_instructional: Cartierul nu poate conține emoji-uri
-            contains_emojis_informative: Cartierul nu poate conține emoji-uri
-            contains_mathematical_symbols_instructional: Cartierul nu poate conține
-              simboluri matematice
-            contains_mathematical_symbols_informative: Cartierul nu poate conține
-              simboluri matematice
-            contains_restricted_characters_instructional: Cartierul poate conține
-              doar litere, numere, caractere locale și caractere speciale
-            contains_restricted_characters_informative: Cartierul nu poate conține
-              caractere restricționate
-            contains_too_many_words_instructional: Cartierul trebuie să aibă mai puțin
+            too_long_informative: Blocul este prea lung
+            contains_emojis_instructional: Blocul nu poate conține emoji-uri
+            contains_emojis_informative: Blocul nu poate conține emoji-uri
+            contains_mathematical_symbols_instructional: Blocul nu poate conține simboluri
+              matematice
+            contains_mathematical_symbols_informative: Blocul nu poate conține simboluri
+              matematice
+            contains_restricted_characters_instructional: Blocul poate conține doar
+              litere, cifre, caractere locale și caractere speciale
+            contains_restricted_characters_informative: Blocul nu poate conține caractere
+              restricționate
+            contains_too_many_words_instructional: Blocul trebuie să aibă mai puțin
               de %{word_count} cuvinte
-            contains_too_many_words_informative: Cartierul trebuie să aibă mai puțin
+            contains_too_many_words_informative: Blocul trebuie să aibă mai puțin
               de %{word_count} cuvinte
-            contains_html_tags_instructional: Cartierul nu poate conține HTML
-            contains_html_tags_informative: Cartierul nu poate conține HTML
-            contains_url_instructional: Cartierul nu poate conține un URL
-            contains_url_informative: Cartierul nu poate conține un URL
-            unknown_for_city_instructional: Introduceți un cartier valid pentru %{city}
-            unknown_for_city_informative: Cartierul nu este valid pentru %{city}
-            unknown_for_zip_instructional: Introduceți un cartier valid pentru %{zip}
-            unknown_for_zip_informative: Cartierul nu este valid pentru %{zip}
-            unknown_for_address_instructional: Cartierul poate fi incorect
-            unknown_for_address_informative: Cartierul poate fi incorect
+            contains_html_tags_instructional: Blocul nu poate conține HTML
+            contains_html_tags_informative: Blocul nu poate conține HTML
+            contains_url_instructional: Blocul nu poate conține un URL
+            contains_url_informative: Blocul nu poate conține un URL
+            unknown_for_city_instructional: Introdu un bloc valid pentru %{city}
+            unknown_for_city_informative: Blocul nu este valid pentru %{city}
+            unknown_for_zip_instructional: Introdu un bloc valid pentru %{zip}
+            unknown_for_zip_informative: Blocul nu este valid pentru %{zip}
+            unknown_for_address_instructional: Este posibil ca blocul să fie incorect
+            unknown_for_address_informative: Este posibil ca blocul să fie incorect
           warnings:
-            contains_too_many_words: Se recomandă ca acest cartier să aibă mai puțin
-              de %{word_count} cuvinte
+            contains_too_many_words: Se recomandă ca blocul să aibă mai puțin de %{word_count}
+              cuvinte

--- a/data/regions/KW/ro.yml
+++ b/data/regions/KW/ro.yml
@@ -58,3 +58,40 @@ ro:
           warnings:
             contains_too_many_words: Se recomandă ca denumirea cvartalului să nu aibă
               mai mult de %{word_count} cuvinte
+        district:
+          label:
+            default: Cartier
+            optional: Cartier (opțional)
+          errors:
+            blank_instructional: Introduceți un cartier
+            blank_informative: Cartierul lipsește
+            too_long_instructional: Cartierul este prea lung (maximul este de %{limit}
+              caractere)
+            too_long_informative: Cartierul este prea lung
+            contains_emojis_instructional: Cartierul nu poate conține emoji-uri
+            contains_emojis_informative: Cartierul nu poate conține emoji-uri
+            contains_mathematical_symbols_instructional: Cartierul nu poate conține
+              simboluri matematice
+            contains_mathematical_symbols_informative: Cartierul nu poate conține
+              simboluri matematice
+            contains_restricted_characters_instructional: Cartierul poate conține
+              doar litere, numere, caractere locale și caractere speciale
+            contains_restricted_characters_informative: Cartierul nu poate conține
+              caractere restricționate
+            contains_too_many_words_instructional: Cartierul trebuie să aibă mai puțin
+              de %{word_count} cuvinte
+            contains_too_many_words_informative: Cartierul trebuie să aibă mai puțin
+              de %{word_count} cuvinte
+            contains_html_tags_instructional: Cartierul nu poate conține HTML
+            contains_html_tags_informative: Cartierul nu poate conține HTML
+            contains_url_instructional: Cartierul nu poate conține un URL
+            contains_url_informative: Cartierul nu poate conține un URL
+            unknown_for_city_instructional: Introduceți un cartier valid pentru %{city}
+            unknown_for_city_informative: Cartierul nu este valid pentru %{city}
+            unknown_for_zip_instructional: Introduceți un cartier valid pentru %{zip}
+            unknown_for_zip_informative: Cartierul nu este valid pentru %{zip}
+            unknown_for_address_instructional: Cartierul poate fi incorect
+            unknown_for_address_informative: Cartierul poate fi incorect
+          warnings:
+            contains_too_many_words: Se recomandă ca acest cartier să aibă mai puțin
+              de %{word_count} cuvinte

--- a/data/regions/KW/ru.yml
+++ b/data/regions/KW/ru.yml
@@ -52,41 +52,38 @@ ru:
               не более %{word_count} сл.
         district:
           label:
-            default: Квартал
-            optional: Квартал (необязательно)
+            default: Блок
+            optional: Блок (необязательно)
           errors:
-            blank_instructional: Введите квартал
-            blank_informative: Квартал не указан
-            too_long_instructional: Название квартала слишком длинное (максимум %{limit}
+            blank_instructional: Введите блок
+            blank_informative: Не указан блок
+            too_long_instructional: Название блока слишком длинное (максимум %{limit}
               символов)
-            too_long_informative: Название квартала слишком длинное
-            contains_emojis_instructional: Название квартала не может содержать эмодзи
-            contains_emojis_informative: Название квартала не может содержать эмодзи
-            contains_mathematical_symbols_instructional: Название квартала не может
-              содержать математические символы
-            contains_mathematical_symbols_informative: Название квартала не может
-              содержать математические символы
-            contains_restricted_characters_instructional: Название квартала может
-              содержать только буквы, цифры, символы местного алфавита и специальные
-              символы
-            contains_restricted_characters_informative: Название квартала не может
-              содержать недопустимые символы
-            contains_too_many_words_instructional: Название квартала должно содержать
+            too_long_informative: Название блока слишком длинное
+            contains_emojis_instructional: Название блока не может содержать эмодзи
+            contains_emojis_informative: Название блока не может содержать эмодзи
+            contains_mathematical_symbols_instructional: Название блока не может содержать
+              математические символы
+            contains_mathematical_symbols_informative: Название блока не может содержать
+              математические символы
+            contains_restricted_characters_instructional: Название блока может содержать
+              только буквы, цифры, местные и специальные символы
+            contains_restricted_characters_informative: Название блока не может содержать
+              запрещенные символы
+            contains_too_many_words_instructional: Название блока должно содержать
               менее %{word_count} слов
-            contains_too_many_words_informative: Название квартала должно содержать
-              менее %{word_count} слов
-            contains_html_tags_instructional: Название квартала не может содержать
-              HTML
-            contains_html_tags_informative: Название квартала не может содержать HTML
-            contains_url_instructional: Название квартала не может содержать URL
-            contains_url_informative: Название квартала не может содержать URL
-            unknown_for_city_instructional: Введите правильный квартал для %{city}
-            unknown_for_city_informative: Неверный квартал для %{city}
-            unknown_for_zip_instructional: Введите правильный квартал для почтового
-              индекса %{zip}
-            unknown_for_zip_informative: Неверный квартал для почтового индекса %{zip}
-            unknown_for_address_instructional: Возможно, квартал указан неверно
-            unknown_for_address_informative: Возможно, квартал указан неверно
+            contains_too_many_words_informative: Название блока должно содержать менее
+              %{word_count} слов
+            contains_html_tags_instructional: Название блока не может содержать HTML
+            contains_html_tags_informative: Название блока не может содержать HTML
+            contains_url_instructional: Название блока не может содержать URL
+            contains_url_informative: Название блока не может содержать URL
+            unknown_for_city_instructional: Введите правильный блок для города %{city}
+            unknown_for_city_informative: Недействительный блок для города %{city}
+            unknown_for_zip_instructional: Введите правильный блок для индекса %{zip}
+            unknown_for_zip_informative: Недействительный блок для индекса %{zip}
+            unknown_for_address_instructional: Возможно, блок указан неверно
+            unknown_for_address_informative: Возможно, блок указан неверно
           warnings:
-            contains_too_many_words: Рекомендуется, чтобы название квартала содержало
+            contains_too_many_words: Рекомендуется, чтобы название блока содержало
               менее %{word_count} слов

--- a/data/regions/KW/ru.yml
+++ b/data/regions/KW/ru.yml
@@ -50,3 +50,43 @@ ru:
           warnings:
             contains_too_many_words: Рекомендуем указывать в поле названия района
               не более %{word_count} сл.
+        district:
+          label:
+            default: Квартал
+            optional: Квартал (необязательно)
+          errors:
+            blank_instructional: Введите квартал
+            blank_informative: Квартал не указан
+            too_long_instructional: Название квартала слишком длинное (максимум %{limit}
+              символов)
+            too_long_informative: Название квартала слишком длинное
+            contains_emojis_instructional: Название квартала не может содержать эмодзи
+            contains_emojis_informative: Название квартала не может содержать эмодзи
+            contains_mathematical_symbols_instructional: Название квартала не может
+              содержать математические символы
+            contains_mathematical_symbols_informative: Название квартала не может
+              содержать математические символы
+            contains_restricted_characters_instructional: Название квартала может
+              содержать только буквы, цифры, символы местного алфавита и специальные
+              символы
+            contains_restricted_characters_informative: Название квартала не может
+              содержать недопустимые символы
+            contains_too_many_words_instructional: Название квартала должно содержать
+              менее %{word_count} слов
+            contains_too_many_words_informative: Название квартала должно содержать
+              менее %{word_count} слов
+            contains_html_tags_instructional: Название квартала не может содержать
+              HTML
+            contains_html_tags_informative: Название квартала не может содержать HTML
+            contains_url_instructional: Название квартала не может содержать URL
+            contains_url_informative: Название квартала не может содержать URL
+            unknown_for_city_instructional: Введите правильный квартал для %{city}
+            unknown_for_city_informative: Неверный квартал для %{city}
+            unknown_for_zip_instructional: Введите правильный квартал для почтового
+              индекса %{zip}
+            unknown_for_zip_informative: Неверный квартал для почтового индекса %{zip}
+            unknown_for_address_instructional: Возможно, квартал указан неверно
+            unknown_for_address_informative: Возможно, квартал указан неверно
+          warnings:
+            contains_too_many_words: Рекомендуется, чтобы название квартала содержало
+              менее %{word_count} слов

--- a/data/regions/KW/sk.yml
+++ b/data/regions/KW/sk.yml
@@ -49,7 +49,7 @@ sk:
         district:
           label:
             default: Blok
-            optional: Blok (nepovinné)
+            optional: Blok (voliteľné)
           errors:
             blank_instructional: Zadajte blok
             blank_informative: Chýba blok
@@ -61,18 +61,18 @@ sk:
               symboly
             contains_mathematical_symbols_informative: Blok nemôže obsahovať matematické
               symboly
-            contains_restricted_characters_instructional: Blok môže obsahovať iba
-              písmená, číslice, lokálne znaky a špeciálne znaky
+            contains_restricted_characters_instructional: Blok môže obsahovať len
+              písmená, číslice, lokálne a špeciálne znaky
             contains_restricted_characters_informative: Blok nemôže obsahovať nepovolené
               znaky
-            contains_too_many_words_instructional: Blok musí obsahovať menej ako %{word_count}
+            contains_too_many_words_instructional: Blok musí mať menej ako %{word_count}
               slov
-            contains_too_many_words_informative: Blok musí obsahovať menej ako %{word_count}
+            contains_too_many_words_informative: Blok musí mať menej ako %{word_count}
               slov
             contains_html_tags_instructional: Blok nemôže obsahovať HTML
             contains_html_tags_informative: Blok nemôže obsahovať HTML
-            contains_url_instructional: Blok nemôže obsahovať URL adresu
-            contains_url_informative: Blok nemôže obsahovať URL adresu
+            contains_url_instructional: Blok nemôže obsahovať adresu URL
+            contains_url_informative: Blok nemôže obsahovať adresu URL
             unknown_for_city_instructional: Zadajte platný blok pre %{city}
             unknown_for_city_informative: Blok nie je platný pre %{city}
             unknown_for_zip_instructional: Zadajte platný blok pre %{zip}
@@ -80,5 +80,5 @@ sk:
             unknown_for_address_instructional: Blok môže byť nesprávny
             unknown_for_address_informative: Blok môže byť nesprávny
           warnings:
-            contains_too_many_words: Odporúča sa, aby blok obsahoval menej ako %{word_count}
+            contains_too_many_words: Odporúča sa, aby blok mal menej ako %{word_count}
               slov

--- a/data/regions/KW/sk.yml
+++ b/data/regions/KW/sk.yml
@@ -46,3 +46,39 @@ sk:
           warnings:
             contains_too_many_words: 'Blok by nemal mať viac ako tento počet slov:
               %{word_count}'
+        district:
+          label:
+            default: Blok
+            optional: Blok (nepovinné)
+          errors:
+            blank_instructional: Zadajte blok
+            blank_informative: Chýba blok
+            too_long_instructional: Blok je príliš dlhý (maximum je %{limit} znakov)
+            too_long_informative: Blok je príliš dlhý
+            contains_emojis_instructional: Blok nemôže obsahovať emoji
+            contains_emojis_informative: Blok nemôže obsahovať emoji
+            contains_mathematical_symbols_instructional: Blok nemôže obsahovať matematické
+              symboly
+            contains_mathematical_symbols_informative: Blok nemôže obsahovať matematické
+              symboly
+            contains_restricted_characters_instructional: Blok môže obsahovať iba
+              písmená, číslice, lokálne znaky a špeciálne znaky
+            contains_restricted_characters_informative: Blok nemôže obsahovať nepovolené
+              znaky
+            contains_too_many_words_instructional: Blok musí obsahovať menej ako %{word_count}
+              slov
+            contains_too_many_words_informative: Blok musí obsahovať menej ako %{word_count}
+              slov
+            contains_html_tags_instructional: Blok nemôže obsahovať HTML
+            contains_html_tags_informative: Blok nemôže obsahovať HTML
+            contains_url_instructional: Blok nemôže obsahovať URL adresu
+            contains_url_informative: Blok nemôže obsahovať URL adresu
+            unknown_for_city_instructional: Zadajte platný blok pre %{city}
+            unknown_for_city_informative: Blok nie je platný pre %{city}
+            unknown_for_zip_instructional: Zadajte platný blok pre %{zip}
+            unknown_for_zip_informative: Blok nie je platný pre %{zip}
+            unknown_for_address_instructional: Blok môže byť nesprávny
+            unknown_for_address_informative: Blok môže byť nesprávny
+          warnings:
+            contains_too_many_words: Odporúča sa, aby blok obsahoval menej ako %{word_count}
+              slov

--- a/data/regions/KW/sl.yml
+++ b/data/regions/KW/sl.yml
@@ -56,7 +56,8 @@ sl:
           errors:
             blank_instructional: Vnesite blok
             blank_informative: Manjka blok
-            too_long_instructional: Blok je predolg (največ %{limit} znakov)
+            too_long_instructional: Blok je predolg (dovoljenih je največ %{limit}
+              znakov)
             too_long_informative: Blok je predolg
             contains_emojis_instructional: Blok ne sme vsebovati emodžijev
             contains_emojis_informative: Blok ne sme vsebovati emodžijev
@@ -64,24 +65,25 @@ sl:
               simbolov
             contains_mathematical_symbols_informative: Blok ne sme vsebovati matematičnih
               simbolov
-            contains_restricted_characters_instructional: Blok lahko vsebuje samo
-              črke, številke, lokalne znake in posebne znake
+            contains_restricted_characters_instructional: Blok lahko vsebuje le črke,
+              številke, lokalne znake in posebne znake
             contains_restricted_characters_informative: Blok ne sme vsebovati nedovoljenih
               znakov
-            contains_too_many_words_instructional: Število besed za blok mora biti
-              manjše od %{word_count}
-            contains_too_many_words_informative: Število besed za blok mora biti manjše
-              od %{word_count}
+            contains_too_many_words_instructional: Blok mora vsebovati manj kot %{word_count}
+              besed
+            contains_too_many_words_informative: Blok mora vsebovati manj kot %{word_count}
+              besed
             contains_html_tags_instructional: Blok ne sme vsebovati kode HTML
             contains_html_tags_informative: Blok ne sme vsebovati kode HTML
             contains_url_instructional: Blok ne sme vsebovati URL-naslova
             contains_url_informative: Blok ne sme vsebovati URL-naslova
-            unknown_for_city_instructional: Vnesite veljaven blok za %{city}
-            unknown_for_city_informative: Blok ni veljaven za %{city}
-            unknown_for_zip_instructional: Vnesite veljaven blok za %{zip}
-            unknown_for_zip_informative: Blok ni veljaven za %{zip}
+            unknown_for_city_instructional: Vnesite veljaven blok za mesto %{city}
+            unknown_for_city_informative: Blok ni veljaven za mesto %{city}
+            unknown_for_zip_instructional: Vnesite veljaven blok za poštno številko
+              %{zip}
+            unknown_for_zip_informative: Blok ni veljaven za poštno številko %{zip}
             unknown_for_address_instructional: Blok je morda napačen
             unknown_for_address_informative: Blok je morda napačen
           warnings:
-            contains_too_many_words: Priporočljivo je, da je število besed za blok
-              manjše od %{word_count}
+            contains_too_many_words: Priporočamo, da blok vsebuje manj kot %{word_count}
+              besed

--- a/data/regions/KW/sl.yml
+++ b/data/regions/KW/sl.yml
@@ -49,3 +49,39 @@ sl:
           warnings:
             contains_too_many_words: Ime ulice naj ne vsebuje več kot %{word_count}
               besed
+        district:
+          label:
+            default: Blok
+            optional: Blok (izbirno)
+          errors:
+            blank_instructional: Vnesite blok
+            blank_informative: Manjka blok
+            too_long_instructional: Blok je predolg (največ %{limit} znakov)
+            too_long_informative: Blok je predolg
+            contains_emojis_instructional: Blok ne sme vsebovati emodžijev
+            contains_emojis_informative: Blok ne sme vsebovati emodžijev
+            contains_mathematical_symbols_instructional: Blok ne sme vsebovati matematičnih
+              simbolov
+            contains_mathematical_symbols_informative: Blok ne sme vsebovati matematičnih
+              simbolov
+            contains_restricted_characters_instructional: Blok lahko vsebuje samo
+              črke, številke, lokalne znake in posebne znake
+            contains_restricted_characters_informative: Blok ne sme vsebovati nedovoljenih
+              znakov
+            contains_too_many_words_instructional: Število besed za blok mora biti
+              manjše od %{word_count}
+            contains_too_many_words_informative: Število besed za blok mora biti manjše
+              od %{word_count}
+            contains_html_tags_instructional: Blok ne sme vsebovati kode HTML
+            contains_html_tags_informative: Blok ne sme vsebovati kode HTML
+            contains_url_instructional: Blok ne sme vsebovati URL-naslova
+            contains_url_informative: Blok ne sme vsebovati URL-naslova
+            unknown_for_city_instructional: Vnesite veljaven blok za %{city}
+            unknown_for_city_informative: Blok ni veljaven za %{city}
+            unknown_for_zip_instructional: Vnesite veljaven blok za %{zip}
+            unknown_for_zip_informative: Blok ni veljaven za %{zip}
+            unknown_for_address_instructional: Blok je morda napačen
+            unknown_for_address_informative: Blok je morda napačen
+          warnings:
+            contains_too_many_words: Priporočljivo je, da je število besed za blok
+              manjše od %{word_count}

--- a/data/regions/KW/sv.yml
+++ b/data/regions/KW/sv.yml
@@ -53,31 +53,32 @@ sv:
           errors:
             blank_instructional: Ange ett kvarter
             blank_informative: Kvarter saknas
-            too_long_instructional: Kvarter är för långt (högst %{limit} tecken)
-            too_long_informative: Kvarter är för långt
-            contains_emojis_instructional: Kvarter får inte innehålla emojis
-            contains_emojis_informative: Kvarter får inte innehålla emojis
-            contains_mathematical_symbols_instructional: Kvarter får inte innehålla
+            too_long_instructional: Kvarteret är för långt (max %{limit} tecken)
+            too_long_informative: Kvarteret är för långt
+            contains_emojis_instructional: Kvarteret kan inte innehålla emojis
+            contains_emojis_informative: Kvarteret kan inte innehålla emojis
+            contains_mathematical_symbols_instructional: Kvarteret kan inte innehålla
               matematiska symboler
-            contains_mathematical_symbols_informative: Kvarter får inte innehålla
+            contains_mathematical_symbols_informative: Kvarteret kan inte innehålla
               matematiska symboler
-            contains_restricted_characters_instructional: Kvarter får endast innehålla
+            contains_restricted_characters_instructional: Kvarteret kan endast innehålla
               bokstäver, siffror, lokala tecken och specialtecken
-            contains_restricted_characters_informative: Kvarter får inte innehålla
+            contains_restricted_characters_informative: Kvarteret kan inte innehålla
               otillåtna tecken
-            contains_too_many_words_instructional: Kvarter måste ha färre än %{word_count}
+            contains_too_many_words_instructional: Kvarteret måste ha färre än %{word_count}
               ord
-            contains_too_many_words_informative: Kvarter måste ha färre än %{word_count}
+            contains_too_many_words_informative: Kvarteret måste ha färre än %{word_count}
               ord
-            contains_html_tags_instructional: Kvarter får inte innehålla HTML
-            contains_html_tags_informative: Kvarter får inte innehålla HTML
-            contains_url_instructional: Kvarter får inte innehålla en URL
-            contains_url_informative: Kvarter får inte innehålla en URL
+            contains_html_tags_instructional: Kvarteret kan inte innehålla HTML
+            contains_html_tags_informative: Kvarteret kan inte innehålla HTML
+            contains_url_instructional: Kvarteret kan inte innehålla en URL
+            contains_url_informative: Kvarteret kan inte innehålla en URL
             unknown_for_city_instructional: Ange ett giltigt kvarter för %{city}
-            unknown_for_city_informative: Kvarter är inte giltigt för %{city}
+            unknown_for_city_informative: Kvarteret är inte giltigt för %{city}
             unknown_for_zip_instructional: Ange ett giltigt kvarter för %{zip}
-            unknown_for_zip_informative: Kvarter är inte giltigt för %{zip}
-            unknown_for_address_instructional: Kvarter kan vara felaktigt
-            unknown_for_address_informative: Kvarter kan vara felaktigt
+            unknown_for_zip_informative: Kvarteret är inte giltigt för %{zip}
+            unknown_for_address_instructional: Kvarteret kan vara felaktigt
+            unknown_for_address_informative: Kvarteret kan vara felaktigt
           warnings:
-            contains_too_many_words: Kvarter bör ha färre än %{word_count} ord
+            contains_too_many_words: Kvarteret rekommenderas ha färre än %{word_count}
+              ord

--- a/data/regions/KW/sv.yml
+++ b/data/regions/KW/sv.yml
@@ -46,3 +46,38 @@ sv:
           warnings:
             contains_too_many_words: Vi rekommenderar att blocket består av färre
               än %{word_count} ord
+        district:
+          label:
+            default: Kvarter
+            optional: Kvarter (valfritt)
+          errors:
+            blank_instructional: Ange ett kvarter
+            blank_informative: Kvarter saknas
+            too_long_instructional: Kvarter är för långt (högst %{limit} tecken)
+            too_long_informative: Kvarter är för långt
+            contains_emojis_instructional: Kvarter får inte innehålla emojis
+            contains_emojis_informative: Kvarter får inte innehålla emojis
+            contains_mathematical_symbols_instructional: Kvarter får inte innehålla
+              matematiska symboler
+            contains_mathematical_symbols_informative: Kvarter får inte innehålla
+              matematiska symboler
+            contains_restricted_characters_instructional: Kvarter får endast innehålla
+              bokstäver, siffror, lokala tecken och specialtecken
+            contains_restricted_characters_informative: Kvarter får inte innehålla
+              otillåtna tecken
+            contains_too_many_words_instructional: Kvarter måste ha färre än %{word_count}
+              ord
+            contains_too_many_words_informative: Kvarter måste ha färre än %{word_count}
+              ord
+            contains_html_tags_instructional: Kvarter får inte innehålla HTML
+            contains_html_tags_informative: Kvarter får inte innehålla HTML
+            contains_url_instructional: Kvarter får inte innehålla en URL
+            contains_url_informative: Kvarter får inte innehålla en URL
+            unknown_for_city_instructional: Ange ett giltigt kvarter för %{city}
+            unknown_for_city_informative: Kvarter är inte giltigt för %{city}
+            unknown_for_zip_instructional: Ange ett giltigt kvarter för %{zip}
+            unknown_for_zip_informative: Kvarter är inte giltigt för %{zip}
+            unknown_for_address_instructional: Kvarter kan vara felaktigt
+            unknown_for_address_informative: Kvarter kan vara felaktigt
+          warnings:
+            contains_too_many_words: Kvarter bör ha färre än %{word_count} ord

--- a/data/regions/KW/th.yml
+++ b/data/regions/KW/th.yml
@@ -47,9 +47,9 @@ th:
             default: บล็อก
             optional: บล็อก (ไม่บังคับ)
           errors:
-            blank_instructional: โปรดระบุบล็อก
-            blank_informative: ไม่มีบล็อก
-            too_long_instructional: บล็อกยาวเกินไป (สูงสุด %{limit} อักขระ)
+            blank_instructional: โปรดป้อนบล็อก
+            blank_informative: ไม่ได้ระบุบล็อก
+            too_long_instructional: บล็อกยาวเกินไป (สูงสุด %{limit} ตัวอักษร)
             too_long_informative: บล็อกยาวเกินไป
             contains_emojis_instructional: บล็อกต้องไม่มีอีโมจิ
             contains_emojis_informative: บล็อกต้องไม่มีอีโมจิ
@@ -66,9 +66,9 @@ th:
             contains_html_tags_informative: บล็อกต้องไม่มี HTML
             contains_url_instructional: บล็อกต้องไม่มี URL
             contains_url_informative: บล็อกต้องไม่มี URL
-            unknown_for_city_instructional: โปรดระบุบล็อกที่ถูกต้องสำหรับ %{city}
+            unknown_for_city_instructional: โปรดป้อนบล็อกที่ถูกต้องสำหรับ %{city}
             unknown_for_city_informative: บล็อกไม่ถูกต้องสำหรับ %{city}
-            unknown_for_zip_instructional: โปรดระบุบล็อกที่ถูกต้องสำหรับ %{zip}
+            unknown_for_zip_instructional: โปรดป้อนบล็อกที่ถูกต้องสำหรับ %{zip}
             unknown_for_zip_informative: บล็อกไม่ถูกต้องสำหรับ %{zip}
             unknown_for_address_instructional: บล็อกอาจไม่ถูกต้อง
             unknown_for_address_informative: บล็อกอาจไม่ถูกต้อง

--- a/data/regions/KW/th.yml
+++ b/data/regions/KW/th.yml
@@ -42,3 +42,35 @@ th:
             unknown_for_address_informative: ชื่อบล็อกอาจไม่ถูกต้อง
           warnings:
             contains_too_many_words: ชื่อบล็อกควรมีความยาวน้อยกว่า %{word_count} คำ
+        district:
+          label:
+            default: บล็อก
+            optional: บล็อก (ไม่บังคับ)
+          errors:
+            blank_instructional: โปรดระบุบล็อก
+            blank_informative: ไม่มีบล็อก
+            too_long_instructional: บล็อกยาวเกินไป (สูงสุด %{limit} อักขระ)
+            too_long_informative: บล็อกยาวเกินไป
+            contains_emojis_instructional: บล็อกต้องไม่มีอีโมจิ
+            contains_emojis_informative: บล็อกต้องไม่มีอีโมจิ
+            contains_mathematical_symbols_instructional: บล็อกต้องไม่มีสัญลักษณ์ทางคณิตศาสตร์
+            contains_mathematical_symbols_informative: บล็อกต้องไม่มีสัญลักษณ์ทางคณิตศาสตร์
+            contains_restricted_characters_instructional: บล็อกต้องมีเฉพาะตัวอักษร
+              ตัวเลข ตัวอักษรท้องถิ่น และอักขระพิเศษเท่านั้น
+            contains_restricted_characters_informative: บล็อกต้องไม่มีอักขระที่ถูกจำกัด
+            contains_too_many_words_instructional: บล็อกต้องมีน้อยกว่า %{word_count}
+              คำ
+            contains_too_many_words_informative: บล็อกต้องมีน้อยกว่า %{word_count}
+              คำ
+            contains_html_tags_instructional: บล็อกต้องไม่มี HTML
+            contains_html_tags_informative: บล็อกต้องไม่มี HTML
+            contains_url_instructional: บล็อกต้องไม่มี URL
+            contains_url_informative: บล็อกต้องไม่มี URL
+            unknown_for_city_instructional: โปรดระบุบล็อกที่ถูกต้องสำหรับ %{city}
+            unknown_for_city_informative: บล็อกไม่ถูกต้องสำหรับ %{city}
+            unknown_for_zip_instructional: โปรดระบุบล็อกที่ถูกต้องสำหรับ %{zip}
+            unknown_for_zip_informative: บล็อกไม่ถูกต้องสำหรับ %{zip}
+            unknown_for_address_instructional: บล็อกอาจไม่ถูกต้อง
+            unknown_for_address_informative: บล็อกอาจไม่ถูกต้อง
+          warnings:
+            contains_too_many_words: ขอแนะนำให้บล็อกมีน้อยกว่า %{word_count} คำ

--- a/data/regions/KW/tr.yml
+++ b/data/regions/KW/tr.yml
@@ -54,7 +54,7 @@ tr:
           errors:
             blank_instructional: Bir blok girin
             blank_informative: Blok eksik
-            too_long_instructional: Blok çok uzun (en fazla %{limit} karakter)
+            too_long_instructional: Blok çok uzun (maksimum %{limit} karakter)
             too_long_informative: Blok çok uzun
             contains_emojis_instructional: Blok emoji içeremez
             contains_emojis_informative: Blok emoji içeremez

--- a/data/regions/KW/tr.yml
+++ b/data/regions/KW/tr.yml
@@ -47,3 +47,37 @@ tr:
           warnings:
             contains_too_many_words: Blok adında %{word_count} adetten az sözcük olması
               önerilir
+        district:
+          label:
+            default: Blok
+            optional: Blok (isteğe bağlı)
+          errors:
+            blank_instructional: Bir blok girin
+            blank_informative: Blok eksik
+            too_long_instructional: Blok çok uzun (en fazla %{limit} karakter)
+            too_long_informative: Blok çok uzun
+            contains_emojis_instructional: Blok emoji içeremez
+            contains_emojis_informative: Blok emoji içeremez
+            contains_mathematical_symbols_instructional: Blok matematiksel semboller
+              içeremez
+            contains_mathematical_symbols_informative: Blok matematiksel semboller
+              içeremez
+            contains_restricted_characters_instructional: Blok yalnızca harf, sayı,
+              yerel karakter ve özel karakter içerebilir
+            contains_restricted_characters_informative: Blok kısıtlanmış karakterler
+              içeremez
+            contains_too_many_words_instructional: Blok %{word_count} kelimeden az
+              olmalıdır
+            contains_too_many_words_informative: Blok %{word_count} kelimeden az olmalıdır
+            contains_html_tags_instructional: Blok HTML içeremez
+            contains_html_tags_informative: Blok HTML içeremez
+            contains_url_instructional: Blok URL içeremez
+            contains_url_informative: Blok URL içeremez
+            unknown_for_city_instructional: "%{city} için geçerli bir blok girin"
+            unknown_for_city_informative: Blok %{city} için geçerli değil
+            unknown_for_zip_instructional: "%{zip} için geçerli bir blok girin"
+            unknown_for_zip_informative: Blok %{zip} için geçerli değil
+            unknown_for_address_instructional: Blok yanlış olabilir
+            unknown_for_address_informative: Blok yanlış olabilir
+          warnings:
+            contains_too_many_words: Bloğun %{word_count} kelimeden az olması önerilir

--- a/data/regions/KW/vi.yml
+++ b/data/regions/KW/vi.yml
@@ -54,14 +54,14 @@ vi:
             blank_informative: Thiếu khu
             too_long_instructional: Khu quá dài (tối đa %{limit} ký tự)
             too_long_informative: Khu quá dài
-            contains_emojis_instructional: Khu không được chứa emoji
-            contains_emojis_informative: Khu không được chứa emoji
+            contains_emojis_instructional: Khu không được chứa biểu tượng cảm xúc
+            contains_emojis_informative: Khu không được chứa biểu tượng cảm xúc
             contains_mathematical_symbols_instructional: Khu không được chứa ký hiệu
               toán học
             contains_mathematical_symbols_informative: Khu không được chứa ký hiệu
               toán học
-            contains_restricted_characters_instructional: Khu chỉ được chứa chữ cái,
-              chữ số, ký tự địa phương và ký tự đặc biệt
+            contains_restricted_characters_instructional: Khu chỉ có thể chứa chữ
+              cái, số, ký tự địa phương và ký tự đặc biệt
             contains_restricted_characters_informative: Khu không được chứa ký tự
               bị hạn chế
             contains_too_many_words_instructional: Khu phải có ít hơn %{word_count}

--- a/data/regions/KW/vi.yml
+++ b/data/regions/KW/vi.yml
@@ -45,3 +45,38 @@ vi:
             unknown_for_address_informative: Khối có thể không chính xác
           warnings:
             contains_too_many_words: Khối nên có tối đa %{word_count} từ
+        district:
+          label:
+            default: Khu
+            optional: Khu (tùy chọn)
+          errors:
+            blank_instructional: Nhập khu
+            blank_informative: Thiếu khu
+            too_long_instructional: Khu quá dài (tối đa %{limit} ký tự)
+            too_long_informative: Khu quá dài
+            contains_emojis_instructional: Khu không được chứa emoji
+            contains_emojis_informative: Khu không được chứa emoji
+            contains_mathematical_symbols_instructional: Khu không được chứa ký hiệu
+              toán học
+            contains_mathematical_symbols_informative: Khu không được chứa ký hiệu
+              toán học
+            contains_restricted_characters_instructional: Khu chỉ được chứa chữ cái,
+              chữ số, ký tự địa phương và ký tự đặc biệt
+            contains_restricted_characters_informative: Khu không được chứa ký tự
+              bị hạn chế
+            contains_too_many_words_instructional: Khu phải có ít hơn %{word_count}
+              từ
+            contains_too_many_words_informative: Khu phải có ít hơn %{word_count}
+              từ
+            contains_html_tags_instructional: Khu không được chứa HTML
+            contains_html_tags_informative: Khu không được chứa HTML
+            contains_url_instructional: Khu không được chứa URL
+            contains_url_informative: Khu không được chứa URL
+            unknown_for_city_instructional: Nhập khu hợp lệ cho %{city}
+            unknown_for_city_informative: Khu không hợp lệ cho %{city}
+            unknown_for_zip_instructional: Nhập khu hợp lệ cho %{zip}
+            unknown_for_zip_informative: Khu không hợp lệ cho %{zip}
+            unknown_for_address_instructional: Khu có thể không chính xác
+            unknown_for_address_informative: Khu có thể không chính xác
+          warnings:
+            contains_too_many_words: Khu nên có ít hơn %{word_count} từ

--- a/data/regions/KW/zh-CN.yml
+++ b/data/regions/KW/zh-CN.yml
@@ -39,3 +39,32 @@ zh-CN:
             unknown_for_address_informative: 街区可能不正确
           warnings:
             contains_too_many_words: 建议街区少于 %{word_count} 个字词
+        district:
+          label:
+            default: 街区
+            optional: 街区（可选）
+          errors:
+            blank_instructional: 输入街区
+            blank_informative: 缺少街区
+            too_long_instructional: 街区名称过长（最多 %{limit} 个字符）
+            too_long_informative: 街区名称过长
+            contains_emojis_instructional: 街区不能包含表情符号
+            contains_emojis_informative: 街区不能包含表情符号
+            contains_mathematical_symbols_instructional: 街区不能包含数学符号
+            contains_mathematical_symbols_informative: 街区不能包含数学符号
+            contains_restricted_characters_instructional: 街区只能包含字母、数字、本地字符和特殊字符
+            contains_restricted_characters_informative: 街区不能包含受限字符
+            contains_too_many_words_instructional: 街区名称必须少于 %{word_count} 个字词
+            contains_too_many_words_informative: 街区名称必须少于 %{word_count} 个字词
+            contains_html_tags_instructional: 街区不能包含 HTML
+            contains_html_tags_informative: 街区不能包含 HTML
+            contains_url_instructional: 街区不能包含 URL
+            contains_url_informative: 街区不能包含 URL
+            unknown_for_city_instructional: 输入 %{city} 的有效街区
+            unknown_for_city_informative: 该街区对 %{city} 无效
+            unknown_for_zip_instructional: 输入 %{zip} 的有效街区
+            unknown_for_zip_informative: 该街区对 %{zip} 无效
+            unknown_for_address_instructional: 街区可能不正确
+            unknown_for_address_informative: 街区可能不正确
+          warnings:
+            contains_too_many_words: 建议街区名称少于 %{word_count} 个字词

--- a/data/regions/KW/zh-CN.yml
+++ b/data/regions/KW/zh-CN.yml
@@ -46,25 +46,25 @@ zh-CN:
           errors:
             blank_instructional: 输入街区
             blank_informative: 缺少街区
-            too_long_instructional: 街区名称过长（最多 %{limit} 个字符）
-            too_long_informative: 街区名称过长
+            too_long_instructional: 街区太长（最多 %{limit} 个字符）
+            too_long_informative: 街区太长
             contains_emojis_instructional: 街区不能包含表情符号
             contains_emojis_informative: 街区不能包含表情符号
             contains_mathematical_symbols_instructional: 街区不能包含数学符号
             contains_mathematical_symbols_informative: 街区不能包含数学符号
             contains_restricted_characters_instructional: 街区只能包含字母、数字、本地字符和特殊字符
             contains_restricted_characters_informative: 街区不能包含受限字符
-            contains_too_many_words_instructional: 街区名称必须少于 %{word_count} 个字词
-            contains_too_many_words_informative: 街区名称必须少于 %{word_count} 个字词
+            contains_too_many_words_instructional: 街区必须少于 %{word_count} 个词
+            contains_too_many_words_informative: 街区必须少于 %{word_count} 个词
             contains_html_tags_instructional: 街区不能包含 HTML
             contains_html_tags_informative: 街区不能包含 HTML
             contains_url_instructional: 街区不能包含 URL
             contains_url_informative: 街区不能包含 URL
-            unknown_for_city_instructional: 输入 %{city} 的有效街区
-            unknown_for_city_informative: 该街区对 %{city} 无效
-            unknown_for_zip_instructional: 输入 %{zip} 的有效街区
-            unknown_for_zip_informative: 该街区对 %{zip} 无效
+            unknown_for_city_instructional: 为 %{city} 输入有效的街区
+            unknown_for_city_informative: 街区对 %{city} 无效
+            unknown_for_zip_instructional: 为 %{zip} 输入有效的街区
+            unknown_for_zip_informative: 街区对 %{zip} 无效
             unknown_for_address_instructional: 街区可能不正确
             unknown_for_address_informative: 街区可能不正确
           warnings:
-            contains_too_many_words: 建议街区名称少于 %{word_count} 个字词
+            contains_too_many_words: 建议街区少于 %{word_count} 个词

--- a/data/regions/KW/zh-TW.yml
+++ b/data/regions/KW/zh-TW.yml
@@ -45,26 +45,26 @@ zh-TW:
             optional: 街區 (選填)
           errors:
             blank_instructional: 輸入街區
-            blank_informative: 缺少街區
-            too_long_instructional: 街區太長 (最多 %{limit} 個字元)
-            too_long_informative: 街區太長
-            contains_emojis_instructional: 街區不可包含表情符號
-            contains_emojis_informative: 街區不可包含表情符號
-            contains_mathematical_symbols_instructional: 街區不可包含數學符號
-            contains_mathematical_symbols_informative: 街區不可包含數學符號
-            contains_restricted_characters_instructional: 街區僅可包含字母、數字、本地字元及特殊字元
-            contains_restricted_characters_informative: 街區不可包含受限字元
-            contains_too_many_words_instructional: 街區的字數必須少於 %{word_count} 個字
-            contains_too_many_words_informative: 街區的字數必須少於 %{word_count} 個字
-            contains_html_tags_instructional: 街區不可包含 HTML
-            contains_html_tags_informative: 街區不可包含 HTML
-            contains_url_instructional: 街區不可包含網址
-            contains_url_informative: 街區不可包含網址
+            blank_informative: 遺漏街區
+            too_long_instructional: 街區名稱過長 (最多 %{limit} 個字元)
+            too_long_informative: 街區名稱過長
+            contains_emojis_instructional: 街區不能包含表情符號
+            contains_emojis_informative: 街區不能包含表情符號
+            contains_mathematical_symbols_instructional: 街區不能包含數學符號
+            contains_mathematical_symbols_informative: 街區不能包含數學符號
+            contains_restricted_characters_instructional: 街區僅能包含字母、數字、當地字元和特殊字元
+            contains_restricted_characters_informative: 街區不能包含受限字元
+            contains_too_many_words_instructional: 街區名稱必須少於 %{word_count} 個字
+            contains_too_many_words_informative: 街區名稱必須少於 %{word_count} 個字
+            contains_html_tags_instructional: 街區不能包含 HTML
+            contains_html_tags_informative: 街區不能包含 HTML
+            contains_url_instructional: 街區不能包含網址
+            contains_url_informative: 街區不能包含網址
             unknown_for_city_instructional: 輸入 %{city} 的有效街區
-            unknown_for_city_informative: 街區不適用於 %{city}
+            unknown_for_city_informative: "%{city} 的街區無效"
             unknown_for_zip_instructional: 輸入 %{zip} 的有效街區
-            unknown_for_zip_informative: 街區不適用於 %{zip}
+            unknown_for_zip_informative: "%{zip} 的街區無效"
             unknown_for_address_instructional: 街區可能不正確
             unknown_for_address_informative: 街區可能不正確
           warnings:
-            contains_too_many_words: 建議街區的字數少於 %{word_count} 個字
+            contains_too_many_words: 街區名稱建議少於 %{word_count} 個字

--- a/data/regions/KW/zh-TW.yml
+++ b/data/regions/KW/zh-TW.yml
@@ -39,3 +39,32 @@ zh-TW:
             unknown_for_address_informative: 街區可能並不正確
           warnings:
             contains_too_many_words: 建議街區少於 %{word_count} 個字
+        district:
+          label:
+            default: 街區
+            optional: 街區 (選填)
+          errors:
+            blank_instructional: 輸入街區
+            blank_informative: 缺少街區
+            too_long_instructional: 街區太長 (最多 %{limit} 個字元)
+            too_long_informative: 街區太長
+            contains_emojis_instructional: 街區不可包含表情符號
+            contains_emojis_informative: 街區不可包含表情符號
+            contains_mathematical_symbols_instructional: 街區不可包含數學符號
+            contains_mathematical_symbols_informative: 街區不可包含數學符號
+            contains_restricted_characters_instructional: 街區僅可包含字母、數字、本地字元及特殊字元
+            contains_restricted_characters_informative: 街區不可包含受限字元
+            contains_too_many_words_instructional: 街區的字數必須少於 %{word_count} 個字
+            contains_too_many_words_informative: 街區的字數必須少於 %{word_count} 個字
+            contains_html_tags_instructional: 街區不可包含 HTML
+            contains_html_tags_informative: 街區不可包含 HTML
+            contains_url_instructional: 街區不可包含網址
+            contains_url_informative: 街區不可包含網址
+            unknown_for_city_instructional: 輸入 %{city} 的有效街區
+            unknown_for_city_informative: 街區不適用於 %{city}
+            unknown_for_zip_instructional: 輸入 %{zip} 的有效街區
+            unknown_for_zip_informative: 街區不適用於 %{zip}
+            unknown_for_address_instructional: 街區可能不正確
+            unknown_for_address_informative: 街區可能不正確
+          warnings:
+            contains_too_many_words: 建議街區的字數少於 %{word_count} 個字

--- a/data/regions/PE/en.yml
+++ b/data/regions/PE/en.yml
@@ -33,3 +33,4 @@ en:
             unknown_for_address_informative: District may be incorrect
           warnings:
             contains_too_many_words: District is recommended to have less than %{word_count} words
+

--- a/data/regions/PH/bg.yml
+++ b/data/regions/PH/bg.yml
@@ -40,3 +40,39 @@ bg:
           warnings:
             contains_too_many_words: Препоръчително е „Барангай“ да не съдържа повече
               от %{word_count} думи
+        district:
+          label:
+            default: Барангай
+            optional: Барангай (по избор)
+          errors:
+            blank_instructional: Въведете барангай
+            blank_informative: Липсва барангай
+            too_long_instructional: Барангаят е твърде дълъг (максимум %{limit} знака)
+            too_long_informative: Барангаят е твърде дълъг
+            contains_emojis_instructional: Барангаят не може да съдържа емоджита
+            contains_emojis_informative: Барангаят не може да съдържа емоджита
+            contains_mathematical_symbols_instructional: Барангаят не може да съдържа
+              математически символи
+            contains_mathematical_symbols_informative: Барангаят не може да съдържа
+              математически символи
+            contains_restricted_characters_instructional: Барангаят може да съдържа
+              само букви, цифри, локални и специални символи
+            contains_restricted_characters_informative: Барангаят не може да съдържа
+              забранени символи
+            contains_too_many_words_instructional: Барангаят трябва да съдържа по-малко
+              от %{word_count} думи
+            contains_too_many_words_informative: Барангаят трябва да съдържа по-малко
+              от %{word_count} думи
+            contains_html_tags_instructional: Барангаят не може да съдържа HTML
+            contains_html_tags_informative: Барангаят не може да съдържа HTML
+            contains_url_instructional: Барангаят не може да съдържа URL
+            contains_url_informative: Барангаят не може да съдържа URL
+            unknown_for_city_instructional: Въведете валидно име на барангай за %{city}
+            unknown_for_city_informative: Въведете валидно име на барангай за %{city}
+            unknown_for_zip_instructional: Въведете валидно име на барангай за %{zip}
+            unknown_for_zip_informative: Въведете валидно име на барангай за %{zip}
+            unknown_for_address_instructional: Барангаят може да е грешен
+            unknown_for_address_informative: Барангаят може да е грешен
+          warnings:
+            contains_too_many_words: Препоръчително е барангаят да съдържа по-малко
+              от %{word_count} думи

--- a/data/regions/PH/bg.yml
+++ b/data/regions/PH/bg.yml
@@ -47,7 +47,8 @@ bg:
           errors:
             blank_instructional: Въведете барангай
             blank_informative: Липсва барангай
-            too_long_instructional: Барангаят е твърде дълъг (максимум %{limit} знака)
+            too_long_instructional: Барангаят е твърде дълъг (максимумът е %{limit}
+              знака)
             too_long_informative: Барангаят е твърде дълъг
             contains_emojis_instructional: Барангаят не може да съдържа емоджита
             contains_emojis_informative: Барангаят не може да съдържа емоджита
@@ -56,17 +57,17 @@ bg:
             contains_mathematical_symbols_informative: Барангаят не може да съдържа
               математически символи
             contains_restricted_characters_instructional: Барангаят може да съдържа
-              само букви, цифри, локални и специални символи
+              само букви, цифри, локални и специални знаци
             contains_restricted_characters_informative: Барангаят не може да съдържа
-              забранени символи
+              неразрешени знаци
             contains_too_many_words_instructional: Барангаят трябва да съдържа по-малко
               от %{word_count} думи
             contains_too_many_words_informative: Барангаят трябва да съдържа по-малко
               от %{word_count} думи
             contains_html_tags_instructional: Барангаят не може да съдържа HTML
             contains_html_tags_informative: Барангаят не може да съдържа HTML
-            contains_url_instructional: Барангаят не може да съдържа URL
-            contains_url_informative: Барангаят не може да съдържа URL
+            contains_url_instructional: Барангаят не може да съдържа URL адрес
+            contains_url_informative: Барангаят не може да съдържа URL адрес
             unknown_for_city_instructional: Въведете валидно име на барангай за %{city}
             unknown_for_city_informative: Въведете валидно име на барангай за %{city}
             unknown_for_zip_instructional: Въведете валидно име на барангай за %{zip}

--- a/data/regions/PH/cs.yml
+++ b/data/regions/PH/cs.yml
@@ -43,37 +43,37 @@ cs:
         district:
           label:
             default: Barangay
-            optional: Barangay (nepovinné)
+            optional: Barangay (volitelné)
           errors:
             blank_instructional: Zadejte barangay
             blank_informative: Chybí barangay
-            too_long_instructional: Barangay je příliš dlouhý (maximálně %{limit}
+            too_long_instructional: Název barangaye je příliš dlouhý (maximum je %{limit}
               znaků)
-            too_long_informative: Barangay je příliš dlouhý
-            contains_emojis_instructional: Barangay nemůže obsahovat emotikony
-            contains_emojis_informative: Barangay nemůže obsahovat emotikony
-            contains_mathematical_symbols_instructional: Barangay nemůže obsahovat
+            too_long_informative: Název barangaye je příliš dlouhý
+            contains_emojis_instructional: Název barangaye nesmí obsahovat emodži
+            contains_emojis_informative: Název barangaye nesmí obsahovat emodži
+            contains_mathematical_symbols_instructional: Název barangaye nesmí obsahovat
               matematické symboly
-            contains_mathematical_symbols_informative: Barangay nemůže obsahovat matematické
-              symboly
-            contains_restricted_characters_instructional: Barangay může obsahovat
-              pouze písmena, číslice, místní a speciální znaky
-            contains_restricted_characters_informative: Barangay nesmí obsahovat nepovolené
-              znaky
-            contains_too_many_words_instructional: Barangay musí mít méně než %{word_count}
-              slov
-            contains_too_many_words_informative: Barangay musí mít méně než %{word_count}
-              slov
-            contains_html_tags_instructional: Barangay nemůže obsahovat HTML
-            contains_html_tags_informative: Barangay nemůže obsahovat HTML
-            contains_url_instructional: Barangay nemůže obsahovat URL
-            contains_url_informative: Barangay nemůže obsahovat URL
-            unknown_for_city_instructional: Zadejte platný název barangay pro %{city}
-            unknown_for_city_informative: Zadejte platný název barangay pro %{city}
-            unknown_for_zip_instructional: Zadejte platný název barangay pro %{zip}
-            unknown_for_zip_informative: Zadejte platný název barangay pro %{zip}
-            unknown_for_address_instructional: Barangay může být nesprávný
-            unknown_for_address_informative: Barangay může být nesprávný
-          warnings:
-            contains_too_many_words: Doporučujeme, aby barangay obsahoval méně než
+            contains_mathematical_symbols_informative: Název barangaye nesmí obsahovat
+              matematické symboly
+            contains_restricted_characters_instructional: Název barangaye smí obsahovat
+              pouze písmena, číslice, místní znaky a speciální znaky
+            contains_restricted_characters_informative: Název barangaye nesmí obsahovat
+              nepovolené znaky
+            contains_too_many_words_instructional: Název barangaye musí mít méně než
               %{word_count} slov
+            contains_too_many_words_informative: Název barangaye musí mít méně než
+              %{word_count} slov
+            contains_html_tags_instructional: Název barangaye nesmí obsahovat HTML
+            contains_html_tags_informative: Název barangaye nesmí obsahovat HTML
+            contains_url_instructional: Název barangaye nesmí obsahovat adresu URL
+            contains_url_informative: Název barangaye nesmí obsahovat adresu URL
+            unknown_for_city_instructional: Zadejte platný název barangaye pro %{city}
+            unknown_for_city_informative: Zadejte platný název barangaye pro %{city}
+            unknown_for_zip_instructional: Zadejte platný název barangaye pro %{zip}
+            unknown_for_zip_informative: Zadejte platný název barangaye pro %{zip}
+            unknown_for_address_instructional: Název barangaye je možná nesprávný
+            unknown_for_address_informative: Název barangaye je možná nesprávný
+          warnings:
+            contains_too_many_words: Doporučujeme, aby název barangaye obsahoval méně
+              než %{word_count} slov

--- a/data/regions/PH/cs.yml
+++ b/data/regions/PH/cs.yml
@@ -40,3 +40,40 @@ cs:
           warnings:
             contains_too_many_words: 'Doporučuje se, aby název barangay obsahoval
               méně než tento počet slov: %{word_count}.'
+        district:
+          label:
+            default: Barangay
+            optional: Barangay (nepovinné)
+          errors:
+            blank_instructional: Zadejte barangay
+            blank_informative: Chybí barangay
+            too_long_instructional: Barangay je příliš dlouhý (maximálně %{limit}
+              znaků)
+            too_long_informative: Barangay je příliš dlouhý
+            contains_emojis_instructional: Barangay nemůže obsahovat emotikony
+            contains_emojis_informative: Barangay nemůže obsahovat emotikony
+            contains_mathematical_symbols_instructional: Barangay nemůže obsahovat
+              matematické symboly
+            contains_mathematical_symbols_informative: Barangay nemůže obsahovat matematické
+              symboly
+            contains_restricted_characters_instructional: Barangay může obsahovat
+              pouze písmena, číslice, místní a speciální znaky
+            contains_restricted_characters_informative: Barangay nesmí obsahovat nepovolené
+              znaky
+            contains_too_many_words_instructional: Barangay musí mít méně než %{word_count}
+              slov
+            contains_too_many_words_informative: Barangay musí mít méně než %{word_count}
+              slov
+            contains_html_tags_instructional: Barangay nemůže obsahovat HTML
+            contains_html_tags_informative: Barangay nemůže obsahovat HTML
+            contains_url_instructional: Barangay nemůže obsahovat URL
+            contains_url_informative: Barangay nemůže obsahovat URL
+            unknown_for_city_instructional: Zadejte platný název barangay pro %{city}
+            unknown_for_city_informative: Zadejte platný název barangay pro %{city}
+            unknown_for_zip_instructional: Zadejte platný název barangay pro %{zip}
+            unknown_for_zip_informative: Zadejte platný název barangay pro %{zip}
+            unknown_for_address_instructional: Barangay může být nesprávný
+            unknown_for_address_informative: Barangay může být nesprávný
+          warnings:
+            contains_too_many_words: Doporučujeme, aby barangay obsahoval méně než
+              %{word_count} slov

--- a/data/regions/PH/da.yml
+++ b/data/regions/PH/da.yml
@@ -43,33 +43,34 @@ da:
             default: Barangay
             optional: Barangay (valgfrit)
           errors:
-            blank_instructional: Angiv en barangay
+            blank_instructional: Indtast en barangay
             blank_informative: Barangay mangler
-            too_long_instructional: Barangay er for lang (maks. %{limit} tegn)
-            too_long_informative: Barangay er for lang
-            contains_emojis_instructional: Barangay kan ikke indeholde emojis
-            contains_emojis_informative: Barangay kan ikke indeholde emojis
-            contains_mathematical_symbols_instructional: Barangay kan ikke indeholde
+            too_long_instructional: Barangayen er for lang (maks. %{limit} tegn)
+            too_long_informative: Barangayen er for lang
+            contains_emojis_instructional: Barangayen kan ikke indeholde emojis
+            contains_emojis_informative: Barangayen kan ikke indeholde emojis
+            contains_mathematical_symbols_instructional: Barangayen kan ikke indeholde
               matematiske symboler
-            contains_mathematical_symbols_informative: Barangay kan ikke indeholde
+            contains_mathematical_symbols_informative: Barangayen kan ikke indeholde
               matematiske symboler
-            contains_restricted_characters_instructional: Barangay kan kun indeholde
+            contains_restricted_characters_instructional: Barangayen kan kun indeholde
               bogstaver, tal, lokale tegn og specialtegn
-            contains_restricted_characters_informative: Barangay kan ikke indeholde
+            contains_restricted_characters_informative: Barangayen kan ikke indeholde
               ikke-tilladte tegn
-            contains_too_many_words_instructional: Barangay skal have færre end %{word_count}
+            contains_too_many_words_instructional: Barangayen skal have færre end
+              %{word_count} ord
+            contains_too_many_words_informative: Barangayen skal have færre end %{word_count}
               ord
-            contains_too_many_words_informative: Barangay skal have færre end %{word_count}
-              ord
-            contains_html_tags_instructional: Barangay kan ikke indeholde HTML
-            contains_html_tags_informative: Barangay kan ikke indeholde HTML
-            contains_url_instructional: Barangay kan ikke indeholde en webadresse
-            contains_url_informative: Barangay kan ikke indeholde en webadresse
-            unknown_for_city_instructional: Angiv et gyldigt barangay-navn for %{city}
-            unknown_for_city_informative: Angiv et gyldigt barangay-navn for %{city}
-            unknown_for_zip_instructional: Angiv et gyldigt barangay-navn for %{zip}
-            unknown_for_zip_informative: Angiv et gyldigt barangay-navn for %{zip}
-            unknown_for_address_instructional: Barangay kan være forkert
-            unknown_for_address_informative: Barangay kan være forkert
+            contains_html_tags_instructional: Barangayen kan ikke indeholde HTML
+            contains_html_tags_informative: Barangayen kan ikke indeholde HTML
+            contains_url_instructional: Barangayen kan ikke indeholde en webadresse
+            contains_url_informative: Barangayen kan ikke indeholde en webadresse
+            unknown_for_city_instructional: Indtast et gyldigt barangay-navn for %{city}
+            unknown_for_city_informative: Indtast et gyldigt barangay-navn for %{city}
+            unknown_for_zip_instructional: Indtast et gyldigt barangay-navn for %{zip}
+            unknown_for_zip_informative: Indtast et gyldigt barangay-navn for %{zip}
+            unknown_for_address_instructional: Barangayen er muligvis forkert
+            unknown_for_address_informative: Barangayen er muligvis forkert
           warnings:
-            contains_too_many_words: Barangay bør have færre end %{word_count} ord
+            contains_too_many_words: Det anbefales, at barangayen har færre end %{word_count}
+              ord

--- a/data/regions/PH/da.yml
+++ b/data/regions/PH/da.yml
@@ -38,3 +38,38 @@ da:
           warnings:
             contains_too_many_words: Det anbefales, at området indeholder færre end
               %{word_count} ord
+        district:
+          label:
+            default: Barangay
+            optional: Barangay (valgfrit)
+          errors:
+            blank_instructional: Angiv en barangay
+            blank_informative: Barangay mangler
+            too_long_instructional: Barangay er for lang (maks. %{limit} tegn)
+            too_long_informative: Barangay er for lang
+            contains_emojis_instructional: Barangay kan ikke indeholde emojis
+            contains_emojis_informative: Barangay kan ikke indeholde emojis
+            contains_mathematical_symbols_instructional: Barangay kan ikke indeholde
+              matematiske symboler
+            contains_mathematical_symbols_informative: Barangay kan ikke indeholde
+              matematiske symboler
+            contains_restricted_characters_instructional: Barangay kan kun indeholde
+              bogstaver, tal, lokale tegn og specialtegn
+            contains_restricted_characters_informative: Barangay kan ikke indeholde
+              ikke-tilladte tegn
+            contains_too_many_words_instructional: Barangay skal have færre end %{word_count}
+              ord
+            contains_too_many_words_informative: Barangay skal have færre end %{word_count}
+              ord
+            contains_html_tags_instructional: Barangay kan ikke indeholde HTML
+            contains_html_tags_informative: Barangay kan ikke indeholde HTML
+            contains_url_instructional: Barangay kan ikke indeholde en webadresse
+            contains_url_informative: Barangay kan ikke indeholde en webadresse
+            unknown_for_city_instructional: Angiv et gyldigt barangay-navn for %{city}
+            unknown_for_city_informative: Angiv et gyldigt barangay-navn for %{city}
+            unknown_for_zip_instructional: Angiv et gyldigt barangay-navn for %{zip}
+            unknown_for_zip_informative: Angiv et gyldigt barangay-navn for %{zip}
+            unknown_for_address_instructional: Barangay kan være forkert
+            unknown_for_address_informative: Barangay kan være forkert
+          warnings:
+            contains_too_many_words: Barangay bør have færre end %{word_count} ord

--- a/data/regions/PH/de.yml
+++ b/data/regions/PH/de.yml
@@ -43,3 +43,43 @@ de:
           warnings:
             contains_too_many_words: Es wird empfohlen, dass das Barangay weniger
               als %{word_count} Wörter enthält.
+        district:
+          label:
+            default: Barangay
+            optional: Barangay (optional)
+          errors:
+            blank_instructional: Gib einen Barangay ein
+            blank_informative: Barangay fehlt
+            too_long_instructional: Barangay ist zu lang (maximal %{limit} Zeichen)
+            too_long_informative: Barangay ist zu lang
+            contains_emojis_instructional: Barangay darf keine Emojis enthalten
+            contains_emojis_informative: Barangay darf keine Emojis enthalten
+            contains_mathematical_symbols_instructional: Barangay darf keine mathematischen
+              Symbole enthalten
+            contains_mathematical_symbols_informative: Barangay darf keine mathematischen
+              Symbole enthalten
+            contains_restricted_characters_instructional: Barangay darf nur Buchstaben,
+              Zahlen, lokale Zeichen und Sonderzeichen enthalten
+            contains_restricted_characters_informative: Barangay darf keine unzulässigen
+              Zeichen enthalten
+            contains_too_many_words_instructional: Barangay muss aus weniger als %{word_count}
+              Wörtern bestehen
+            contains_too_many_words_informative: Barangay muss aus weniger als %{word_count}
+              Wörtern bestehen
+            contains_html_tags_instructional: Barangay darf kein HTML enthalten
+            contains_html_tags_informative: Barangay darf kein HTML enthalten
+            contains_url_instructional: Barangay darf keine URL enthalten
+            contains_url_informative: Barangay darf keine URL enthalten
+            unknown_for_city_instructional: Gib einen gültigen Barangay-Namen für
+              %{city} ein
+            unknown_for_city_informative: Gib einen gültigen Barangay-Namen für %{city}
+              ein
+            unknown_for_zip_instructional: Gib einen gültigen Barangay-Namen für %{zip}
+              ein
+            unknown_for_zip_informative: Gib einen gültigen Barangay-Namen für %{zip}
+              ein
+            unknown_for_address_instructional: Barangay ist möglicherweise falsch
+            unknown_for_address_informative: Barangay ist möglicherweise falsch
+          warnings:
+            contains_too_many_words: Barangay sollte aus weniger als %{word_count}
+              Wörtern bestehen

--- a/data/regions/PH/de.yml
+++ b/data/regions/PH/de.yml
@@ -48,7 +48,7 @@ de:
             default: Barangay
             optional: Barangay (optional)
           errors:
-            blank_instructional: Gib einen Barangay ein
+            blank_instructional: Gib ein Barangay ein
             blank_informative: Barangay fehlt
             too_long_instructional: Barangay ist zu lang (maximal %{limit} Zeichen)
             too_long_informative: Barangay ist zu lang

--- a/data/regions/PH/el.yml
+++ b/data/regions/PH/el.yml
@@ -46,3 +46,45 @@ el:
           warnings:
             contains_too_many_words: Το χωριό συνιστάται να έχει λιγότερες από %{word_count}
               λέξεις
+        district:
+          label:
+            default: Μπαρανγκάι
+            optional: Μπαρανγκάι (προαιρετικό)
+          errors:
+            blank_instructional: Καταχωρίστε μπαρανγκάι
+            blank_informative: Λείπει το μπαρανγκάι
+            too_long_instructional: Το μπαρανγκάι είναι πολύ μεγάλο (το μέγιστο είναι
+              %{limit} χαρακτήρες)
+            too_long_informative: Το μπαρανγκάι είναι πολύ μεγάλο
+            contains_emojis_instructional: Το μπαρανγκάι δεν μπορεί να περιέχει emoji
+            contains_emojis_informative: Το μπαρανγκάι δεν μπορεί να περιέχει emoji
+            contains_mathematical_symbols_instructional: Το μπαρανγκάι δεν μπορεί
+              να περιέχει μαθηματικά σύμβολα
+            contains_mathematical_symbols_informative: Το μπαρανγκάι δεν μπορεί να
+              περιέχει μαθηματικά σύμβολα
+            contains_restricted_characters_instructional: Το μπαρανγκάι μπορεί να
+              περιέχει μόνο γράμματα, αριθμούς, τοπικούς και ειδικούς χαρακτήρες
+            contains_restricted_characters_informative: Το μπαρανγκάι δεν μπορεί να
+              περιέχει μη επιτρεπόμενους χαρακτήρες
+            contains_too_many_words_instructional: Το μπαρανγκάι πρέπει να έχει λιγότερες
+              από %{word_count} λέξεις
+            contains_too_many_words_informative: Το μπαρανγκάι πρέπει να έχει λιγότερες
+              από %{word_count} λέξεις
+            contains_html_tags_instructional: Το μπαρανγκάι δεν μπορεί να περιέχει
+              HTML
+            contains_html_tags_informative: Το μπαρανγκάι δεν μπορεί να περιέχει HTML
+            contains_url_instructional: Το μπαρανγκάι δεν μπορεί να περιέχει URL
+            contains_url_informative: Το μπαρανγκάι δεν μπορεί να περιέχει URL
+            unknown_for_city_instructional: Καταχωρίστε ένα έγκυρο όνομα μπαρανγκάι
+              για %{city}
+            unknown_for_city_informative: Καταχωρίστε ένα έγκυρο όνομα μπαρανγκάι
+              για %{city}
+            unknown_for_zip_instructional: Καταχωρίστε ένα έγκυρο όνομα μπαρανγκάι
+              για τον Τ.Κ. %{zip}
+            unknown_for_zip_informative: Καταχωρίστε ένα έγκυρο όνομα μπαρανγκάι για
+              τον Τ.Κ. %{zip}
+            unknown_for_address_instructional: Το μπαρανγκάι ενδέχεται να είναι εσφαλμένο
+            unknown_for_address_informative: Το μπαρανγκάι ενδέχεται να είναι εσφαλμένο
+          warnings:
+            contains_too_many_words: Συνιστάται το μπαρανγκάι να έχει λιγότερες από
+              %{word_count} λέξεις

--- a/data/regions/PH/el.yml
+++ b/data/regions/PH/el.yml
@@ -48,43 +48,42 @@ el:
               λέξεις
         district:
           label:
-            default: Μπαρανγκάι
-            optional: Μπαρανγκάι (προαιρετικό)
+            default: Barangay
+            optional: Barangay (προαιρετικό)
           errors:
-            blank_instructional: Καταχωρίστε μπαρανγκάι
-            blank_informative: Λείπει το μπαρανγκάι
-            too_long_instructional: Το μπαρανγκάι είναι πολύ μεγάλο (το μέγιστο είναι
+            blank_instructional: Εισαγάγετε ένα Barangay
+            blank_informative: Λείπει το Barangay
+            too_long_instructional: Το Barangay είναι πολύ μεγάλο (το μέγιστο είναι
               %{limit} χαρακτήρες)
-            too_long_informative: Το μπαρανγκάι είναι πολύ μεγάλο
-            contains_emojis_instructional: Το μπαρανγκάι δεν μπορεί να περιέχει emoji
-            contains_emojis_informative: Το μπαρανγκάι δεν μπορεί να περιέχει emoji
-            contains_mathematical_symbols_instructional: Το μπαρανγκάι δεν μπορεί
-              να περιέχει μαθηματικά σύμβολα
-            contains_mathematical_symbols_informative: Το μπαρανγκάι δεν μπορεί να
+            too_long_informative: Το Barangay είναι πολύ μεγάλο
+            contains_emojis_instructional: Το Barangay δεν μπορεί να περιέχει emoji
+            contains_emojis_informative: Το Barangay δεν μπορεί να περιέχει emoji
+            contains_mathematical_symbols_instructional: Το Barangay δεν μπορεί να
               περιέχει μαθηματικά σύμβολα
-            contains_restricted_characters_instructional: Το μπαρανγκάι μπορεί να
-              περιέχει μόνο γράμματα, αριθμούς, τοπικούς και ειδικούς χαρακτήρες
-            contains_restricted_characters_informative: Το μπαρανγκάι δεν μπορεί να
+            contains_mathematical_symbols_informative: Το Barangay δεν μπορεί να περιέχει
+              μαθηματικά σύμβολα
+            contains_restricted_characters_instructional: Το Barangay μπορεί να περιέχει
+              μόνο γράμματα, αριθμούς, τοπικούς χαρακτήρες και ειδικούς χαρακτήρες
+            contains_restricted_characters_informative: Το Barangay δεν μπορεί να
               περιέχει μη επιτρεπόμενους χαρακτήρες
-            contains_too_many_words_instructional: Το μπαρανγκάι πρέπει να έχει λιγότερες
+            contains_too_many_words_instructional: Το Barangay πρέπει να έχει λιγότερες
               από %{word_count} λέξεις
-            contains_too_many_words_informative: Το μπαρανγκάι πρέπει να έχει λιγότερες
+            contains_too_many_words_informative: Το Barangay πρέπει να έχει λιγότερες
               από %{word_count} λέξεις
-            contains_html_tags_instructional: Το μπαρανγκάι δεν μπορεί να περιέχει
-              HTML
-            contains_html_tags_informative: Το μπαρανγκάι δεν μπορεί να περιέχει HTML
-            contains_url_instructional: Το μπαρανγκάι δεν μπορεί να περιέχει URL
-            contains_url_informative: Το μπαρανγκάι δεν μπορεί να περιέχει URL
-            unknown_for_city_instructional: Καταχωρίστε ένα έγκυρο όνομα μπαρανγκάι
-              για %{city}
-            unknown_for_city_informative: Καταχωρίστε ένα έγκυρο όνομα μπαρανγκάι
-              για %{city}
-            unknown_for_zip_instructional: Καταχωρίστε ένα έγκυρο όνομα μπαρανγκάι
-              για τον Τ.Κ. %{zip}
-            unknown_for_zip_informative: Καταχωρίστε ένα έγκυρο όνομα μπαρανγκάι για
-              τον Τ.Κ. %{zip}
-            unknown_for_address_instructional: Το μπαρανγκάι ενδέχεται να είναι εσφαλμένο
-            unknown_for_address_informative: Το μπαρανγκάι ενδέχεται να είναι εσφαλμένο
+            contains_html_tags_instructional: Το Barangay δεν μπορεί να περιέχει HTML
+            contains_html_tags_informative: Το Barangay δεν μπορεί να περιέχει HTML
+            contains_url_instructional: Το Barangay δεν μπορεί να περιέχει URL
+            contains_url_informative: Το Barangay δεν μπορεί να περιέχει URL
+            unknown_for_city_instructional: Εισαγάγετε ένα έγκυρο όνομα Barangay για
+              %{city}
+            unknown_for_city_informative: Εισαγάγετε ένα έγκυρο όνομα Barangay για
+              %{city}
+            unknown_for_zip_instructional: Εισαγάγετε ένα έγκυρο όνομα Barangay για
+              %{zip}
+            unknown_for_zip_informative: Εισαγάγετε ένα έγκυρο όνομα Barangay για
+              %{zip}
+            unknown_for_address_instructional: Το Barangay ενδέχεται να είναι λανθασμένο
+            unknown_for_address_informative: Το Barangay ενδέχεται να είναι λανθασμένο
           warnings:
-            contains_too_many_words: Συνιστάται το μπαρανγκάι να έχει λιγότερες από
+            contains_too_many_words: Συνιστάται το Barangay να έχει λιγότερες από
               %{word_count} λέξεις

--- a/data/regions/PH/en.yml
+++ b/data/regions/PH/en.yml
@@ -33,3 +33,33 @@ en:
             unknown_for_address_informative: Barangay may be incorrect
           warnings:
             contains_too_many_words: Barangay is recommended to have less than %{word_count} words
+        district:
+          label:
+            default: Barangay
+            optional: Barangay (optional)
+          errors:
+            blank_instructional: Enter a barangay
+            blank_informative: Barangay is missing
+            too_long_instructional: Barangay is too long (maximum is %{limit} characters)
+            too_long_informative: Barangay is too long
+            contains_emojis_instructional: Barangay can't contain emojis
+            contains_emojis_informative: Barangay can't contain emojis
+            contains_mathematical_symbols_instructional: Barangay can't contain mathematical symbols
+            contains_mathematical_symbols_informative: Barangay can't contain mathematical symbols
+            contains_restricted_characters_instructional: Barangay can only contain letters, numbers,
+              local characters, and special characters
+            contains_restricted_characters_informative: Barangay can't contain restricted characters
+            contains_too_many_words_instructional: Barangay must have fewer than %{word_count} words
+            contains_too_many_words_informative: Barangay must have fewer than %{word_count} words
+            contains_html_tags_instructional: Barangay can't contain HTML
+            contains_html_tags_informative: Barangay can't contain HTML
+            contains_url_instructional: Barangay can't contain a URL
+            contains_url_informative: Barangay can't contain a URL
+            unknown_for_city_instructional: Enter a valid barangay name for %{city}
+            unknown_for_city_informative: Enter a valid barangay name for %{city}
+            unknown_for_zip_instructional: Enter a valid barangay name for %{zip}
+            unknown_for_zip_informative: Enter a valid barangay name for %{zip}
+            unknown_for_address_instructional: Barangay may be incorrect
+            unknown_for_address_informative: Barangay may be incorrect
+          warnings:
+            contains_too_many_words: Barangay is recommended to have less than %{word_count} words

--- a/data/regions/PH/es.yml
+++ b/data/regions/PH/es.yml
@@ -46,3 +46,44 @@ es:
           warnings:
             contains_too_many_words: Se recomienda que el nombre del barangay tenga
               menos de %{word_count} palabras.
+        district:
+          label:
+            default: Barangay
+            optional: Barangay (opcional)
+          errors:
+            blank_instructional: Ingresa un barangay
+            blank_informative: Falta el barangay
+            too_long_instructional: El barangay es demasiado largo (el máximo es de
+              %{limit} caracteres)
+            too_long_informative: El barangay es demasiado largo
+            contains_emojis_instructional: El barangay no puede contener emojis
+            contains_emojis_informative: El barangay no puede contener emojis
+            contains_mathematical_symbols_instructional: El barangay no puede contener
+              símbolos matemáticos
+            contains_mathematical_symbols_informative: El barangay no puede contener
+              símbolos matemáticos
+            contains_restricted_characters_instructional: El barangay solo puede contener
+              letras, números, caracteres locales y caracteres especiales
+            contains_restricted_characters_informative: El barangay no puede contener
+              caracteres restringidos
+            contains_too_many_words_instructional: El barangay debe tener menos de
+              %{word_count} palabras
+            contains_too_many_words_informative: El barangay debe tener menos de %{word_count}
+              palabras
+            contains_html_tags_instructional: El barangay no puede contener HTML
+            contains_html_tags_informative: El barangay no puede contener HTML
+            contains_url_instructional: El barangay no puede contener una URL
+            contains_url_informative: El barangay no puede contener una URL
+            unknown_for_city_instructional: Ingresa un nombre de barangay válido para
+              %{city}
+            unknown_for_city_informative: Ingresa un nombre de barangay válido para
+              %{city}
+            unknown_for_zip_instructional: Ingresa un nombre de barangay válido para
+              %{zip}
+            unknown_for_zip_informative: Ingresa un nombre de barangay válido para
+              %{zip}
+            unknown_for_address_instructional: El barangay podría ser incorrecto
+            unknown_for_address_informative: El barangay podría ser incorrecto
+          warnings:
+            contains_too_many_words: Se recomienda que el barangay tenga menos de
+              %{word_count} palabras

--- a/data/regions/PH/fi.yml
+++ b/data/regions/PH/fi.yml
@@ -53,15 +53,15 @@ fi:
             blank_informative: Barangay puuttuu
             too_long_instructional: Barangay on liian pitkä (enintään %{limit} merkkiä)
             too_long_informative: Barangay on liian pitkä
-            contains_emojis_instructional: Barangay ei voi sisältää emojeita
-            contains_emojis_informative: Barangay ei voi sisältää emojeita
+            contains_emojis_instructional: Barangay ei voi sisältää emojeja
+            contains_emojis_informative: Barangay ei voi sisältää emojeja
             contains_mathematical_symbols_instructional: Barangay ei voi sisältää
-              matemaattisia symboleita
+              matemaattisia symboleja
             contains_mathematical_symbols_informative: Barangay ei voi sisältää matemaattisia
-              symboleita
+              symboleja
             contains_restricted_characters_instructional: Barangay voi sisältää vain
               kirjaimia, numeroita, paikallisia merkkejä ja erikoismerkkejä
-            contains_restricted_characters_informative: Barangay ei voi sisältää rajoitettuja
+            contains_restricted_characters_informative: Barangay ei voi sisältää kiellettyjä
               merkkejä
             contains_too_many_words_instructional: Barangayssa on oltava alle %{word_count}
               sanaa
@@ -71,13 +71,12 @@ fi:
             contains_html_tags_informative: Barangay ei voi sisältää HTML:ää
             contains_url_instructional: Barangay ei voi sisältää URL-osoitetta
             contains_url_informative: Barangay ei voi sisältää URL-osoitetta
-            unknown_for_city_instructional: Anna kelvollinen barangayn nimi kaupungille
+            unknown_for_city_instructional: Anna kelvollinen barangay kaupungille
               %{city}
-            unknown_for_city_informative: Anna kelvollinen barangayn nimi kaupungille
-              %{city}
-            unknown_for_zip_instructional: Anna kelvollinen barangayn nimi postinumerolle
+            unknown_for_city_informative: Anna kelvollinen barangay kaupungille %{city}
+            unknown_for_zip_instructional: Anna kelvollinen barangay postinumerolle
               %{zip}
-            unknown_for_zip_informative: Anna kelvollinen barangayn nimi postinumerolle
+            unknown_for_zip_informative: Anna kelvollinen barangay postinumerolle
               %{zip}
             unknown_for_address_instructional: Barangay saattaa olla virheellinen
             unknown_for_address_informative: Barangay saattaa olla virheellinen

--- a/data/regions/PH/fi.yml
+++ b/data/regions/PH/fi.yml
@@ -44,3 +44,43 @@ fi:
           warnings:
             contains_too_many_words: Barangay-kentän pituudeksi suositellaan alle
               %{word_count} sanaa
+        district:
+          label:
+            default: Barangay
+            optional: Barangay (valinnainen)
+          errors:
+            blank_instructional: Anna barangay
+            blank_informative: Barangay puuttuu
+            too_long_instructional: Barangay on liian pitkä (enintään %{limit} merkkiä)
+            too_long_informative: Barangay on liian pitkä
+            contains_emojis_instructional: Barangay ei voi sisältää emojeita
+            contains_emojis_informative: Barangay ei voi sisältää emojeita
+            contains_mathematical_symbols_instructional: Barangay ei voi sisältää
+              matemaattisia symboleita
+            contains_mathematical_symbols_informative: Barangay ei voi sisältää matemaattisia
+              symboleita
+            contains_restricted_characters_instructional: Barangay voi sisältää vain
+              kirjaimia, numeroita, paikallisia merkkejä ja erikoismerkkejä
+            contains_restricted_characters_informative: Barangay ei voi sisältää rajoitettuja
+              merkkejä
+            contains_too_many_words_instructional: Barangayssa on oltava alle %{word_count}
+              sanaa
+            contains_too_many_words_informative: Barangayssa on oltava alle %{word_count}
+              sanaa
+            contains_html_tags_instructional: Barangay ei voi sisältää HTML:ää
+            contains_html_tags_informative: Barangay ei voi sisältää HTML:ää
+            contains_url_instructional: Barangay ei voi sisältää URL-osoitetta
+            contains_url_informative: Barangay ei voi sisältää URL-osoitetta
+            unknown_for_city_instructional: Anna kelvollinen barangayn nimi kaupungille
+              %{city}
+            unknown_for_city_informative: Anna kelvollinen barangayn nimi kaupungille
+              %{city}
+            unknown_for_zip_instructional: Anna kelvollinen barangayn nimi postinumerolle
+              %{zip}
+            unknown_for_zip_informative: Anna kelvollinen barangayn nimi postinumerolle
+              %{zip}
+            unknown_for_address_instructional: Barangay saattaa olla virheellinen
+            unknown_for_address_informative: Barangay saattaa olla virheellinen
+          warnings:
+            contains_too_many_words: Barangayssa suositellaan olevan alle %{word_count}
+              sanaa

--- a/data/regions/PH/fr.yml
+++ b/data/regions/PH/fr.yml
@@ -52,27 +52,28 @@ fr:
           errors:
             blank_instructional: Saisissez un barangay
             blank_informative: Le barangay est manquant
-            too_long_instructional: Le barangay est trop long (%{limit} caractères
-              maximum)
+            too_long_instructional: Le barangay est trop long (maximum de %{limit}
+              caractères)
             too_long_informative: Le barangay est trop long
-            contains_emojis_instructional: Le barangay ne peut pas contenir d’emojis
-            contains_emojis_informative: Le barangay ne peut pas contenir d’emojis
+            contains_emojis_instructional: Le barangay ne peut pas contenir d’émojis
+            contains_emojis_informative: Le barangay ne peut pas contenir d’émojis
             contains_mathematical_symbols_instructional: Le barangay ne peut pas contenir
               de symboles mathématiques
             contains_mathematical_symbols_informative: Le barangay ne peut pas contenir
               de symboles mathématiques
-            contains_restricted_characters_instructional: Le barangay ne peut contenir
-              que des lettres, des chiffres, des caractères locaux et des caractères
+            contains_restricted_characters_instructional: Le barangay peut uniquement
+              contenir des lettres, des chiffres, des caractères locaux et des caractères
               spéciaux
             contains_restricted_characters_informative: Le barangay ne peut pas contenir
               de caractères restreints
-            contains_too_many_words_instructional: Le barangay doit contenir moins
+            contains_too_many_words_instructional: Le barangay doit comporter moins
               de %{word_count} mots
-            contains_too_many_words_informative: Le barangay doit contenir moins de
-              %{word_count} mots
+            contains_too_many_words_informative: Le barangay doit comporter moins
+              de %{word_count} mots
             contains_html_tags_instructional: Le barangay ne peut pas contenir de
+              code HTML
+            contains_html_tags_informative: Le barangay ne peut pas contenir de code
               HTML
-            contains_html_tags_informative: Le barangay ne peut pas contenir de HTML
             contains_url_instructional: Le barangay ne peut pas contenir d’URL
             contains_url_informative: Le barangay ne peut pas contenir d’URL
             unknown_for_city_instructional: Saisissez un nom de barangay valide pour
@@ -86,5 +87,5 @@ fr:
             unknown_for_address_instructional: Le barangay est peut-être incorrect
             unknown_for_address_informative: Le barangay est peut-être incorrect
           warnings:
-            contains_too_many_words: Il est recommandé que le barangay contienne moins
+            contains_too_many_words: Il est recommandé que le barangay comporte moins
               de %{word_count} mots

--- a/data/regions/PH/fr.yml
+++ b/data/regions/PH/fr.yml
@@ -45,3 +45,46 @@ fr:
           warnings:
             contains_too_many_words: Il est conseillé que le barangay comporte moins
               de %{word_count} mots
+        district:
+          label:
+            default: Barangay
+            optional: Barangay (facultatif)
+          errors:
+            blank_instructional: Saisissez un barangay
+            blank_informative: Le barangay est manquant
+            too_long_instructional: Le barangay est trop long (%{limit} caractères
+              maximum)
+            too_long_informative: Le barangay est trop long
+            contains_emojis_instructional: Le barangay ne peut pas contenir d’emojis
+            contains_emojis_informative: Le barangay ne peut pas contenir d’emojis
+            contains_mathematical_symbols_instructional: Le barangay ne peut pas contenir
+              de symboles mathématiques
+            contains_mathematical_symbols_informative: Le barangay ne peut pas contenir
+              de symboles mathématiques
+            contains_restricted_characters_instructional: Le barangay ne peut contenir
+              que des lettres, des chiffres, des caractères locaux et des caractères
+              spéciaux
+            contains_restricted_characters_informative: Le barangay ne peut pas contenir
+              de caractères restreints
+            contains_too_many_words_instructional: Le barangay doit contenir moins
+              de %{word_count} mots
+            contains_too_many_words_informative: Le barangay doit contenir moins de
+              %{word_count} mots
+            contains_html_tags_instructional: Le barangay ne peut pas contenir de
+              HTML
+            contains_html_tags_informative: Le barangay ne peut pas contenir de HTML
+            contains_url_instructional: Le barangay ne peut pas contenir d’URL
+            contains_url_informative: Le barangay ne peut pas contenir d’URL
+            unknown_for_city_instructional: Saisissez un nom de barangay valide pour
+              %{city}
+            unknown_for_city_informative: Saisissez un nom de barangay valide pour
+              %{city}
+            unknown_for_zip_instructional: Saisissez un nom de barangay valide pour
+              %{zip}
+            unknown_for_zip_informative: Saisissez un nom de barangay valide pour
+              %{zip}
+            unknown_for_address_instructional: Le barangay est peut-être incorrect
+            unknown_for_address_informative: Le barangay est peut-être incorrect
+          warnings:
+            contains_too_many_words: Il est recommandé que le barangay contienne moins
+              de %{word_count} mots

--- a/data/regions/PH/hi.yml
+++ b/data/regions/PH/hi.yml
@@ -44,42 +44,39 @@ hi:
               में %{word_count} से कम शब्द होने चाहिए
         district:
           label:
-            default: बारंगाय
-            optional: बारंगाय (वैकल्पिक)
+            default: बारंगे
+            optional: बारंगे (वैकल्पिक)
           errors:
-            blank_instructional: कोई बारंगाय दर्ज करें
-            blank_informative: बारंगाय मौजूद नहीं है
-            too_long_instructional: बारंगाय बहुत लंबा है (अधिकतम %{limit} वर्ण होने
-              चाहिए)
-            too_long_informative: बारंगाय बहुत लंबा है
-            contains_emojis_instructional: बारंगाय में इमोजी नहीं हो सकते
-            contains_emojis_informative: बारंगाय में इमोजी नहीं हो सकते
-            contains_mathematical_symbols_instructional: बारंगाय में गणितीय चिह्न
-              नहीं हो सकते
-            contains_mathematical_symbols_informative: बारंगाय में गणितीय चिह्न नहीं
-              हो सकते
-            contains_restricted_characters_instructional: बारंगाय में केवल अक्षर,
-              संख्याएं, स्थानीय वर्ण और विशेष वर्ण शामिल हो सकते हैं
-            contains_restricted_characters_informative: बारंगाय में प्रतिबंधित वर्ण
-              नहीं हो सकते
-            contains_too_many_words_instructional: बारंगाय में %{word_count} से कम
-              शब्द होने चाहिए
-            contains_too_many_words_informative: बारंगाय में %{word_count} से कम शब्द
-              होने चाहिए
-            contains_html_tags_instructional: बारंगाय में HTML नहीं हो सकता
-            contains_html_tags_informative: बारंगाय में HTML नहीं हो सकता
-            contains_url_instructional: बारंगाय में कोई URL नहीं हो सकता
-            contains_url_informative: बारंगाय में कोई URL नहीं हो सकता
-            unknown_for_city_instructional: "%{city} के लिए एक मान्य बारंगाय का नाम
-              दर्ज करें"
-            unknown_for_city_informative: "%{city} के लिए एक मान्य बारंगाय का नाम
-              दर्ज करें"
-            unknown_for_zip_instructional: "%{zip} के लिए एक मान्य बारंगाय का नाम
-              दर्ज करें"
-            unknown_for_zip_informative: "%{zip} के लिए एक मान्य बारंगाय का नाम दर्ज
-              करें"
-            unknown_for_address_instructional: बारंगाय गलत हो सकता है
-            unknown_for_address_informative: बारंगाय गलत हो सकता है
+            blank_instructional: कोई बारंगे दर्ज करें.
+            blank_informative: बारंगे मौजूद नहीं है.
+            too_long_instructional: बारंगे बहुत लंबा है (अधिकतम %{limit} वर्ण होने
+              चाहिए).
+            too_long_informative: बारंगे बहुत लंबा है.
+            contains_emojis_instructional: बारंगे में इमोजी नहीं हो सकते.
+            contains_emojis_informative: बारंगे में इमोजी नहीं हो सकते.
+            contains_mathematical_symbols_instructional: बारंगे में गणितीय चिह्न नहीं
+              हो सकते.
+            contains_mathematical_symbols_informative: बारंगे में गणितीय चिह्न नहीं
+              हो सकते.
+            contains_restricted_characters_instructional: बारंगे में केवल अक्षर, अंक,
+              स्थानीय वर्ण और विशेष वर्ण हो सकते हैं.
+            contains_restricted_characters_informative: बारंगे में प्रतिबंधित वर्ण
+              नहीं हो सकते.
+            contains_too_many_words_instructional: बारंगे में %{word_count} से कम
+              शब्द होने चाहिए.
+            contains_too_many_words_informative: बारंगे में %{word_count} से कम शब्द
+              होने चाहिए.
+            contains_html_tags_instructional: बारंगे में HTML नहीं हो सकता.
+            contains_html_tags_informative: बारंगे में HTML नहीं हो सकता.
+            contains_url_instructional: बारंगे में कोई URL नहीं हो सकता.
+            contains_url_informative: बारंगे में कोई URL नहीं हो सकता.
+            unknown_for_city_instructional: "%{city} के लिए कोई मान्य बारंगे दर्ज
+              करें."
+            unknown_for_city_informative: "%{city} के लिए कोई मान्य बारंगे दर्ज करें."
+            unknown_for_zip_instructional: "%{zip} के लिए कोई मान्य बारंगे दर्ज करें."
+            unknown_for_zip_informative: "%{zip} के लिए कोई मान्य बारंगे दर्ज करें."
+            unknown_for_address_instructional: बारंगे गलत हो सकता है.
+            unknown_for_address_informative: बारंगे गलत हो सकता है.
           warnings:
-            contains_too_many_words: यह सुझाव दिया जाता है कि बारंगाय में %{word_count}
-              से कम शब्द हों
+            contains_too_many_words: सुझाव है कि बारंगे में %{word_count} से कम शब्द
+              हों.

--- a/data/regions/PH/hi.yml
+++ b/data/regions/PH/hi.yml
@@ -42,3 +42,44 @@ hi:
           warnings:
             contains_too_many_words: इस बात का सुझाव दिया जाता है कि बारांगे के नाम
               में %{word_count} से कम शब्द होने चाहिए
+        district:
+          label:
+            default: बारंगाय
+            optional: बारंगाय (वैकल्पिक)
+          errors:
+            blank_instructional: कोई बारंगाय दर्ज करें
+            blank_informative: बारंगाय मौजूद नहीं है
+            too_long_instructional: बारंगाय बहुत लंबा है (अधिकतम %{limit} वर्ण होने
+              चाहिए)
+            too_long_informative: बारंगाय बहुत लंबा है
+            contains_emojis_instructional: बारंगाय में इमोजी नहीं हो सकते
+            contains_emojis_informative: बारंगाय में इमोजी नहीं हो सकते
+            contains_mathematical_symbols_instructional: बारंगाय में गणितीय चिह्न
+              नहीं हो सकते
+            contains_mathematical_symbols_informative: बारंगाय में गणितीय चिह्न नहीं
+              हो सकते
+            contains_restricted_characters_instructional: बारंगाय में केवल अक्षर,
+              संख्याएं, स्थानीय वर्ण और विशेष वर्ण शामिल हो सकते हैं
+            contains_restricted_characters_informative: बारंगाय में प्रतिबंधित वर्ण
+              नहीं हो सकते
+            contains_too_many_words_instructional: बारंगाय में %{word_count} से कम
+              शब्द होने चाहिए
+            contains_too_many_words_informative: बारंगाय में %{word_count} से कम शब्द
+              होने चाहिए
+            contains_html_tags_instructional: बारंगाय में HTML नहीं हो सकता
+            contains_html_tags_informative: बारंगाय में HTML नहीं हो सकता
+            contains_url_instructional: बारंगाय में कोई URL नहीं हो सकता
+            contains_url_informative: बारंगाय में कोई URL नहीं हो सकता
+            unknown_for_city_instructional: "%{city} के लिए एक मान्य बारंगाय का नाम
+              दर्ज करें"
+            unknown_for_city_informative: "%{city} के लिए एक मान्य बारंगाय का नाम
+              दर्ज करें"
+            unknown_for_zip_instructional: "%{zip} के लिए एक मान्य बारंगाय का नाम
+              दर्ज करें"
+            unknown_for_zip_informative: "%{zip} के लिए एक मान्य बारंगाय का नाम दर्ज
+              करें"
+            unknown_for_address_instructional: बारंगाय गलत हो सकता है
+            unknown_for_address_informative: बारंगाय गलत हो सकता है
+          warnings:
+            contains_too_many_words: यह सुझाव दिया जाता है कि बारंगाय में %{word_count}
+              से कम शब्द हों

--- a/data/regions/PH/hr.yml
+++ b/data/regions/PH/hr.yml
@@ -44,12 +44,13 @@ hr:
         district:
           label:
             default: Barangay
-            optional: Barangay (neobavezno)
+            optional: Barangay (nije obavezno)
           errors:
             blank_instructional: Unesite barangay
             blank_informative: Nedostaje barangay
-            too_long_instructional: 'Barangay je predug (najviše znakova: %{limit})'
-            too_long_informative: Barangay je predug
+            too_long_instructional: 'Naziv barangaya je predug (maksimalan broj znakova:
+              %{limit})'
+            too_long_informative: Naziv barangaya je predug
             contains_emojis_instructional: Barangay ne može sadržavati emojije
             contains_emojis_informative: Barangay ne može sadržavati emojije
             contains_mathematical_symbols_instructional: Barangay ne može sadržavati
@@ -59,24 +60,21 @@ hr:
             contains_restricted_characters_instructional: Barangay može sadržavati
               samo slova, brojeve, lokalne znakove i posebne znakove
             contains_restricted_characters_informative: Barangay ne može sadržavati
-              nedopuštene znakove
-            contains_too_many_words_instructional: Barangay mora imati manje od %{word_count}
-              riječi
-            contains_too_many_words_informative: Barangay mora imati manje od %{word_count}
-              riječi
+              zabranjene znakove
+            contains_too_many_words_instructional: Naziv barangaya mora imati manje
+              od %{word_count} riječi
+            contains_too_many_words_informative: Naziv barangaya mora imati manje
+              od %{word_count} riječi
             contains_html_tags_instructional: Barangay ne može sadržavati HTML
             contains_html_tags_informative: Barangay ne može sadržavati HTML
             contains_url_instructional: Barangay ne može sadržavati URL
             contains_url_informative: Barangay ne može sadržavati URL
-            unknown_for_city_instructional: Unesite važeći naziv barangaya za grad
-              %{city}
-            unknown_for_city_informative: Unesite važeći naziv barangaya za grad %{city}
-            unknown_for_zip_instructional: Unesite važeći naziv barangaya za poštanski
-              broj %{zip}
-            unknown_for_zip_informative: Unesite važeći naziv barangaya za poštanski
-              broj %{zip}
+            unknown_for_city_instructional: Unesite važeći naziv barangaya za %{city}
+            unknown_for_city_informative: Unesite važeći naziv barangaya za %{city}
+            unknown_for_zip_instructional: Unesite važeći naziv barangaya za %{zip}
+            unknown_for_zip_informative: Unesite važeći naziv barangaya za %{zip}
             unknown_for_address_instructional: Barangay je možda netočan
             unknown_for_address_informative: Barangay je možda netočan
           warnings:
-            contains_too_many_words: Preporučuje se da barangay ima manje od %{word_count}
-              riječi
+            contains_too_many_words: Preporučuje se da naziv barangaya ima manje od
+              %{word_count} riječi

--- a/data/regions/PH/hr.yml
+++ b/data/regions/PH/hr.yml
@@ -41,3 +41,42 @@ hr:
           warnings:
             contains_too_many_words: Preporučujemo da naziv barangaja sadrži manje
               od %{word_count} riječ/i
+        district:
+          label:
+            default: Barangay
+            optional: Barangay (neobavezno)
+          errors:
+            blank_instructional: Unesite barangay
+            blank_informative: Nedostaje barangay
+            too_long_instructional: 'Barangay je predug (najviše znakova: %{limit})'
+            too_long_informative: Barangay je predug
+            contains_emojis_instructional: Barangay ne može sadržavati emojije
+            contains_emojis_informative: Barangay ne može sadržavati emojije
+            contains_mathematical_symbols_instructional: Barangay ne može sadržavati
+              matematičke simbole
+            contains_mathematical_symbols_informative: Barangay ne može sadržavati
+              matematičke simbole
+            contains_restricted_characters_instructional: Barangay može sadržavati
+              samo slova, brojeve, lokalne znakove i posebne znakove
+            contains_restricted_characters_informative: Barangay ne može sadržavati
+              nedopuštene znakove
+            contains_too_many_words_instructional: Barangay mora imati manje od %{word_count}
+              riječi
+            contains_too_many_words_informative: Barangay mora imati manje od %{word_count}
+              riječi
+            contains_html_tags_instructional: Barangay ne može sadržavati HTML
+            contains_html_tags_informative: Barangay ne može sadržavati HTML
+            contains_url_instructional: Barangay ne može sadržavati URL
+            contains_url_informative: Barangay ne može sadržavati URL
+            unknown_for_city_instructional: Unesite važeći naziv barangaya za grad
+              %{city}
+            unknown_for_city_informative: Unesite važeći naziv barangaya za grad %{city}
+            unknown_for_zip_instructional: Unesite važeći naziv barangaya za poštanski
+              broj %{zip}
+            unknown_for_zip_informative: Unesite važeći naziv barangaya za poštanski
+              broj %{zip}
+            unknown_for_address_instructional: Barangay je možda netočan
+            unknown_for_address_informative: Barangay je možda netočan
+          warnings:
+            contains_too_many_words: Preporučuje se da barangay ima manje od %{word_count}
+              riječi

--- a/data/regions/PH/hu.yml
+++ b/data/regions/PH/hu.yml
@@ -64,24 +64,24 @@ hu:
               számokat, helyi karaktereket és speciális karaktereket tartalmazhat
             contains_restricted_characters_informative: A barangay nem tartalmazhat
               tiltott karaktereket
-            contains_too_many_words_instructional: A barangay kevesebb mint %{word_count}
-              szóból állhat
-            contains_too_many_words_informative: A barangay kevesebb mint %{word_count}
-              szóból állhat
+            contains_too_many_words_instructional: A barangay nevének kevesebb mint
+              %{word_count} szóból kell állnia
+            contains_too_many_words_informative: A barangay nevének kevesebb mint
+              %{word_count} szóból kell állnia
             contains_html_tags_instructional: A barangay nem tartalmazhat HTML-t
             contains_html_tags_informative: A barangay nem tartalmazhat HTML-t
             contains_url_instructional: A barangay nem tartalmazhat URL-t
             contains_url_informative: A barangay nem tartalmazhat URL-t
             unknown_for_city_instructional: 'Adjon meg egy érvényes barangaynevet
-              a következőhöz: %{city}'
-            unknown_for_city_informative: 'Adjon meg egy érvényes barangaynevet a
-              következőhöz: %{city}'
-            unknown_for_zip_instructional: 'Adjon meg egy érvényes barangaynevet a
-              következőhöz: %{zip}'
-            unknown_for_zip_informative: 'Adjon meg egy érvényes barangaynevet a következőhöz:
-              %{zip}'
-            unknown_for_address_instructional: A barangay helytelen lehet
-            unknown_for_address_informative: A barangay helytelen lehet
+              itt: %{city}'
+            unknown_for_city_informative: 'Adjon meg egy érvényes barangaynevet itt:
+              %{city}'
+            unknown_for_zip_instructional: 'Adjon meg egy érvényes barangaynevet ehhez
+              az irányítószámhoz: %{zip}'
+            unknown_for_zip_informative: 'Adjon meg egy érvényes barangaynevet ehhez
+              az irányítószámhoz: %{zip}'
+            unknown_for_address_instructional: Lehet, hogy a barangay hibás
+            unknown_for_address_informative: Lehet, hogy a barangay hibás
           warnings:
-            contains_too_many_words: Javasoljuk, hogy a barangay kevesebb mint %{word_count}
-              szóból álljon
+            contains_too_many_words: Javasoljuk, hogy a barangay neve kevesebb mint
+              %{word_count} szóból álljon

--- a/data/regions/PH/hu.yml
+++ b/data/regions/PH/hu.yml
@@ -44,3 +44,44 @@ hu:
           warnings:
             contains_too_many_words: A barangay nevének javasolt hossza kevesebb mint
               %{word_count} szó
+        district:
+          label:
+            default: Barangay
+            optional: Barangay (opcionális)
+          errors:
+            blank_instructional: Adjon meg egy barangayt
+            blank_informative: A barangay hiányzik
+            too_long_instructional: A barangay túl hosszú (legfeljebb %{limit} karakter
+              lehet)
+            too_long_informative: A barangay túl hosszú
+            contains_emojis_instructional: A barangay nem tartalmazhat emojikat
+            contains_emojis_informative: A barangay nem tartalmazhat emojikat
+            contains_mathematical_symbols_instructional: A barangay nem tartalmazhat
+              matematikai szimbólumokat
+            contains_mathematical_symbols_informative: A barangay nem tartalmazhat
+              matematikai szimbólumokat
+            contains_restricted_characters_instructional: A barangay csak betűket,
+              számokat, helyi karaktereket és speciális karaktereket tartalmazhat
+            contains_restricted_characters_informative: A barangay nem tartalmazhat
+              tiltott karaktereket
+            contains_too_many_words_instructional: A barangay kevesebb mint %{word_count}
+              szóból állhat
+            contains_too_many_words_informative: A barangay kevesebb mint %{word_count}
+              szóból állhat
+            contains_html_tags_instructional: A barangay nem tartalmazhat HTML-t
+            contains_html_tags_informative: A barangay nem tartalmazhat HTML-t
+            contains_url_instructional: A barangay nem tartalmazhat URL-t
+            contains_url_informative: A barangay nem tartalmazhat URL-t
+            unknown_for_city_instructional: 'Adjon meg egy érvényes barangaynevet
+              a következőhöz: %{city}'
+            unknown_for_city_informative: 'Adjon meg egy érvényes barangaynevet a
+              következőhöz: %{city}'
+            unknown_for_zip_instructional: 'Adjon meg egy érvényes barangaynevet a
+              következőhöz: %{zip}'
+            unknown_for_zip_informative: 'Adjon meg egy érvényes barangaynevet a következőhöz:
+              %{zip}'
+            unknown_for_address_instructional: A barangay helytelen lehet
+            unknown_for_address_informative: A barangay helytelen lehet
+          warnings:
+            contains_too_many_words: Javasoljuk, hogy a barangay kevesebb mint %{word_count}
+              szóból álljon

--- a/data/regions/PH/id.yml
+++ b/data/regions/PH/id.yml
@@ -43,3 +43,42 @@ id:
           warnings:
             contains_too_many_words: Nama barangay sebaiknya berisi kurang dari %{word_count}
               kata
+        district:
+          label:
+            default: Barangay
+            optional: Barangay (opsional)
+          errors:
+            blank_instructional: Masukkan barangay
+            blank_informative: Barangay belum diisi
+            too_long_instructional: Barangay terlalu panjang (maksimal %{limit} karakter)
+            too_long_informative: Barangay terlalu panjang
+            contains_emojis_instructional: Barangay tidak boleh berisi emoji
+            contains_emojis_informative: Barangay tidak boleh berisi emoji
+            contains_mathematical_symbols_instructional: Barangay tidak boleh berisi
+              simbol matematika
+            contains_mathematical_symbols_informative: Barangay tidak boleh berisi
+              simbol matematika
+            contains_restricted_characters_instructional: Barangay hanya boleh berisi
+              huruf, angka, karakter lokal, dan karakter khusus
+            contains_restricted_characters_informative: Barangay tidak boleh berisi
+              karakter yang dibatasi
+            contains_too_many_words_instructional: Barangay harus kurang dari %{word_count}
+              kata
+            contains_too_many_words_informative: Barangay harus kurang dari %{word_count}
+              kata
+            contains_html_tags_instructional: Barangay tidak boleh berisi HTML
+            contains_html_tags_informative: Barangay tidak boleh berisi HTML
+            contains_url_instructional: Barangay tidak boleh berisi URL
+            contains_url_informative: Barangay tidak boleh berisi URL
+            unknown_for_city_instructional: Masukkan nama barangay yang valid untuk
+              %{city}
+            unknown_for_city_informative: Masukkan nama barangay yang valid untuk
+              %{city}
+            unknown_for_zip_instructional: Masukkan nama barangay yang valid untuk
+              %{zip}
+            unknown_for_zip_informative: Masukkan nama barangay yang valid untuk %{zip}
+            unknown_for_address_instructional: Barangay mungkin salah
+            unknown_for_address_informative: Barangay mungkin salah
+          warnings:
+            contains_too_many_words: Barangay disarankan kurang dari %{word_count}
+              kata

--- a/data/regions/PH/id.yml
+++ b/data/regions/PH/id.yml
@@ -61,7 +61,7 @@ id:
             contains_restricted_characters_instructional: Barangay hanya boleh berisi
               huruf, angka, karakter lokal, dan karakter khusus
             contains_restricted_characters_informative: Barangay tidak boleh berisi
-              karakter yang dibatasi
+              karakter yang dilarang
             contains_too_many_words_instructional: Barangay harus kurang dari %{word_count}
               kata
             contains_too_many_words_informative: Barangay harus kurang dari %{word_count}

--- a/data/regions/PH/it.yml
+++ b/data/regions/PH/it.yml
@@ -45,3 +45,43 @@ it:
           warnings:
             contains_too_many_words: Il campo Barangay deve contenere meno di %{word_count}
               parole
+        district:
+          label:
+            default: Barangay
+            optional: Barangay (facoltativo)
+          errors:
+            blank_instructional: Inserisci un barangay
+            blank_informative: Barangay mancante
+            too_long_instructional: Il barangay è troppo lungo (massimo %{limit} caratteri)
+            too_long_informative: Il barangay è troppo lungo
+            contains_emojis_instructional: Il barangay non può contenere emoji
+            contains_emojis_informative: Il barangay non può contenere emoji
+            contains_mathematical_symbols_instructional: Il barangay non può contenere
+              simboli matematici
+            contains_mathematical_symbols_informative: Il barangay non può contenere
+              simboli matematici
+            contains_restricted_characters_instructional: Il barangay può contenere
+              solo lettere, numeri, caratteri locali e caratteri speciali
+            contains_restricted_characters_informative: Il barangay non può contenere
+              caratteri non consentiti
+            contains_too_many_words_instructional: Il barangay deve contenere meno
+              di %{word_count} parole
+            contains_too_many_words_informative: Il barangay deve contenere meno di
+              %{word_count} parole
+            contains_html_tags_instructional: Il barangay non può contenere HTML
+            contains_html_tags_informative: Il barangay non può contenere HTML
+            contains_url_instructional: Il barangay non può contenere un URL
+            contains_url_informative: Il barangay non può contenere un URL
+            unknown_for_city_instructional: Inserisci un nome di barangay valido per
+              %{city}
+            unknown_for_city_informative: Inserisci un nome di barangay valido per
+              %{city}
+            unknown_for_zip_instructional: Inserisci un nome di barangay valido per
+              %{zip}
+            unknown_for_zip_informative: Inserisci un nome di barangay valido per
+              %{zip}
+            unknown_for_address_instructional: Il barangay potrebbe essere errato
+            unknown_for_address_informative: Il barangay potrebbe essere errato
+          warnings:
+            contains_too_many_words: È consigliabile che il barangay contenga meno
+              di %{word_count} parole

--- a/data/regions/PH/it.yml
+++ b/data/regions/PH/it.yml
@@ -51,7 +51,7 @@ it:
             optional: Barangay (facoltativo)
           errors:
             blank_instructional: Inserisci un barangay
-            blank_informative: Barangay mancante
+            blank_informative: Manca il barangay
             too_long_instructional: Il barangay è troppo lungo (massimo %{limit} caratteri)
             too_long_informative: Il barangay è troppo lungo
             contains_emojis_instructional: Il barangay non può contenere emoji
@@ -64,10 +64,10 @@ it:
               solo lettere, numeri, caratteri locali e caratteri speciali
             contains_restricted_characters_informative: Il barangay non può contenere
               caratteri non consentiti
-            contains_too_many_words_instructional: Il barangay deve contenere meno
-              di %{word_count} parole
-            contains_too_many_words_informative: Il barangay deve contenere meno di
+            contains_too_many_words_instructional: Il barangay deve avere meno di
               %{word_count} parole
+            contains_too_many_words_informative: Il barangay deve avere meno di %{word_count}
+              parole
             contains_html_tags_instructional: Il barangay non può contenere HTML
             contains_html_tags_informative: Il barangay non può contenere HTML
             contains_url_instructional: Il barangay non può contenere un URL
@@ -83,5 +83,5 @@ it:
             unknown_for_address_instructional: Il barangay potrebbe essere errato
             unknown_for_address_informative: Il barangay potrebbe essere errato
           warnings:
-            contains_too_many_words: È consigliabile che il barangay contenga meno
+            contains_too_many_words: Si consiglia di inserire un barangay con meno
               di %{word_count} parole

--- a/data/regions/PH/ja.yml
+++ b/data/regions/PH/ja.yml
@@ -32,3 +32,32 @@ ja:
             unknown_for_address_informative: バランガイが正しくない可能性があります
           warnings:
             contains_too_many_words: バランガイは%{word_count}文字未満が推奨されています
+        district:
+          label:
+            default: バランガイ
+            optional: バランガイ (オプション)
+          errors:
+            blank_instructional: バランガイを入力してください
+            blank_informative: バランガイが入力されていません
+            too_long_instructional: バランガイが長すぎます (最大 %{limit} 文字)
+            too_long_informative: バランガイが長すぎます
+            contains_emojis_instructional: バランガイに絵文字を含めることはできません
+            contains_emojis_informative: バランガイに絵文字を含めることはできません
+            contains_mathematical_symbols_instructional: バランガイに数学記号を含めることはできません
+            contains_mathematical_symbols_informative: バランガイに数学記号を含めることはできません
+            contains_restricted_characters_instructional: バランガイには、文字、数字、現地の文字、特殊文字のみを使用できます
+            contains_restricted_characters_informative: バランガイに制限された文字を含めることはできません
+            contains_too_many_words_instructional: バランガイは %{word_count} 語未満にする必要があります
+            contains_too_many_words_informative: バランガイは %{word_count} 語未満にする必要があります
+            contains_html_tags_instructional: バランガイに HTML を含めることはできません
+            contains_html_tags_informative: バランガイに HTML を含めることはできません
+            contains_url_instructional: バランガイに URL を含めることはできません
+            contains_url_informative: バランガイに URL を含めることはできません
+            unknown_for_city_instructional: "%{city} に有効なバランガイ名を入力してください"
+            unknown_for_city_informative: "%{city} に有効なバランガイ名を入力してください"
+            unknown_for_zip_instructional: "%{zip} に有効なバランガイ名を入力してください"
+            unknown_for_zip_informative: "%{zip} に有効なバランガイ名を入力してください"
+            unknown_for_address_instructional: バランガイが間違っている可能性があります
+            unknown_for_address_informative: バランガイが間違っている可能性があります
+          warnings:
+            contains_too_many_words: バランガイは %{word_count} 語未満にすることをおすすめします

--- a/data/regions/PH/ja.yml
+++ b/data/regions/PH/ja.yml
@@ -35,16 +35,16 @@ ja:
         district:
           label:
             default: バランガイ
-            optional: バランガイ (オプション)
+            optional: バランガイ（オプション）
           errors:
             blank_instructional: バランガイを入力してください
             blank_informative: バランガイが入力されていません
-            too_long_instructional: バランガイが長すぎます (最大 %{limit} 文字)
+            too_long_instructional: バランガイが長すぎます（最大 %{limit} 文字）
             too_long_informative: バランガイが長すぎます
             contains_emojis_instructional: バランガイに絵文字を含めることはできません
             contains_emojis_informative: バランガイに絵文字を含めることはできません
-            contains_mathematical_symbols_instructional: バランガイに数学記号を含めることはできません
-            contains_mathematical_symbols_informative: バランガイに数学記号を含めることはできません
+            contains_mathematical_symbols_instructional: バランガイに算術記号を含めることはできません
+            contains_mathematical_symbols_informative: バランガイに算術記号を含めることはできません
             contains_restricted_characters_instructional: バランガイには、文字、数字、現地の文字、特殊文字のみを使用できます
             contains_restricted_characters_informative: バランガイに制限された文字を含めることはできません
             contains_too_many_words_instructional: バランガイは %{word_count} 語未満にする必要があります
@@ -53,11 +53,11 @@ ja:
             contains_html_tags_informative: バランガイに HTML を含めることはできません
             contains_url_instructional: バランガイに URL を含めることはできません
             contains_url_informative: バランガイに URL を含めることはできません
-            unknown_for_city_instructional: "%{city} に有効なバランガイ名を入力してください"
-            unknown_for_city_informative: "%{city} に有効なバランガイ名を入力してください"
-            unknown_for_zip_instructional: "%{zip} に有効なバランガイ名を入力してください"
-            unknown_for_zip_informative: "%{zip} に有効なバランガイ名を入力してください"
-            unknown_for_address_instructional: バランガイが間違っている可能性があります
-            unknown_for_address_informative: バランガイが間違っている可能性があります
+            unknown_for_city_instructional: "%{city} の有効なバランガイ名を入力してください"
+            unknown_for_city_informative: "%{city} の有効なバランガイ名を入力してください"
+            unknown_for_zip_instructional: "%{zip} の有効なバランガイ名を入力してください"
+            unknown_for_zip_informative: "%{zip} の有効なバランガイ名を入力してください"
+            unknown_for_address_instructional: バランガイに誤りがある可能性があります
+            unknown_for_address_informative: バランガイに誤りがある可能性があります
           warnings:
             contains_too_many_words: バランガイは %{word_count} 語未満にすることをおすすめします

--- a/data/regions/PH/ko.yml
+++ b/data/regions/PH/ko.yml
@@ -39,3 +39,35 @@ ko:
           warnings:
             contains_too_many_words: Barangay(필리핀 행정구역)에는 %{word_count}개 미만의 단어를 사용하는
               것이 좋습니다
+        district:
+          label:
+            default: 바랑가이
+            optional: 바랑가이(선택 사항)
+          errors:
+            blank_instructional: 바랑가이를 입력하십시오.
+            blank_informative: 바랑가이가 누락되었습니다.
+            too_long_instructional: 바랑가이가 너무 깁니다(최대 %{limit}자).
+            too_long_informative: 바랑가이가 너무 깁니다.
+            contains_emojis_instructional: 바랑가이에는 이모티콘을 포함할 수 없습니다.
+            contains_emojis_informative: 바랑가이에는 이모티콘을 포함할 수 없습니다.
+            contains_mathematical_symbols_instructional: 바랑가이에는 수학 기호를 포함할 수 없습니다.
+            contains_mathematical_symbols_informative: 바랑가이에는 수학 기호를 포함할 수 없습니다.
+            contains_restricted_characters_instructional: 바랑가이에는 문자, 숫자, 현지 문자, 특수
+              문자만 포함할 수 있습니다.
+            contains_restricted_characters_informative: 바랑가이에는 제한된 문자를 포함할 수 없습니다.
+            contains_too_many_words_instructional: 바랑가이는 %{word_count}개 미만의 단어로 구성되어야
+              합니다.
+            contains_too_many_words_informative: 바랑가이는 %{word_count}개 미만의 단어로 구성되어야
+              합니다.
+            contains_html_tags_instructional: 바랑가이에는 HTML을 포함할 수 없습니다.
+            contains_html_tags_informative: 바랑가이에는 HTML을 포함할 수 없습니다.
+            contains_url_instructional: 바랑가이에는 URL을 포함할 수 없습니다.
+            contains_url_informative: 바랑가이에는 URL을 포함할 수 없습니다.
+            unknown_for_city_instructional: "%{city}의 유효한 바랑가이 이름을 입력하십시오."
+            unknown_for_city_informative: "%{city}의 유효한 바랑가이 이름을 입력하십시오."
+            unknown_for_zip_instructional: "%{zip}의 유효한 바랑가이 이름을 입력하십시오."
+            unknown_for_zip_informative: "%{zip}의 유효한 바랑가이 이름을 입력하십시오."
+            unknown_for_address_instructional: 바랑가이가 올바르지 않을 수 있습니다.
+            unknown_for_address_informative: 바랑가이가 올바르지 않을 수 있습니다.
+          warnings:
+            contains_too_many_words: 바랑가이는 %{word_count}개 미만의 단어로 구성하는 것이 좋습니다.

--- a/data/regions/PH/ko.yml
+++ b/data/regions/PH/ko.yml
@@ -48,17 +48,15 @@ ko:
             blank_informative: 바랑가이가 누락되었습니다.
             too_long_instructional: 바랑가이가 너무 깁니다(최대 %{limit}자).
             too_long_informative: 바랑가이가 너무 깁니다.
-            contains_emojis_instructional: 바랑가이에는 이모티콘을 포함할 수 없습니다.
-            contains_emojis_informative: 바랑가이에는 이모티콘을 포함할 수 없습니다.
+            contains_emojis_instructional: 바랑가이에는 이모지를 포함할 수 없습니다.
+            contains_emojis_informative: 바랑가이에는 이모지를 포함할 수 없습니다.
             contains_mathematical_symbols_instructional: 바랑가이에는 수학 기호를 포함할 수 없습니다.
             contains_mathematical_symbols_informative: 바랑가이에는 수학 기호를 포함할 수 없습니다.
-            contains_restricted_characters_instructional: 바랑가이에는 문자, 숫자, 현지 문자, 특수
+            contains_restricted_characters_instructional: 바랑가이에는 문자, 숫자, 현지 문자 및 특수
               문자만 포함할 수 있습니다.
             contains_restricted_characters_informative: 바랑가이에는 제한된 문자를 포함할 수 없습니다.
-            contains_too_many_words_instructional: 바랑가이는 %{word_count}개 미만의 단어로 구성되어야
-              합니다.
-            contains_too_many_words_informative: 바랑가이는 %{word_count}개 미만의 단어로 구성되어야
-              합니다.
+            contains_too_many_words_instructional: 바랑가이는 %{word_count}단어 미만이어야 합니다.
+            contains_too_many_words_informative: 바랑가이는 %{word_count}단어 미만이어야 합니다.
             contains_html_tags_instructional: 바랑가이에는 HTML을 포함할 수 없습니다.
             contains_html_tags_informative: 바랑가이에는 HTML을 포함할 수 없습니다.
             contains_url_instructional: 바랑가이에는 URL을 포함할 수 없습니다.
@@ -70,4 +68,4 @@ ko:
             unknown_for_address_instructional: 바랑가이가 올바르지 않을 수 있습니다.
             unknown_for_address_informative: 바랑가이가 올바르지 않을 수 있습니다.
           warnings:
-            contains_too_many_words: 바랑가이는 %{word_count}개 미만의 단어로 구성하는 것이 좋습니다.
+            contains_too_many_words: 바랑가이는 %{word_count}단어 미만으로 입력하는 것이 좋습니다.

--- a/data/regions/PH/lt.yml
+++ b/data/regions/PH/lt.yml
@@ -49,3 +49,44 @@ lt:
           warnings:
             contains_too_many_words: Patartina, kad bario pavadinimą sudarytų mažiau
               nei %{word_count} žodžiai (-ių, -is)
+        district:
+          label:
+            default: Barangajus
+            optional: Barangajus (neprivaloma)
+          errors:
+            blank_instructional: Įveskite barangajų
+            blank_informative: Nenurodytas barangajus
+            too_long_instructional: Barangajaus pavadinimas per ilgas (daugiausia
+              %{limit} simbolių)
+            too_long_informative: Barangajaus pavadinimas per ilgas
+            contains_emojis_instructional: Barangajaus pavadinime negali būti jaustukų
+            contains_emojis_informative: Barangajaus pavadinime negali būti jaustukų
+            contains_mathematical_symbols_instructional: Barangajaus pavadinime negali
+              būti matematinių simbolių
+            contains_mathematical_symbols_informative: Barangajaus pavadinime negali
+              būti matematinių simbolių
+            contains_restricted_characters_instructional: Barangajaus pavadinime gali
+              būti tik raidės, skaičiai, vietiniai ir specialieji simboliai
+            contains_restricted_characters_informative: Barangajaus pavadinime negali
+              būti draudžiamų simbolių
+            contains_too_many_words_instructional: Barangajaus pavadinimą turi sudaryti
+              mažiau nei %{word_count} žodžių
+            contains_too_many_words_informative: Barangajaus pavadinimą turi sudaryti
+              mažiau nei %{word_count} žodžių
+            contains_html_tags_instructional: Barangajaus pavadinime negali būti HTML
+            contains_html_tags_informative: Barangajaus pavadinime negali būti HTML
+            contains_url_instructional: Barangajaus pavadinime negali būti URL
+            contains_url_informative: Barangajaus pavadinime negali būti URL
+            unknown_for_city_instructional: Įveskite tinkamą barangajaus pavadinimą
+              miestui %{city}
+            unknown_for_city_informative: Įveskite tinkamą barangajaus pavadinimą
+              miestui %{city}
+            unknown_for_zip_instructional: Įveskite tinkamą barangajaus pavadinimą
+              pašto kodui %{zip}
+            unknown_for_zip_informative: Įveskite tinkamą barangajaus pavadinimą pašto
+              kodui %{zip}
+            unknown_for_address_instructional: Barangajus gali būti nurodytas neteisingai
+            unknown_for_address_informative: Barangajus gali būti nurodytas neteisingai
+          warnings:
+            contains_too_many_words: Rekomenduojama, kad barangajaus pavadinimą sudarytų
+              mažiau nei %{word_count} žodžių

--- a/data/regions/PH/lt.yml
+++ b/data/regions/PH/lt.yml
@@ -52,12 +52,12 @@ lt:
         district:
           label:
             default: Barangajus
-            optional: Barangajus (neprivaloma)
+            optional: Barangajus (pasirenkama)
           errors:
             blank_instructional: Įveskite barangajų
             blank_informative: Nenurodytas barangajus
             too_long_instructional: Barangajaus pavadinimas per ilgas (daugiausia
-              %{limit} simbolių)
+              %{limit} simb.)
             too_long_informative: Barangajaus pavadinimas per ilgas
             contains_emojis_instructional: Barangajaus pavadinime negali būti jaustukų
             contains_emojis_informative: Barangajaus pavadinime negali būti jaustukų
@@ -70,23 +70,19 @@ lt:
             contains_restricted_characters_informative: Barangajaus pavadinime negali
               būti draudžiamų simbolių
             contains_too_many_words_instructional: Barangajaus pavadinimą turi sudaryti
-              mažiau nei %{word_count} žodžių
+              mažiau nei %{word_count} žodž.
             contains_too_many_words_informative: Barangajaus pavadinimą turi sudaryti
-              mažiau nei %{word_count} žodžių
+              mažiau nei %{word_count} žodž.
             contains_html_tags_instructional: Barangajaus pavadinime negali būti HTML
             contains_html_tags_informative: Barangajaus pavadinime negali būti HTML
             contains_url_instructional: Barangajaus pavadinime negali būti URL
             contains_url_informative: Barangajaus pavadinime negali būti URL
-            unknown_for_city_instructional: Įveskite tinkamą barangajaus pavadinimą
-              miestui %{city}
-            unknown_for_city_informative: Įveskite tinkamą barangajaus pavadinimą
-              miestui %{city}
-            unknown_for_zip_instructional: Įveskite tinkamą barangajaus pavadinimą
-              pašto kodui %{zip}
-            unknown_for_zip_informative: Įveskite tinkamą barangajaus pavadinimą pašto
-              kodui %{zip}
+            unknown_for_city_instructional: Įveskite tinkamą %{city} barangajaus pavadinimą
+            unknown_for_city_informative: Įveskite tinkamą %{city} barangajaus pavadinimą
+            unknown_for_zip_instructional: Įveskite tinkamą %{zip} barangajaus pavadinimą
+            unknown_for_zip_informative: Įveskite tinkamą %{zip} barangajaus pavadinimą
             unknown_for_address_instructional: Barangajus gali būti nurodytas neteisingai
             unknown_for_address_informative: Barangajus gali būti nurodytas neteisingai
           warnings:
             contains_too_many_words: Rekomenduojama, kad barangajaus pavadinimą sudarytų
-              mažiau nei %{word_count} žodžių
+              mažiau nei %{word_count} žodž.

--- a/data/regions/PH/ms.yml
+++ b/data/regions/PH/ms.yml
@@ -77,5 +77,5 @@ ms:
             unknown_for_address_instructional: Barangay mungkin tidak betul
             unknown_for_address_informative: Barangay mungkin tidak betul
           warnings:
-            contains_too_many_words: Barangay disyorkan agar kurang daripada %{word_count}
-              perkataan
+            contains_too_many_words: Barangay disyorkan mempunyai kurang daripada
+              %{word_count} perkataan

--- a/data/regions/PH/ms.yml
+++ b/data/regions/PH/ms.yml
@@ -41,3 +41,41 @@ ms:
           warnings:
             contains_too_many_words: Barangay disyorkan untuk mengandungi kurang daripada
               %{word_count} perkataan
+        district:
+          label:
+            default: Barangay
+            optional: Barangay (pilihan)
+          errors:
+            blank_instructional: Masukkan barangay
+            blank_informative: Barangay tiada
+            too_long_instructional: Barangay terlalu panjang (maksimum ialah %{limit}
+              aksara)
+            too_long_informative: Barangay terlalu panjang
+            contains_emojis_instructional: Barangay tidak boleh mengandungi emoji
+            contains_emojis_informative: Barangay tidak boleh mengandungi emoji
+            contains_mathematical_symbols_instructional: Barangay tidak boleh mengandungi
+              simbol matematik
+            contains_mathematical_symbols_informative: Barangay tidak boleh mengandungi
+              simbol matematik
+            contains_restricted_characters_instructional: Barangay hanya boleh mengandungi
+              huruf, nombor, aksara tempatan dan aksara khas
+            contains_restricted_characters_informative: Barangay tidak boleh mengandungi
+              aksara terhad
+            contains_too_many_words_instructional: Barangay mesti kurang daripada
+              %{word_count} perkataan
+            contains_too_many_words_informative: Barangay mesti kurang daripada %{word_count}
+              perkataan
+            contains_html_tags_instructional: Barangay tidak boleh mengandungi HTML
+            contains_html_tags_informative: Barangay tidak boleh mengandungi HTML
+            contains_url_instructional: Barangay tidak boleh mengandungi URL
+            contains_url_informative: Barangay tidak boleh mengandungi URL
+            unknown_for_city_instructional: Masukkan nama barangay yang sah untuk
+              %{city}
+            unknown_for_city_informative: Masukkan nama barangay yang sah untuk %{city}
+            unknown_for_zip_instructional: Masukkan nama barangay yang sah untuk %{zip}
+            unknown_for_zip_informative: Masukkan nama barangay yang sah untuk %{zip}
+            unknown_for_address_instructional: Barangay mungkin tidak betul
+            unknown_for_address_informative: Barangay mungkin tidak betul
+          warnings:
+            contains_too_many_words: Barangay disyorkan agar kurang daripada %{word_count}
+              perkataan

--- a/data/regions/PH/nb.yml
+++ b/data/regions/PH/nb.yml
@@ -47,8 +47,8 @@ nb:
           errors:
             blank_instructional: Angi en barangay
             blank_informative: Barangay mangler
-            too_long_instructional: Barangay er for lang (maks %{limit} tegn)
-            too_long_informative: Barangay er for lang
+            too_long_instructional: Barangayen er for lang (maksimalt %{limit} tegn)
+            too_long_informative: Barangayen er for lang
             contains_emojis_instructional: Barangay kan ikke inneholde emojier
             contains_emojis_informative: Barangay kan ikke inneholde emojier
             contains_mathematical_symbols_instructional: Barangay kan ikke inneholde
@@ -58,7 +58,7 @@ nb:
             contains_restricted_characters_instructional: Barangay kan bare inneholde
               bokstaver, tall, lokale tegn og spesialtegn
             contains_restricted_characters_informative: Barangay kan ikke inneholde
-              begrensede tegn
+              ikke-tillatte tegn
             contains_too_many_words_instructional: Barangay må ha færre enn %{word_count}
               ord
             contains_too_many_words_informative: Barangay må ha færre enn %{word_count}
@@ -71,8 +71,8 @@ nb:
             unknown_for_city_informative: Angi et gyldig barangay-navn for %{city}
             unknown_for_zip_instructional: Angi et gyldig barangay-navn for %{zip}
             unknown_for_zip_informative: Angi et gyldig barangay-navn for %{zip}
-            unknown_for_address_instructional: Barangay kan være feil
-            unknown_for_address_informative: Barangay kan være feil
+            unknown_for_address_instructional: Barangayen kan være feil
+            unknown_for_address_informative: Barangayen kan være feil
           warnings:
-            contains_too_many_words: Det anbefales at barangay har færre enn %{word_count}
+            contains_too_many_words: Det anbefales at barangayen har færre enn %{word_count}
               ord

--- a/data/regions/PH/nb.yml
+++ b/data/regions/PH/nb.yml
@@ -40,3 +40,39 @@ nb:
           warnings:
             contains_too_many_words: Vi anbefaler at barangaynavnet inneholder færre
               enn %{word_count} ord
+        district:
+          label:
+            default: Barangay
+            optional: Barangay (valgfritt)
+          errors:
+            blank_instructional: Angi en barangay
+            blank_informative: Barangay mangler
+            too_long_instructional: Barangay er for lang (maks %{limit} tegn)
+            too_long_informative: Barangay er for lang
+            contains_emojis_instructional: Barangay kan ikke inneholde emojier
+            contains_emojis_informative: Barangay kan ikke inneholde emojier
+            contains_mathematical_symbols_instructional: Barangay kan ikke inneholde
+              matematiske symboler
+            contains_mathematical_symbols_informative: Barangay kan ikke inneholde
+              matematiske symboler
+            contains_restricted_characters_instructional: Barangay kan bare inneholde
+              bokstaver, tall, lokale tegn og spesialtegn
+            contains_restricted_characters_informative: Barangay kan ikke inneholde
+              begrensede tegn
+            contains_too_many_words_instructional: Barangay må ha færre enn %{word_count}
+              ord
+            contains_too_many_words_informative: Barangay må ha færre enn %{word_count}
+              ord
+            contains_html_tags_instructional: Barangay kan ikke inneholde HTML
+            contains_html_tags_informative: Barangay kan ikke inneholde HTML
+            contains_url_instructional: Barangay kan ikke inneholde en URL-adresse
+            contains_url_informative: Barangay kan ikke inneholde en URL-adresse
+            unknown_for_city_instructional: Angi et gyldig barangay-navn for %{city}
+            unknown_for_city_informative: Angi et gyldig barangay-navn for %{city}
+            unknown_for_zip_instructional: Angi et gyldig barangay-navn for %{zip}
+            unknown_for_zip_informative: Angi et gyldig barangay-navn for %{zip}
+            unknown_for_address_instructional: Barangay kan være feil
+            unknown_for_address_informative: Barangay kan være feil
+          warnings:
+            contains_too_many_words: Det anbefales at barangay har færre enn %{word_count}
+              ord

--- a/data/regions/PH/nl.yml
+++ b/data/regions/PH/nl.yml
@@ -40,3 +40,40 @@ nl:
           warnings:
             contains_too_many_words: Geef minder dan %{word_count} woorden op voor
               barangay
+        district:
+          label:
+            default: Barangay
+            optional: Barangay (optioneel)
+          errors:
+            blank_instructional: Voer een barangay in
+            blank_informative: Barangay ontbreekt
+            too_long_instructional: Barangay is te lang (maximaal %{limit} tekens)
+            too_long_informative: Barangay is te lang
+            contains_emojis_instructional: Barangay mag geen emoji's bevatten
+            contains_emojis_informative: Barangay mag geen emoji's bevatten
+            contains_mathematical_symbols_instructional: Barangay mag geen wiskundige
+              symbolen bevatten
+            contains_mathematical_symbols_informative: Barangay mag geen wiskundige
+              symbolen bevatten
+            contains_restricted_characters_instructional: Barangay mag alleen letters,
+              cijfers, lokale tekens en speciale tekens bevatten
+            contains_restricted_characters_informative: Barangay mag geen niet-toegestane
+              tekens bevatten
+            contains_too_many_words_instructional: Barangay moet minder dan %{word_count}
+              woorden bevatten
+            contains_too_many_words_informative: Barangay moet minder dan %{word_count}
+              woorden bevatten
+            contains_html_tags_instructional: Barangay mag geen HTML bevatten
+            contains_html_tags_informative: Barangay mag geen HTML bevatten
+            contains_url_instructional: Barangay mag geen URL bevatten
+            contains_url_informative: Barangay mag geen URL bevatten
+            unknown_for_city_instructional: Voer een geldige barangaynaam in voor
+              %{city}
+            unknown_for_city_informative: Voer een geldige barangaynaam in voor %{city}
+            unknown_for_zip_instructional: Voer een geldige barangaynaam in voor %{zip}
+            unknown_for_zip_informative: Voer een geldige barangaynaam in voor %{zip}
+            unknown_for_address_instructional: Barangay is mogelijk onjuist
+            unknown_for_address_informative: Barangay is mogelijk onjuist
+          warnings:
+            contains_too_many_words: Barangay bevat bij voorkeur minder dan %{word_count}
+              woorden

--- a/data/regions/PH/nl.yml
+++ b/data/regions/PH/nl.yml
@@ -57,12 +57,12 @@ nl:
               symbolen bevatten
             contains_restricted_characters_instructional: Barangay mag alleen letters,
               cijfers, lokale tekens en speciale tekens bevatten
-            contains_restricted_characters_informative: Barangay mag geen niet-toegestane
+            contains_restricted_characters_informative: Barangay mag geen beperkte
               tekens bevatten
-            contains_too_many_words_instructional: Barangay moet minder dan %{word_count}
-              woorden bevatten
-            contains_too_many_words_informative: Barangay moet minder dan %{word_count}
-              woorden bevatten
+            contains_too_many_words_instructional: Barangay moet uit minder dan %{word_count}
+              woorden bestaan
+            contains_too_many_words_informative: Barangay moet uit minder dan %{word_count}
+              woorden bestaan
             contains_html_tags_instructional: Barangay mag geen HTML bevatten
             contains_html_tags_informative: Barangay mag geen HTML bevatten
             contains_url_instructional: Barangay mag geen URL bevatten

--- a/data/regions/PH/pl.yml
+++ b/data/regions/PH/pl.yml
@@ -46,37 +46,40 @@ pl:
             optional: Barangay (opcjonalnie)
           errors:
             blank_instructional: Wprowadź barangay
-            blank_informative: Brakuje barangayu
-            too_long_instructional: Barangay jest za długi (maksymalnie %{limit} znaków)
-            too_long_informative: Barangay jest za długi
-            contains_emojis_instructional: Barangay nie może zawierać emoji
-            contains_emojis_informative: Barangay nie może zawierać emoji
-            contains_mathematical_symbols_instructional: Barangay nie może zawierać
+            blank_informative: Brak barangayu
+            too_long_instructional: Nazwa barangayu jest za długa (maksymalnie %{limit}
+              znaków)
+            too_long_informative: Nazwa barangayu jest za długa
+            contains_emojis_instructional: Nazwa barangayu nie może zawierać emoji
+            contains_emojis_informative: Nazwa barangayu nie może zawierać emoji
+            contains_mathematical_symbols_instructional: Nazwa barangayu nie może
+              zawierać symboli matematycznych
+            contains_mathematical_symbols_informative: Nazwa barangayu nie może zawierać
               symboli matematycznych
-            contains_mathematical_symbols_informative: Barangay nie może zawierać
-              symboli matematycznych
-            contains_restricted_characters_instructional: Barangay może zawierać tylko
-              litery, cyfry, znaki lokalne i znaki specjalne
-            contains_restricted_characters_informative: Barangay nie może zawierać
+            contains_restricted_characters_instructional: Nazwa barangayu może zawierać
+              tylko litery, cyfry, znaki lokalne i znaki specjalne
+            contains_restricted_characters_informative: Nazwa barangayu nie może zawierać
               niedozwolonych znaków
-            contains_too_many_words_instructional: Barangay musi zawierać mniej niż
-              %{word_count} słów
-            contains_too_many_words_informative: Barangay musi zawierać mniej niż
-              %{word_count} słów
-            contains_html_tags_instructional: Barangay nie może zawierać kodu HTML
-            contains_html_tags_informative: Barangay nie może zawierać kodu HTML
-            contains_url_instructional: Barangay nie może zawierać adresu URL
-            contains_url_informative: Barangay nie może zawierać adresu URL
-            unknown_for_city_instructional: Wprowadź prawidłową nazwę barangayu dla
-              miasta %{city}
-            unknown_for_city_informative: Wprowadź prawidłową nazwę barangayu dla
-              miasta %{city}
-            unknown_for_zip_instructional: Wprowadź prawidłową nazwę barangayu dla
-              kodu pocztowego %{zip}
-            unknown_for_zip_informative: Wprowadź prawidłową nazwę barangayu dla kodu
-              pocztowego %{zip}
-            unknown_for_address_instructional: Barangay może być nieprawidłowy
-            unknown_for_address_informative: Barangay może być nieprawidłowy
+            contains_too_many_words_instructional: Liczba słów w nazwie barangayu
+              musi być mniejsza niż %{word_count}
+            contains_too_many_words_informative: Liczba słów w nazwie barangayu musi
+              być mniejsza niż %{word_count}
+            contains_html_tags_instructional: Nazwa barangayu nie może zawierać kodu
+              HTML
+            contains_html_tags_informative: Nazwa barangayu nie może zawierać kodu
+              HTML
+            contains_url_instructional: Nazwa barangayu nie może zawierać adresu URL
+            contains_url_informative: Nazwa barangayu nie może zawierać adresu URL
+            unknown_for_city_instructional: 'Wprowadź prawidłową nazwę barangayu dla:
+              %{city}'
+            unknown_for_city_informative: 'Wprowadź prawidłową nazwę barangayu dla:
+              %{city}'
+            unknown_for_zip_instructional: 'Wprowadź prawidłową nazwę barangayu dla:
+              %{zip}'
+            unknown_for_zip_informative: 'Wprowadź prawidłową nazwę barangayu dla:
+              %{zip}'
+            unknown_for_address_instructional: Nazwa barangayu może być nieprawidłowa
+            unknown_for_address_informative: Nazwa barangayu może być nieprawidłowa
           warnings:
-            contains_too_many_words: Zaleca się, aby barangay zawierał mniej niż %{word_count}
-              słów
+            contains_too_many_words: Zaleca się, aby liczba słów w nazwie barangayu
+              była mniejsza niż %{word_count}

--- a/data/regions/PH/pl.yml
+++ b/data/regions/PH/pl.yml
@@ -40,3 +40,43 @@ pl:
           warnings:
             contains_too_many_words: Zaleca się, aby barangay zawierał mniej niż %{word_count}
               słów (słowa)
+        district:
+          label:
+            default: Barangay
+            optional: Barangay (opcjonalnie)
+          errors:
+            blank_instructional: Wprowadź barangay
+            blank_informative: Brakuje barangayu
+            too_long_instructional: Barangay jest za długi (maksymalnie %{limit} znaków)
+            too_long_informative: Barangay jest za długi
+            contains_emojis_instructional: Barangay nie może zawierać emoji
+            contains_emojis_informative: Barangay nie może zawierać emoji
+            contains_mathematical_symbols_instructional: Barangay nie może zawierać
+              symboli matematycznych
+            contains_mathematical_symbols_informative: Barangay nie może zawierać
+              symboli matematycznych
+            contains_restricted_characters_instructional: Barangay może zawierać tylko
+              litery, cyfry, znaki lokalne i znaki specjalne
+            contains_restricted_characters_informative: Barangay nie może zawierać
+              niedozwolonych znaków
+            contains_too_many_words_instructional: Barangay musi zawierać mniej niż
+              %{word_count} słów
+            contains_too_many_words_informative: Barangay musi zawierać mniej niż
+              %{word_count} słów
+            contains_html_tags_instructional: Barangay nie może zawierać kodu HTML
+            contains_html_tags_informative: Barangay nie może zawierać kodu HTML
+            contains_url_instructional: Barangay nie może zawierać adresu URL
+            contains_url_informative: Barangay nie może zawierać adresu URL
+            unknown_for_city_instructional: Wprowadź prawidłową nazwę barangayu dla
+              miasta %{city}
+            unknown_for_city_informative: Wprowadź prawidłową nazwę barangayu dla
+              miasta %{city}
+            unknown_for_zip_instructional: Wprowadź prawidłową nazwę barangayu dla
+              kodu pocztowego %{zip}
+            unknown_for_zip_informative: Wprowadź prawidłową nazwę barangayu dla kodu
+              pocztowego %{zip}
+            unknown_for_address_instructional: Barangay może być nieprawidłowy
+            unknown_for_address_informative: Barangay może być nieprawidłowy
+          warnings:
+            contains_too_many_words: Zaleca się, aby barangay zawierał mniej niż %{word_count}
+              słów

--- a/data/regions/PH/pt-BR.yml
+++ b/data/regions/PH/pt-BR.yml
@@ -68,8 +68,8 @@ pt-BR:
               palavras
             contains_html_tags_instructional: O barangay não pode conter HTML
             contains_html_tags_informative: O barangay não pode conter HTML
-            contains_url_instructional: O barangay não pode conter um URL
-            contains_url_informative: O barangay não pode conter um URL
+            contains_url_instructional: O barangay não pode conter uma URL
+            contains_url_informative: O barangay não pode conter uma URL
             unknown_for_city_instructional: Insira um nome de barangay válido para
               %{city}
             unknown_for_city_informative: Insira um nome de barangay válido para %{city}

--- a/data/regions/PH/pt-BR.yml
+++ b/data/regions/PH/pt-BR.yml
@@ -42,3 +42,42 @@ pt-BR:
           warnings:
             contains_too_many_words: É recomendável que o barangay tenha menos de
               %{word_count} palavras
+        district:
+          label:
+            default: Barangay
+            optional: Barangay (opcional)
+          errors:
+            blank_instructional: Insira um barangay
+            blank_informative: Falta o barangay
+            too_long_instructional: O barangay é muito longo (o máximo é de %{limit}
+              caracteres)
+            too_long_informative: O barangay é muito longo
+            contains_emojis_instructional: O barangay não pode conter emojis
+            contains_emojis_informative: O barangay não pode conter emojis
+            contains_mathematical_symbols_instructional: O barangay não pode conter
+              símbolos matemáticos
+            contains_mathematical_symbols_informative: O barangay não pode conter
+              símbolos matemáticos
+            contains_restricted_characters_instructional: O barangay só pode conter
+              letras, números, caracteres locais e caracteres especiais
+            contains_restricted_characters_informative: O barangay não pode conter
+              caracteres restritos
+            contains_too_many_words_instructional: O barangay deve ter menos de %{word_count}
+              palavras
+            contains_too_many_words_informative: O barangay deve ter menos de %{word_count}
+              palavras
+            contains_html_tags_instructional: O barangay não pode conter HTML
+            contains_html_tags_informative: O barangay não pode conter HTML
+            contains_url_instructional: O barangay não pode conter um URL
+            contains_url_informative: O barangay não pode conter um URL
+            unknown_for_city_instructional: Insira um nome de barangay válido para
+              %{city}
+            unknown_for_city_informative: Insira um nome de barangay válido para %{city}
+            unknown_for_zip_instructional: Insira um nome de barangay válido para
+              %{zip}
+            unknown_for_zip_informative: Insira um nome de barangay válido para %{zip}
+            unknown_for_address_instructional: O barangay pode estar incorreto
+            unknown_for_address_informative: O barangay pode estar incorreto
+          warnings:
+            contains_too_many_words: Recomenda-se que o barangay tenha menos de %{word_count}
+              palavras

--- a/data/regions/PH/pt-PT.yml
+++ b/data/regions/PH/pt-PT.yml
@@ -49,9 +49,9 @@ pt-PT:
             default: Barangay
             optional: Barangay (opcional)
           errors:
-            blank_instructional: Insira um barangay
-            blank_informative: Falta o barangay
-            too_long_instructional: O barangay é demasiado longo (o máximo é de %{limit}
+            blank_instructional: Introduza um barangay
+            blank_informative: O barangay está em falta
+            too_long_instructional: O barangay é demasiado longo (o máximo é %{limit}
               carateres)
             too_long_informative: O barangay é demasiado longo
             contains_emojis_instructional: O barangay não pode conter emojis
@@ -60,7 +60,7 @@ pt-PT:
               símbolos matemáticos
             contains_mathematical_symbols_informative: O barangay não pode conter
               símbolos matemáticos
-            contains_restricted_characters_instructional: O barangay apenas pode conter
+            contains_restricted_characters_instructional: O barangay só pode conter
               letras, números, carateres locais e carateres especiais
             contains_restricted_characters_informative: O barangay não pode conter
               carateres restritos
@@ -72,12 +72,14 @@ pt-PT:
             contains_html_tags_informative: O barangay não pode conter HTML
             contains_url_instructional: O barangay não pode conter um URL
             contains_url_informative: O barangay não pode conter um URL
-            unknown_for_city_instructional: Insira um nome de barangay válido para
+            unknown_for_city_instructional: Introduza um nome de barangay válido para
               %{city}
-            unknown_for_city_informative: Insira um nome de barangay válido para %{city}
-            unknown_for_zip_instructional: Insira um nome de barangay válido para
+            unknown_for_city_informative: Introduza um nome de barangay válido para
+              %{city}
+            unknown_for_zip_instructional: Introduza um nome de barangay válido para
               %{zip}
-            unknown_for_zip_informative: Insira um nome de barangay válido para %{zip}
+            unknown_for_zip_informative: Introduza um nome de barangay válido para
+              %{zip}
             unknown_for_address_instructional: O barangay pode estar incorreto
             unknown_for_address_informative: O barangay pode estar incorreto
           warnings:

--- a/data/regions/PH/pt-PT.yml
+++ b/data/regions/PH/pt-PT.yml
@@ -44,3 +44,42 @@ pt-PT:
           warnings:
             contains_too_many_words: É recomendado que o barangay tenha menos de %{word_count}
               palavras
+        district:
+          label:
+            default: Barangay
+            optional: Barangay (opcional)
+          errors:
+            blank_instructional: Insira um barangay
+            blank_informative: Falta o barangay
+            too_long_instructional: O barangay é demasiado longo (o máximo é de %{limit}
+              carateres)
+            too_long_informative: O barangay é demasiado longo
+            contains_emojis_instructional: O barangay não pode conter emojis
+            contains_emojis_informative: O barangay não pode conter emojis
+            contains_mathematical_symbols_instructional: O barangay não pode conter
+              símbolos matemáticos
+            contains_mathematical_symbols_informative: O barangay não pode conter
+              símbolos matemáticos
+            contains_restricted_characters_instructional: O barangay apenas pode conter
+              letras, números, carateres locais e carateres especiais
+            contains_restricted_characters_informative: O barangay não pode conter
+              carateres restritos
+            contains_too_many_words_instructional: O barangay tem de ter menos de
+              %{word_count} palavras
+            contains_too_many_words_informative: O barangay tem de ter menos de %{word_count}
+              palavras
+            contains_html_tags_instructional: O barangay não pode conter HTML
+            contains_html_tags_informative: O barangay não pode conter HTML
+            contains_url_instructional: O barangay não pode conter um URL
+            contains_url_informative: O barangay não pode conter um URL
+            unknown_for_city_instructional: Insira um nome de barangay válido para
+              %{city}
+            unknown_for_city_informative: Insira um nome de barangay válido para %{city}
+            unknown_for_zip_instructional: Insira um nome de barangay válido para
+              %{zip}
+            unknown_for_zip_informative: Insira um nome de barangay válido para %{zip}
+            unknown_for_address_instructional: O barangay pode estar incorreto
+            unknown_for_address_informative: O barangay pode estar incorreto
+          warnings:
+            contains_too_many_words: Recomenda-se que o barangay tenha menos de %{word_count}
+              palavras

--- a/data/regions/PH/ro.yml
+++ b/data/regions/PH/ro.yml
@@ -52,3 +52,44 @@ ro:
           warnings:
             contains_too_many_words: Se recomandă ca denumirea pentru barangay să
               nu aibă mai mult de %{word_count} cuvinte
+        district:
+          label:
+            default: Barangay
+            optional: Barangay (opțional)
+          errors:
+            blank_instructional: Introduceți un barangay
+            blank_informative: Barangay-ul lipsește
+            too_long_instructional: Barangay-ul este prea lung (maximul este de %{limit}
+              caractere)
+            too_long_informative: Barangay-ul este prea lung
+            contains_emojis_instructional: Barangay-ul nu poate conține emoji-uri
+            contains_emojis_informative: Barangay-ul nu poate conține emoji-uri
+            contains_mathematical_symbols_instructional: Barangay-ul nu poate conține
+              simboluri matematice
+            contains_mathematical_symbols_informative: Barangay-ul nu poate conține
+              simboluri matematice
+            contains_restricted_characters_instructional: Barangay-ul poate conține
+              doar litere, numere, caractere locale și caractere speciale
+            contains_restricted_characters_informative: Barangay-ul nu poate conține
+              caractere restricționate
+            contains_too_many_words_instructional: Barangay-ul trebuie să aibă mai
+              puțin de %{word_count} cuvinte
+            contains_too_many_words_informative: Barangay-ul trebuie să aibă mai puțin
+              de %{word_count} cuvinte
+            contains_html_tags_instructional: Barangay-ul nu poate conține HTML
+            contains_html_tags_informative: Barangay-ul nu poate conține HTML
+            contains_url_instructional: Barangay-ul nu poate conține un URL
+            contains_url_informative: Barangay-ul nu poate conține un URL
+            unknown_for_city_instructional: Introduceți un nume valid de barangay
+              pentru %{city}
+            unknown_for_city_informative: Introduceți un nume valid de barangay pentru
+              %{city}
+            unknown_for_zip_instructional: Introduceți un nume valid de barangay pentru
+              %{zip}
+            unknown_for_zip_informative: Introduceți un nume valid de barangay pentru
+              %{zip}
+            unknown_for_address_instructional: Barangay-ul poate fi incorect
+            unknown_for_address_informative: Barangay-ul poate fi incorect
+          warnings:
+            contains_too_many_words: Se recomandă ca barangay-ul să aibă mai puțin
+              de %{word_count} cuvinte

--- a/data/regions/PH/ro.yml
+++ b/data/regions/PH/ro.yml
@@ -57,9 +57,9 @@ ro:
             default: Barangay
             optional: Barangay (opțional)
           errors:
-            blank_instructional: Introduceți un barangay
-            blank_informative: Barangay-ul lipsește
-            too_long_instructional: Barangay-ul este prea lung (maximul este de %{limit}
+            blank_instructional: Introdu un barangay
+            blank_informative: Lipsește barangay-ul
+            too_long_instructional: Barangay-ul este prea lung (maximum este de %{limit}
               caractere)
             too_long_informative: Barangay-ul este prea lung
             contains_emojis_instructional: Barangay-ul nu poate conține emoji-uri
@@ -69,7 +69,7 @@ ro:
             contains_mathematical_symbols_informative: Barangay-ul nu poate conține
               simboluri matematice
             contains_restricted_characters_instructional: Barangay-ul poate conține
-              doar litere, numere, caractere locale și caractere speciale
+              doar litere, cifre, caractere locale și caractere speciale
             contains_restricted_characters_informative: Barangay-ul nu poate conține
               caractere restricționate
             contains_too_many_words_instructional: Barangay-ul trebuie să aibă mai
@@ -80,16 +80,17 @@ ro:
             contains_html_tags_informative: Barangay-ul nu poate conține HTML
             contains_url_instructional: Barangay-ul nu poate conține un URL
             contains_url_informative: Barangay-ul nu poate conține un URL
-            unknown_for_city_instructional: Introduceți un nume valid de barangay
-              pentru %{city}
-            unknown_for_city_informative: Introduceți un nume valid de barangay pentru
+            unknown_for_city_instructional: Introdu un nume de barangay valid pentru
               %{city}
-            unknown_for_zip_instructional: Introduceți un nume valid de barangay pentru
+            unknown_for_city_informative: Introdu un nume de barangay valid pentru
+              %{city}
+            unknown_for_zip_instructional: Introdu un nume de barangay valid pentru
               %{zip}
-            unknown_for_zip_informative: Introduceți un nume valid de barangay pentru
+            unknown_for_zip_informative: Introdu un nume de barangay valid pentru
               %{zip}
-            unknown_for_address_instructional: Barangay-ul poate fi incorect
-            unknown_for_address_informative: Barangay-ul poate fi incorect
+            unknown_for_address_instructional: Este posibil ca barangay-ul să fie
+              incorect
+            unknown_for_address_informative: Este posibil ca barangay-ul să fie incorect
           warnings:
             contains_too_many_words: Se recomandă ca barangay-ul să aibă mai puțin
               de %{word_count} cuvinte

--- a/data/regions/PH/ru.yml
+++ b/data/regions/PH/ru.yml
@@ -47,3 +47,46 @@ ru:
           warnings:
             contains_too_many_words: Рекомендуем указывать в поле названия барангая
               не более %{word_count} сл.
+        district:
+          label:
+            default: Барангай
+            optional: Барангай (необязательно)
+          errors:
+            blank_instructional: Введите барангай
+            blank_informative: Барангай не указан
+            too_long_instructional: Название барангая слишком длинное (максимум %{limit}
+              символов)
+            too_long_informative: Название барангая слишком длинное
+            contains_emojis_instructional: Название барангая не может содержать эмодзи
+            contains_emojis_informative: Название барангая не может содержать эмодзи
+            contains_mathematical_symbols_instructional: Название барангая не может
+              содержать математические символы
+            contains_mathematical_symbols_informative: Название барангая не может
+              содержать математические символы
+            contains_restricted_characters_instructional: Название барангая может
+              содержать только буквы, цифры, символы местного алфавита и специальные
+              символы
+            contains_restricted_characters_informative: Название барангая не может
+              содержать недопустимые символы
+            contains_too_many_words_instructional: Название барангая должно содержать
+              менее %{word_count} слов
+            contains_too_many_words_informative: Название барангая должно содержать
+              менее %{word_count} слов
+            contains_html_tags_instructional: Название барангая не может содержать
+              HTML
+            contains_html_tags_informative: Название барангая не может содержать HTML
+            contains_url_instructional: Название барангая не может содержать URL
+            contains_url_informative: Название барангая не может содержать URL
+            unknown_for_city_instructional: Введите правильное название барангая для
+              %{city}
+            unknown_for_city_informative: Введите правильное название барангая для
+              %{city}
+            unknown_for_zip_instructional: Введите правильное название барангая для
+              почтового индекса %{zip}
+            unknown_for_zip_informative: Введите правильное название барангая для
+              почтового индекса %{zip}
+            unknown_for_address_instructional: Возможно, барангай указан неверно
+            unknown_for_address_informative: Возможно, барангай указан неверно
+          warnings:
+            contains_too_many_words: Рекомендуется, чтобы название барангая содержало
+              менее %{word_count} слов

--- a/data/regions/PH/ru.yml
+++ b/data/regions/PH/ru.yml
@@ -53,7 +53,7 @@ ru:
             optional: Барангай (необязательно)
           errors:
             blank_instructional: Введите барангай
-            blank_informative: Барангай не указан
+            blank_informative: Не указан барангай
             too_long_instructional: Название барангая слишком длинное (максимум %{limit}
               символов)
             too_long_informative: Название барангая слишком длинное
@@ -64,10 +64,9 @@ ru:
             contains_mathematical_symbols_informative: Название барангая не может
               содержать математические символы
             contains_restricted_characters_instructional: Название барангая может
-              содержать только буквы, цифры, символы местного алфавита и специальные
-              символы
+              содержать только буквы, цифры, местные и специальные символы
             contains_restricted_characters_informative: Название барангая не может
-              содержать недопустимые символы
+              содержать запрещенные символы
             contains_too_many_words_instructional: Название барангая должно содержать
               менее %{word_count} слов
             contains_too_many_words_informative: Название барангая должно содержать
@@ -78,13 +77,13 @@ ru:
             contains_url_instructional: Название барангая не может содержать URL
             contains_url_informative: Название барангая не может содержать URL
             unknown_for_city_instructional: Введите правильное название барангая для
-              %{city}
+              города %{city}
             unknown_for_city_informative: Введите правильное название барангая для
-              %{city}
+              города %{city}
             unknown_for_zip_instructional: Введите правильное название барангая для
-              почтового индекса %{zip}
+              индекса %{zip}
             unknown_for_zip_informative: Введите правильное название барангая для
-              почтового индекса %{zip}
+              индекса %{zip}
             unknown_for_address_instructional: Возможно, барангай указан неверно
             unknown_for_address_informative: Возможно, барангай указан неверно
           warnings:

--- a/data/regions/PH/sk.yml
+++ b/data/regions/PH/sk.yml
@@ -44,7 +44,7 @@ sk:
         district:
           label:
             default: Barangay
-            optional: Barangay (nepovinné)
+            optional: Barangay (voliteľné)
           errors:
             blank_instructional: Zadajte barangay
             blank_informative: Chýba barangay
@@ -57,23 +57,23 @@ sk:
             contains_mathematical_symbols_informative: Barangay nemôže obsahovať matematické
               symboly
             contains_restricted_characters_instructional: Barangay môže obsahovať
-              iba písmená, číslice, lokálne znaky a špeciálne znaky
+              len písmená, číslice, lokálne a špeciálne znaky
             contains_restricted_characters_informative: Barangay nemôže obsahovať
               nepovolené znaky
-            contains_too_many_words_instructional: Barangay musí obsahovať menej ako
-              %{word_count} slov
-            contains_too_many_words_informative: Barangay musí obsahovať menej ako
-              %{word_count} slov
+            contains_too_many_words_instructional: Barangay musí mať menej ako %{word_count}
+              slov
+            contains_too_many_words_informative: Barangay musí mať menej ako %{word_count}
+              slov
             contains_html_tags_instructional: Barangay nemôže obsahovať HTML
             contains_html_tags_informative: Barangay nemôže obsahovať HTML
-            contains_url_instructional: Barangay nemôže obsahovať URL adresu
-            contains_url_informative: Barangay nemôže obsahovať URL adresu
-            unknown_for_city_instructional: Zadajte platný názov barangaya pre %{city}
-            unknown_for_city_informative: Zadajte platný názov barangaya pre %{city}
-            unknown_for_zip_instructional: Zadajte platný názov barangaya pre %{zip}
-            unknown_for_zip_informative: Zadajte platný názov barangaya pre %{zip}
+            contains_url_instructional: Barangay nemôže obsahovať adresu URL
+            contains_url_informative: Barangay nemôže obsahovať adresu URL
+            unknown_for_city_instructional: Zadajte platný názov barangay pre %{city}
+            unknown_for_city_informative: Zadajte platný názov barangay pre %{city}
+            unknown_for_zip_instructional: Zadajte platný názov barangay pre %{zip}
+            unknown_for_zip_informative: Zadajte platný názov barangay pre %{zip}
             unknown_for_address_instructional: Barangay môže byť nesprávny
             unknown_for_address_informative: Barangay môže byť nesprávny
           warnings:
-            contains_too_many_words: Odporúča sa, aby barangay obsahoval menej ako
-              %{word_count} slov
+            contains_too_many_words: Odporúča sa, aby barangay mal menej ako %{word_count}
+              slov

--- a/data/regions/PH/sk.yml
+++ b/data/regions/PH/sk.yml
@@ -41,3 +41,39 @@ sk:
           warnings:
             contains_too_many_words: 'Barangay by nemalo mať viac ako tento počet
               slov: %{word_count}'
+        district:
+          label:
+            default: Barangay
+            optional: Barangay (nepovinné)
+          errors:
+            blank_instructional: Zadajte barangay
+            blank_informative: Chýba barangay
+            too_long_instructional: Barangay je príliš dlhý (maximum je %{limit} znakov)
+            too_long_informative: Barangay je príliš dlhý
+            contains_emojis_instructional: Barangay nemôže obsahovať emoji
+            contains_emojis_informative: Barangay nemôže obsahovať emoji
+            contains_mathematical_symbols_instructional: Barangay nemôže obsahovať
+              matematické symboly
+            contains_mathematical_symbols_informative: Barangay nemôže obsahovať matematické
+              symboly
+            contains_restricted_characters_instructional: Barangay môže obsahovať
+              iba písmená, číslice, lokálne znaky a špeciálne znaky
+            contains_restricted_characters_informative: Barangay nemôže obsahovať
+              nepovolené znaky
+            contains_too_many_words_instructional: Barangay musí obsahovať menej ako
+              %{word_count} slov
+            contains_too_many_words_informative: Barangay musí obsahovať menej ako
+              %{word_count} slov
+            contains_html_tags_instructional: Barangay nemôže obsahovať HTML
+            contains_html_tags_informative: Barangay nemôže obsahovať HTML
+            contains_url_instructional: Barangay nemôže obsahovať URL adresu
+            contains_url_informative: Barangay nemôže obsahovať URL adresu
+            unknown_for_city_instructional: Zadajte platný názov barangaya pre %{city}
+            unknown_for_city_informative: Zadajte platný názov barangaya pre %{city}
+            unknown_for_zip_instructional: Zadajte platný názov barangaya pre %{zip}
+            unknown_for_zip_informative: Zadajte platný názov barangaya pre %{zip}
+            unknown_for_address_instructional: Barangay môže byť nesprávny
+            unknown_for_address_informative: Barangay môže byť nesprávny
+          warnings:
+            contains_too_many_words: Odporúča sa, aby barangay obsahoval menej ako
+              %{word_count} slov

--- a/data/regions/PH/sl.yml
+++ b/data/regions/PH/sl.yml
@@ -53,7 +53,8 @@ sl:
           errors:
             blank_instructional: Vnesite barangay
             blank_informative: Manjka barangay
-            too_long_instructional: Barangay je predolg (največ %{limit} znakov)
+            too_long_instructional: Barangay je predolg (dovoljenih je največ %{limit}
+              znakov)
             too_long_informative: Barangay je predolg
             contains_emojis_instructional: Barangay ne sme vsebovati emodžijev
             contains_emojis_informative: Barangay ne sme vsebovati emodžijev
@@ -61,24 +62,28 @@ sl:
               matematičnih simbolov
             contains_mathematical_symbols_informative: Barangay ne sme vsebovati matematičnih
               simbolov
-            contains_restricted_characters_instructional: Barangay lahko vsebuje samo
+            contains_restricted_characters_instructional: Barangay lahko vsebuje le
               črke, številke, lokalne znake in posebne znake
             contains_restricted_characters_informative: Barangay ne sme vsebovati
               nedovoljenih znakov
-            contains_too_many_words_instructional: Število besed za barangay mora
-              biti manjše od %{word_count}
-            contains_too_many_words_informative: Število besed za barangay mora biti
-              manjše od %{word_count}
+            contains_too_many_words_instructional: Barangay mora vsebovati manj kot
+              %{word_count} besed
+            contains_too_many_words_informative: Barangay mora vsebovati manj kot
+              %{word_count} besed
             contains_html_tags_instructional: Barangay ne sme vsebovati kode HTML
             contains_html_tags_informative: Barangay ne sme vsebovati kode HTML
             contains_url_instructional: Barangay ne sme vsebovati URL-naslova
             contains_url_informative: Barangay ne sme vsebovati URL-naslova
-            unknown_for_city_instructional: Vnesite veljavno ime barangaya za %{city}
-            unknown_for_city_informative: Vnesite veljavno ime barangaya za %{city}
-            unknown_for_zip_instructional: Vnesite veljavno ime barangaya za %{zip}
-            unknown_for_zip_informative: Vnesite veljavno ime barangaya za %{zip}
+            unknown_for_city_instructional: Vnesite veljavno ime za barangay za mesto
+              %{city}
+            unknown_for_city_informative: Vnesite veljavno ime za barangay za mesto
+              %{city}
+            unknown_for_zip_instructional: Vnesite veljavno ime za barangay za poštno
+              številko %{zip}
+            unknown_for_zip_informative: Vnesite veljavno ime za barangay za poštno
+              številko %{zip}
             unknown_for_address_instructional: Barangay je morda napačen
             unknown_for_address_informative: Barangay je morda napačen
           warnings:
-            contains_too_many_words: Priporočljivo je, da je število besed za barangay
-              manjše od %{word_count}
+            contains_too_many_words: Priporočamo, da barangay vsebuje manj kot %{word_count}
+              besed

--- a/data/regions/PH/sl.yml
+++ b/data/regions/PH/sl.yml
@@ -46,3 +46,39 @@ sl:
           warnings:
             contains_too_many_words: Ime barangaya naj ne vsebuje več kot %{word_count}
               besed
+        district:
+          label:
+            default: Barangay
+            optional: Barangay (izbirno)
+          errors:
+            blank_instructional: Vnesite barangay
+            blank_informative: Manjka barangay
+            too_long_instructional: Barangay je predolg (največ %{limit} znakov)
+            too_long_informative: Barangay je predolg
+            contains_emojis_instructional: Barangay ne sme vsebovati emodžijev
+            contains_emojis_informative: Barangay ne sme vsebovati emodžijev
+            contains_mathematical_symbols_instructional: Barangay ne sme vsebovati
+              matematičnih simbolov
+            contains_mathematical_symbols_informative: Barangay ne sme vsebovati matematičnih
+              simbolov
+            contains_restricted_characters_instructional: Barangay lahko vsebuje samo
+              črke, številke, lokalne znake in posebne znake
+            contains_restricted_characters_informative: Barangay ne sme vsebovati
+              nedovoljenih znakov
+            contains_too_many_words_instructional: Število besed za barangay mora
+              biti manjše od %{word_count}
+            contains_too_many_words_informative: Število besed za barangay mora biti
+              manjše od %{word_count}
+            contains_html_tags_instructional: Barangay ne sme vsebovati kode HTML
+            contains_html_tags_informative: Barangay ne sme vsebovati kode HTML
+            contains_url_instructional: Barangay ne sme vsebovati URL-naslova
+            contains_url_informative: Barangay ne sme vsebovati URL-naslova
+            unknown_for_city_instructional: Vnesite veljavno ime barangaya za %{city}
+            unknown_for_city_informative: Vnesite veljavno ime barangaya za %{city}
+            unknown_for_zip_instructional: Vnesite veljavno ime barangaya za %{zip}
+            unknown_for_zip_informative: Vnesite veljavno ime barangaya za %{zip}
+            unknown_for_address_instructional: Barangay je morda napačen
+            unknown_for_address_informative: Barangay je morda napačen
+          warnings:
+            contains_too_many_words: Priporočljivo je, da je število besed za barangay
+              manjše od %{word_count}

--- a/data/regions/PH/sv.yml
+++ b/data/regions/PH/sv.yml
@@ -46,31 +46,32 @@ sv:
           errors:
             blank_instructional: Ange en barangay
             blank_informative: Barangay saknas
-            too_long_instructional: Barangay är för lång (högst %{limit} tecken)
+            too_long_instructional: Barangay är för lång (max %{limit} tecken)
             too_long_informative: Barangay är för lång
-            contains_emojis_instructional: Barangay får inte innehålla emojis
-            contains_emojis_informative: Barangay får inte innehålla emojis
-            contains_mathematical_symbols_instructional: Barangay får inte innehålla
+            contains_emojis_instructional: Barangay kan inte innehålla emojis
+            contains_emojis_informative: Barangay kan inte innehålla emojis
+            contains_mathematical_symbols_instructional: Barangay kan inte innehålla
               matematiska symboler
-            contains_mathematical_symbols_informative: Barangay får inte innehålla
+            contains_mathematical_symbols_informative: Barangay kan inte innehålla
               matematiska symboler
-            contains_restricted_characters_instructional: Barangay får endast innehålla
+            contains_restricted_characters_instructional: Barangay kan endast innehålla
               bokstäver, siffror, lokala tecken och specialtecken
-            contains_restricted_characters_informative: Barangay får inte innehålla
+            contains_restricted_characters_informative: Barangay kan inte innehålla
               otillåtna tecken
             contains_too_many_words_instructional: Barangay måste ha färre än %{word_count}
               ord
             contains_too_many_words_informative: Barangay måste ha färre än %{word_count}
               ord
-            contains_html_tags_instructional: Barangay får inte innehålla HTML
-            contains_html_tags_informative: Barangay får inte innehålla HTML
-            contains_url_instructional: Barangay får inte innehålla en URL
-            contains_url_informative: Barangay får inte innehålla en URL
-            unknown_for_city_instructional: Ange ett giltigt barangay-namn för %{city}
-            unknown_for_city_informative: Ange ett giltigt barangay-namn för %{city}
-            unknown_for_zip_instructional: Ange ett giltigt barangay-namn för %{zip}
-            unknown_for_zip_informative: Ange ett giltigt barangay-namn för %{zip}
+            contains_html_tags_instructional: Barangay kan inte innehålla HTML
+            contains_html_tags_informative: Barangay kan inte innehålla HTML
+            contains_url_instructional: Barangay kan inte innehålla en URL
+            contains_url_informative: Barangay kan inte innehålla en URL
+            unknown_for_city_instructional: Ange en giltig barangay för %{city}
+            unknown_for_city_informative: Ange en giltig barangay för %{city}
+            unknown_for_zip_instructional: Ange en giltig barangay för %{zip}
+            unknown_for_zip_informative: Ange en giltig barangay för %{zip}
             unknown_for_address_instructional: Barangay kan vara felaktig
             unknown_for_address_informative: Barangay kan vara felaktig
           warnings:
-            contains_too_many_words: Barangay bör ha färre än %{word_count} ord
+            contains_too_many_words: Barangay rekommenderas ha färre än %{word_count}
+              ord

--- a/data/regions/PH/sv.yml
+++ b/data/regions/PH/sv.yml
@@ -39,3 +39,38 @@ sv:
           warnings:
             contains_too_many_words: Vi rekommenderar att barangay-namnet består av
               färre än %{word_count} ord
+        district:
+          label:
+            default: Barangay
+            optional: Barangay (valfritt)
+          errors:
+            blank_instructional: Ange en barangay
+            blank_informative: Barangay saknas
+            too_long_instructional: Barangay är för lång (högst %{limit} tecken)
+            too_long_informative: Barangay är för lång
+            contains_emojis_instructional: Barangay får inte innehålla emojis
+            contains_emojis_informative: Barangay får inte innehålla emojis
+            contains_mathematical_symbols_instructional: Barangay får inte innehålla
+              matematiska symboler
+            contains_mathematical_symbols_informative: Barangay får inte innehålla
+              matematiska symboler
+            contains_restricted_characters_instructional: Barangay får endast innehålla
+              bokstäver, siffror, lokala tecken och specialtecken
+            contains_restricted_characters_informative: Barangay får inte innehålla
+              otillåtna tecken
+            contains_too_many_words_instructional: Barangay måste ha färre än %{word_count}
+              ord
+            contains_too_many_words_informative: Barangay måste ha färre än %{word_count}
+              ord
+            contains_html_tags_instructional: Barangay får inte innehålla HTML
+            contains_html_tags_informative: Barangay får inte innehålla HTML
+            contains_url_instructional: Barangay får inte innehålla en URL
+            contains_url_informative: Barangay får inte innehålla en URL
+            unknown_for_city_instructional: Ange ett giltigt barangay-namn för %{city}
+            unknown_for_city_informative: Ange ett giltigt barangay-namn för %{city}
+            unknown_for_zip_instructional: Ange ett giltigt barangay-namn för %{zip}
+            unknown_for_zip_informative: Ange ett giltigt barangay-namn för %{zip}
+            unknown_for_address_instructional: Barangay kan vara felaktig
+            unknown_for_address_informative: Barangay kan vara felaktig
+          warnings:
+            contains_too_many_words: Barangay bör ha färre än %{word_count} ord

--- a/data/regions/PH/th.yml
+++ b/data/regions/PH/th.yml
@@ -36,3 +36,35 @@ th:
           warnings:
             contains_too_many_words: ชื่อบารังไกควรมีความยาวน้อยกว่า %{word_count}
               คำ
+        district:
+          label:
+            default: บารังไก
+            optional: บารังไก (ไม่บังคับ)
+          errors:
+            blank_instructional: โปรดระบุบารังไก
+            blank_informative: ไม่มีบารังไก
+            too_long_instructional: บารังไกยาวเกินไป (สูงสุด %{limit} อักขระ)
+            too_long_informative: บารังไกยาวเกินไป
+            contains_emojis_instructional: บารังไกต้องไม่มีอีโมจิ
+            contains_emojis_informative: บารังไกต้องไม่มีอีโมจิ
+            contains_mathematical_symbols_instructional: บารังไกต้องไม่มีสัญลักษณ์ทางคณิตศาสตร์
+            contains_mathematical_symbols_informative: บารังไกต้องไม่มีสัญลักษณ์ทางคณิตศาสตร์
+            contains_restricted_characters_instructional: บารังไกต้องมีเฉพาะตัวอักษร
+              ตัวเลข ตัวอักษรท้องถิ่น และอักขระพิเศษเท่านั้น
+            contains_restricted_characters_informative: บารังไกต้องไม่มีอักขระที่ถูกจำกัด
+            contains_too_many_words_instructional: บารังไกต้องมีน้อยกว่า %{word_count}
+              คำ
+            contains_too_many_words_informative: บารังไกต้องมีน้อยกว่า %{word_count}
+              คำ
+            contains_html_tags_instructional: บารังไกต้องไม่มี HTML
+            contains_html_tags_informative: บารังไกต้องไม่มี HTML
+            contains_url_instructional: บารังไกต้องไม่มี URL
+            contains_url_informative: บารังไกต้องไม่มี URL
+            unknown_for_city_instructional: โปรดระบุชื่อบารังไกที่ถูกต้องสำหรับ %{city}
+            unknown_for_city_informative: โปรดระบุชื่อบารังไกที่ถูกต้องสำหรับ %{city}
+            unknown_for_zip_instructional: โปรดระบุชื่อบารังไกที่ถูกต้องสำหรับ %{zip}
+            unknown_for_zip_informative: โปรดระบุชื่อบารังไกที่ถูกต้องสำหรับ %{zip}
+            unknown_for_address_instructional: บารังไกอาจไม่ถูกต้อง
+            unknown_for_address_informative: บารังไกอาจไม่ถูกต้อง
+          warnings:
+            contains_too_many_words: ขอแนะนำให้บารังไกมีน้อยกว่า %{word_count} คำ

--- a/data/regions/PH/th.yml
+++ b/data/regions/PH/th.yml
@@ -41,9 +41,9 @@ th:
             default: บารังไก
             optional: บารังไก (ไม่บังคับ)
           errors:
-            blank_instructional: โปรดระบุบารังไก
-            blank_informative: ไม่มีบารังไก
-            too_long_instructional: บารังไกยาวเกินไป (สูงสุด %{limit} อักขระ)
+            blank_instructional: โปรดป้อนบารังไก
+            blank_informative: ไม่ได้ระบุบารังไก
+            too_long_instructional: บารังไกยาวเกินไป (สูงสุด %{limit} ตัวอักษร)
             too_long_informative: บารังไกยาวเกินไป
             contains_emojis_instructional: บารังไกต้องไม่มีอีโมจิ
             contains_emojis_informative: บารังไกต้องไม่มีอีโมจิ
@@ -60,10 +60,10 @@ th:
             contains_html_tags_informative: บารังไกต้องไม่มี HTML
             contains_url_instructional: บารังไกต้องไม่มี URL
             contains_url_informative: บารังไกต้องไม่มี URL
-            unknown_for_city_instructional: โปรดระบุชื่อบารังไกที่ถูกต้องสำหรับ %{city}
-            unknown_for_city_informative: โปรดระบุชื่อบารังไกที่ถูกต้องสำหรับ %{city}
-            unknown_for_zip_instructional: โปรดระบุชื่อบารังไกที่ถูกต้องสำหรับ %{zip}
-            unknown_for_zip_informative: โปรดระบุชื่อบารังไกที่ถูกต้องสำหรับ %{zip}
+            unknown_for_city_instructional: โปรดป้อนชื่อบารังไกที่ถูกต้องสำหรับ %{city}
+            unknown_for_city_informative: โปรดป้อนชื่อบารังไกที่ถูกต้องสำหรับ %{city}
+            unknown_for_zip_instructional: โปรดป้อนชื่อบารังไกที่ถูกต้องสำหรับ %{zip}
+            unknown_for_zip_informative: โปรดป้อนชื่อบารังไกที่ถูกต้องสำหรับ %{zip}
             unknown_for_address_instructional: บารังไกอาจไม่ถูกต้อง
             unknown_for_address_informative: บารังไกอาจไม่ถูกต้อง
           warnings:

--- a/data/regions/PH/tr.yml
+++ b/data/regions/PH/tr.yml
@@ -41,3 +41,40 @@ tr:
           warnings:
             contains_too_many_words: Barangay adında %{word_count} adetten az kelime
               olması önerilir
+        district:
+          label:
+            default: Barangay
+            optional: Barangay (isteğe bağlı)
+          errors:
+            blank_instructional: Bir barangay girin
+            blank_informative: Barangay eksik
+            too_long_instructional: Barangay çok uzun (en fazla %{limit} karakter)
+            too_long_informative: Barangay çok uzun
+            contains_emojis_instructional: Barangay emoji içeremez
+            contains_emojis_informative: Barangay emoji içeremez
+            contains_mathematical_symbols_instructional: Barangay matematiksel semboller
+              içeremez
+            contains_mathematical_symbols_informative: Barangay matematiksel semboller
+              içeremez
+            contains_restricted_characters_instructional: Barangay yalnızca harf,
+              sayı, yerel karakter ve özel karakter içerebilir
+            contains_restricted_characters_informative: Barangay kısıtlanmış karakterler
+              içeremez
+            contains_too_many_words_instructional: Barangay %{word_count} kelimeden
+              az olmalıdır
+            contains_too_many_words_informative: Barangay %{word_count} kelimeden
+              az olmalıdır
+            contains_html_tags_instructional: Barangay HTML içeremez
+            contains_html_tags_informative: Barangay HTML içeremez
+            contains_url_instructional: Barangay URL içeremez
+            contains_url_informative: Barangay URL içeremez
+            unknown_for_city_instructional: "%{city} için geçerli bir barangay adı
+              girin"
+            unknown_for_city_informative: "%{city} için geçerli bir barangay adı girin"
+            unknown_for_zip_instructional: "%{zip} için geçerli bir barangay adı girin"
+            unknown_for_zip_informative: "%{zip} için geçerli bir barangay adı girin"
+            unknown_for_address_instructional: Barangay yanlış olabilir
+            unknown_for_address_informative: Barangay yanlış olabilir
+          warnings:
+            contains_too_many_words: Barangayın %{word_count} kelimeden az olması
+              önerilir

--- a/data/regions/PH/tr.yml
+++ b/data/regions/PH/tr.yml
@@ -48,7 +48,7 @@ tr:
           errors:
             blank_instructional: Bir barangay girin
             blank_informative: Barangay eksik
-            too_long_instructional: Barangay çok uzun (en fazla %{limit} karakter)
+            too_long_instructional: Barangay çok uzun (maksimum %{limit} karakter)
             too_long_informative: Barangay çok uzun
             contains_emojis_instructional: Barangay emoji içeremez
             contains_emojis_informative: Barangay emoji içeremez

--- a/data/regions/PH/vi.yml
+++ b/data/regions/PH/vi.yml
@@ -49,14 +49,15 @@ vi:
             blank_informative: Thiếu barangay
             too_long_instructional: Barangay quá dài (tối đa %{limit} ký tự)
             too_long_informative: Barangay quá dài
-            contains_emojis_instructional: Barangay không được chứa emoji
-            contains_emojis_informative: Barangay không được chứa emoji
+            contains_emojis_instructional: Barangay không được chứa biểu tượng cảm
+              xúc
+            contains_emojis_informative: Barangay không được chứa biểu tượng cảm xúc
             contains_mathematical_symbols_instructional: Barangay không được chứa
               ký hiệu toán học
             contains_mathematical_symbols_informative: Barangay không được chứa ký
               hiệu toán học
-            contains_restricted_characters_instructional: Barangay chỉ được chứa chữ
-              cái, chữ số, ký tự địa phương và ký tự đặc biệt
+            contains_restricted_characters_instructional: Barangay chỉ có thể chứa
+              chữ cái, số, ký tự địa phương và ký tự đặc biệt
             contains_restricted_characters_informative: Barangay không được chứa ký
               tự bị hạn chế
             contains_too_many_words_instructional: Barangay phải có ít hơn %{word_count}

--- a/data/regions/PH/vi.yml
+++ b/data/regions/PH/vi.yml
@@ -40,3 +40,38 @@ vi:
             unknown_for_address_informative: Xã/phường có thể không chính xác
           warnings:
             contains_too_many_words: Xã/phường nên có tối đa %{word_count} từ
+        district:
+          label:
+            default: Barangay
+            optional: Barangay (tùy chọn)
+          errors:
+            blank_instructional: Nhập barangay
+            blank_informative: Thiếu barangay
+            too_long_instructional: Barangay quá dài (tối đa %{limit} ký tự)
+            too_long_informative: Barangay quá dài
+            contains_emojis_instructional: Barangay không được chứa emoji
+            contains_emojis_informative: Barangay không được chứa emoji
+            contains_mathematical_symbols_instructional: Barangay không được chứa
+              ký hiệu toán học
+            contains_mathematical_symbols_informative: Barangay không được chứa ký
+              hiệu toán học
+            contains_restricted_characters_instructional: Barangay chỉ được chứa chữ
+              cái, chữ số, ký tự địa phương và ký tự đặc biệt
+            contains_restricted_characters_informative: Barangay không được chứa ký
+              tự bị hạn chế
+            contains_too_many_words_instructional: Barangay phải có ít hơn %{word_count}
+              từ
+            contains_too_many_words_informative: Barangay phải có ít hơn %{word_count}
+              từ
+            contains_html_tags_instructional: Barangay không được chứa HTML
+            contains_html_tags_informative: Barangay không được chứa HTML
+            contains_url_instructional: Barangay không được chứa URL
+            contains_url_informative: Barangay không được chứa URL
+            unknown_for_city_instructional: Nhập tên barangay hợp lệ cho %{city}
+            unknown_for_city_informative: Nhập tên barangay hợp lệ cho %{city}
+            unknown_for_zip_instructional: Nhập tên barangay hợp lệ cho %{zip}
+            unknown_for_zip_informative: Nhập tên barangay hợp lệ cho %{zip}
+            unknown_for_address_instructional: Barangay có thể không chính xác
+            unknown_for_address_informative: Barangay có thể không chính xác
+          warnings:
+            contains_too_many_words: Barangay nên có ít hơn %{word_count} từ

--- a/data/regions/PH/zh-CN.yml
+++ b/data/regions/PH/zh-CN.yml
@@ -39,25 +39,25 @@ zh-CN:
           errors:
             blank_instructional: 输入描笼涯
             blank_informative: 缺少描笼涯
-            too_long_instructional: 描笼涯名称过长（最多 %{limit} 个字符）
-            too_long_informative: 描笼涯名称过长
+            too_long_instructional: 描笼涯太长（最多 %{limit} 个字符）
+            too_long_informative: 描笼涯太长
             contains_emojis_instructional: 描笼涯不能包含表情符号
             contains_emojis_informative: 描笼涯不能包含表情符号
             contains_mathematical_symbols_instructional: 描笼涯不能包含数学符号
             contains_mathematical_symbols_informative: 描笼涯不能包含数学符号
             contains_restricted_characters_instructional: 描笼涯只能包含字母、数字、本地字符和特殊字符
             contains_restricted_characters_informative: 描笼涯不能包含受限字符
-            contains_too_many_words_instructional: 描笼涯名称必须少于 %{word_count} 个字词
-            contains_too_many_words_informative: 描笼涯名称必须少于 %{word_count} 个字词
+            contains_too_many_words_instructional: 描笼涯必须少于 %{word_count} 个词
+            contains_too_many_words_informative: 描笼涯必须少于 %{word_count} 个词
             contains_html_tags_instructional: 描笼涯不能包含 HTML
             contains_html_tags_informative: 描笼涯不能包含 HTML
             contains_url_instructional: 描笼涯不能包含 URL
             contains_url_informative: 描笼涯不能包含 URL
-            unknown_for_city_instructional: 输入 %{city} 的有效描笼涯名称
-            unknown_for_city_informative: 输入 %{city} 的有效描笼涯名称
-            unknown_for_zip_instructional: 输入 %{zip} 的有效描笼涯名称
-            unknown_for_zip_informative: 输入 %{zip} 的有效描笼涯名称
+            unknown_for_city_instructional: 为 %{city} 输入有效的描笼涯名称
+            unknown_for_city_informative: 为 %{city} 输入有效的描笼涯名称
+            unknown_for_zip_instructional: 为 %{zip} 输入有效的描笼涯名称
+            unknown_for_zip_informative: 为 %{zip} 输入有效的描笼涯名称
             unknown_for_address_instructional: 描笼涯可能不正确
             unknown_for_address_informative: 描笼涯可能不正确
           warnings:
-            contains_too_many_words: 建议描笼涯名称少于 %{word_count} 个字词
+            contains_too_many_words: 建议描笼涯少于 %{word_count} 个词

--- a/data/regions/PH/zh-CN.yml
+++ b/data/regions/PH/zh-CN.yml
@@ -32,3 +32,32 @@ zh-CN:
             unknown_for_address_informative: 村名可能不正确
           warnings:
             contains_too_many_words: 建议村名少于 %{word_count} 个字词
+        district:
+          label:
+            default: 描笼涯
+            optional: 描笼涯（可选）
+          errors:
+            blank_instructional: 输入描笼涯
+            blank_informative: 缺少描笼涯
+            too_long_instructional: 描笼涯名称过长（最多 %{limit} 个字符）
+            too_long_informative: 描笼涯名称过长
+            contains_emojis_instructional: 描笼涯不能包含表情符号
+            contains_emojis_informative: 描笼涯不能包含表情符号
+            contains_mathematical_symbols_instructional: 描笼涯不能包含数学符号
+            contains_mathematical_symbols_informative: 描笼涯不能包含数学符号
+            contains_restricted_characters_instructional: 描笼涯只能包含字母、数字、本地字符和特殊字符
+            contains_restricted_characters_informative: 描笼涯不能包含受限字符
+            contains_too_many_words_instructional: 描笼涯名称必须少于 %{word_count} 个字词
+            contains_too_many_words_informative: 描笼涯名称必须少于 %{word_count} 个字词
+            contains_html_tags_instructional: 描笼涯不能包含 HTML
+            contains_html_tags_informative: 描笼涯不能包含 HTML
+            contains_url_instructional: 描笼涯不能包含 URL
+            contains_url_informative: 描笼涯不能包含 URL
+            unknown_for_city_instructional: 输入 %{city} 的有效描笼涯名称
+            unknown_for_city_informative: 输入 %{city} 的有效描笼涯名称
+            unknown_for_zip_instructional: 输入 %{zip} 的有效描笼涯名称
+            unknown_for_zip_informative: 输入 %{zip} 的有效描笼涯名称
+            unknown_for_address_instructional: 描笼涯可能不正确
+            unknown_for_address_informative: 描笼涯可能不正确
+          warnings:
+            contains_too_many_words: 建议描笼涯名称少于 %{word_count} 个字词

--- a/data/regions/PH/zh-TW.yml
+++ b/data/regions/PH/zh-TW.yml
@@ -32,3 +32,32 @@ zh-TW:
             unknown_for_address_informative: "「鎮」可能不正確"
           warnings:
             contains_too_many_words: 建議「鎮」少於 %{word_count} 個字
+        district:
+          label:
+            default: 描籠涯
+            optional: 描籠涯 (選填)
+          errors:
+            blank_instructional: 輸入描籠涯
+            blank_informative: 缺少描籠涯
+            too_long_instructional: 描籠涯太長 (最多 %{limit} 個字元)
+            too_long_informative: 描籠涯太長
+            contains_emojis_instructional: 描籠涯不可包含表情符號
+            contains_emojis_informative: 描籠涯不可包含表情符號
+            contains_mathematical_symbols_instructional: 描籠涯不可包含數學符號
+            contains_mathematical_symbols_informative: 描籠涯不可包含數學符號
+            contains_restricted_characters_instructional: 描籠涯僅可包含字母、數字、本地字元及特殊字元
+            contains_restricted_characters_informative: 描籠涯不可包含受限字元
+            contains_too_many_words_instructional: 描籠涯的字數必須少於 %{word_count} 個字
+            contains_too_many_words_informative: 描籠涯的字數必須少於 %{word_count} 個字
+            contains_html_tags_instructional: 描籠涯不可包含 HTML
+            contains_html_tags_informative: 描籠涯不可包含 HTML
+            contains_url_instructional: 描籠涯不可包含網址
+            contains_url_informative: 描籠涯不可包含網址
+            unknown_for_city_instructional: 輸入 %{city} 的有效描籠涯名稱
+            unknown_for_city_informative: 輸入 %{city} 的有效描籠涯名稱
+            unknown_for_zip_instructional: 輸入 %{zip} 的有效描籠涯名稱
+            unknown_for_zip_informative: 輸入 %{zip} 的有效描籠涯名稱
+            unknown_for_address_instructional: 描籠涯可能不正確
+            unknown_for_address_informative: 描籠涯可能不正確
+          warnings:
+            contains_too_many_words: 建議描籠涯的字數少於 %{word_count} 個字

--- a/data/regions/PH/zh-TW.yml
+++ b/data/regions/PH/zh-TW.yml
@@ -38,21 +38,21 @@ zh-TW:
             optional: 描籠涯 (選填)
           errors:
             blank_instructional: 輸入描籠涯
-            blank_informative: 缺少描籠涯
-            too_long_instructional: 描籠涯太長 (最多 %{limit} 個字元)
-            too_long_informative: 描籠涯太長
-            contains_emojis_instructional: 描籠涯不可包含表情符號
-            contains_emojis_informative: 描籠涯不可包含表情符號
-            contains_mathematical_symbols_instructional: 描籠涯不可包含數學符號
-            contains_mathematical_symbols_informative: 描籠涯不可包含數學符號
-            contains_restricted_characters_instructional: 描籠涯僅可包含字母、數字、本地字元及特殊字元
-            contains_restricted_characters_informative: 描籠涯不可包含受限字元
-            contains_too_many_words_instructional: 描籠涯的字數必須少於 %{word_count} 個字
-            contains_too_many_words_informative: 描籠涯的字數必須少於 %{word_count} 個字
-            contains_html_tags_instructional: 描籠涯不可包含 HTML
-            contains_html_tags_informative: 描籠涯不可包含 HTML
-            contains_url_instructional: 描籠涯不可包含網址
-            contains_url_informative: 描籠涯不可包含網址
+            blank_informative: 遺漏描籠涯
+            too_long_instructional: 描籠涯名稱過長 (最多 %{limit} 個字元)
+            too_long_informative: 描籠涯名稱過長
+            contains_emojis_instructional: 描籠涯不能包含表情符號
+            contains_emojis_informative: 描籠涯不能包含表情符號
+            contains_mathematical_symbols_instructional: 描籠涯不能包含數學符號
+            contains_mathematical_symbols_informative: 描籠涯不能包含數學符號
+            contains_restricted_characters_instructional: 描籠涯僅能包含字母、數字、當地字元和特殊字元
+            contains_restricted_characters_informative: 描籠涯不能包含受限字元
+            contains_too_many_words_instructional: 描籠涯名稱必須少於 %{word_count} 個字
+            contains_too_many_words_informative: 描籠涯名稱必須少於 %{word_count} 個字
+            contains_html_tags_instructional: 描籠涯不能包含 HTML
+            contains_html_tags_informative: 描籠涯不能包含 HTML
+            contains_url_instructional: 描籠涯不能包含網址
+            contains_url_informative: 描籠涯不能包含網址
             unknown_for_city_instructional: 輸入 %{city} 的有效描籠涯名稱
             unknown_for_city_informative: 輸入 %{city} 的有效描籠涯名稱
             unknown_for_zip_instructional: 輸入 %{zip} 的有效描籠涯名稱
@@ -60,4 +60,4 @@ zh-TW:
             unknown_for_address_instructional: 描籠涯可能不正確
             unknown_for_address_informative: 描籠涯可能不正確
           warnings:
-            contains_too_many_words: 建議描籠涯的字數少於 %{word_count} 個字
+            contains_too_many_words: 描籠涯名稱建議少於 %{word_count} 個字

--- a/data/regions/_default/bg.yml
+++ b/data/regions/_default/bg.yml
@@ -469,7 +469,8 @@ bg:
           errors:
             blank_instructional: Въведете район
             blank_informative: Липсва район
-            too_long_instructional: Районът е твърде дълъг (максимум %{limit} знака)
+            too_long_instructional: Районът е твърде дълъг (максимумът е %{limit}
+              знака)
             too_long_informative: Районът е твърде дълъг
             contains_emojis_instructional: Районът не може да съдържа емоджита
             contains_emojis_informative: Районът не може да съдържа емоджита
@@ -478,9 +479,9 @@ bg:
             contains_mathematical_symbols_informative: Районът не може да съдържа
               математически символи
             contains_restricted_characters_instructional: Районът може да съдържа
-              само букви, цифри, локални и специални символи
+              само букви, цифри, локални и специални знаци
             contains_restricted_characters_informative: Районът не може да съдържа
-              забранени символи
+              неразрешени знаци
             contains_too_many_words_instructional: Районът трябва да съдържа по-малко
               от %{word_count} думи
             contains_too_many_words_informative: Районът трябва да съдържа по-малко
@@ -505,7 +506,8 @@ bg:
           errors:
             blank_instructional: Въведете подрайон
             blank_informative: Липсва подрайон
-            too_long_instructional: Подрайонът е твърде дълъг (максимум %{limit} знака)
+            too_long_instructional: Подрайонът е твърде дълъг (максимумът е %{limit}
+              знака)
             too_long_informative: Подрайонът е твърде дълъг
             contains_emojis_instructional: Подрайонът не може да съдържа емоджита
             contains_emojis_informative: Подрайонът не може да съдържа емоджита
@@ -514,9 +516,9 @@ bg:
             contains_mathematical_symbols_informative: Подрайонът не може да съдържа
               математически символи
             contains_restricted_characters_instructional: Подрайонът може да съдържа
-              само букви, цифри, локални и специални символи
+              само букви, цифри, локални и специални знаци
             contains_restricted_characters_informative: Подрайонът не може да съдържа
-              забранени символи
+              неразрешени знаци
             contains_too_many_words_instructional: Подрайонът трябва да съдържа по-малко
               от %{word_count} думи
             contains_too_many_words_informative: Подрайонът трябва да съдържа по-малко

--- a/data/regions/_default/bg.yml
+++ b/data/regions/_default/bg.yml
@@ -462,3 +462,75 @@ bg:
           errors:
             may_not_exist_instructional: Адресът не е открит или не съществува
             may_not_exist_informative: Адресът не е открит
+        district:
+          label:
+            default: Район
+            optional: Район (по избор)
+          errors:
+            blank_instructional: Въведете район
+            blank_informative: Липсва район
+            too_long_instructional: Районът е твърде дълъг (максимум %{limit} знака)
+            too_long_informative: Районът е твърде дълъг
+            contains_emojis_instructional: Районът не може да съдържа емоджита
+            contains_emojis_informative: Районът не може да съдържа емоджита
+            contains_mathematical_symbols_instructional: Районът не може да съдържа
+              математически символи
+            contains_mathematical_symbols_informative: Районът не може да съдържа
+              математически символи
+            contains_restricted_characters_instructional: Районът може да съдържа
+              само букви, цифри, локални и специални символи
+            contains_restricted_characters_informative: Районът не може да съдържа
+              забранени символи
+            contains_too_many_words_instructional: Районът трябва да съдържа по-малко
+              от %{word_count} думи
+            contains_too_many_words_informative: Районът трябва да съдържа по-малко
+              от %{word_count} думи
+            contains_html_tags_instructional: Районът не може да съдържа HTML тагове
+            contains_html_tags_informative: Районът не може да съдържа HTML тагове
+            contains_url_instructional: Районът не може да съдържа URL адреси
+            contains_url_informative: Районът не може да съдържа URL адреси
+            unknown_for_city_instructional: Въведете валидно име на район за %{city}
+            unknown_for_city_informative: Въведете валидно име на район за %{city}
+            unknown_for_zip_instructional: Въведете валидно име на район за %{zip}
+            unknown_for_zip_informative: Въведете валидно име на район за %{zip}
+            unknown_for_address_instructional: Районът може да е грешен
+            unknown_for_address_informative: Районът може да е грешен
+          warnings:
+            contains_too_many_words: Препоръчително е районът да съдържа по-малко
+              от %{word_count} думи
+        subdistrict:
+          label:
+            default: Подрайон
+            optional: Подрайон (по избор)
+          errors:
+            blank_instructional: Въведете подрайон
+            blank_informative: Липсва подрайон
+            too_long_instructional: Подрайонът е твърде дълъг (максимум %{limit} знака)
+            too_long_informative: Подрайонът е твърде дълъг
+            contains_emojis_instructional: Подрайонът не може да съдържа емоджита
+            contains_emojis_informative: Подрайонът не може да съдържа емоджита
+            contains_mathematical_symbols_instructional: Подрайонът не може да съдържа
+              математически символи
+            contains_mathematical_symbols_informative: Подрайонът не може да съдържа
+              математически символи
+            contains_restricted_characters_instructional: Подрайонът може да съдържа
+              само букви, цифри, локални и специални символи
+            contains_restricted_characters_informative: Подрайонът не може да съдържа
+              забранени символи
+            contains_too_many_words_instructional: Подрайонът трябва да съдържа по-малко
+              от %{word_count} думи
+            contains_too_many_words_informative: Подрайонът трябва да съдържа по-малко
+              от %{word_count} думи
+            contains_html_tags_instructional: Подрайонът не може да съдържа HTML тагове
+            contains_html_tags_informative: Подрайонът не може да съдържа HTML тагове
+            contains_url_instructional: Подрайонът не може да съдържа URL адреси
+            contains_url_informative: Подрайонът не може да съдържа URL адреси
+            unknown_for_city_instructional: Въведете валидно име на подрайон за %{city}
+            unknown_for_city_informative: Въведете валидно име на подрайон за %{city}
+            unknown_for_zip_instructional: Въведете валидно име на подрайон за %{zip}
+            unknown_for_zip_informative: Въведете валидно име на подрайон за %{zip}
+            unknown_for_address_instructional: Подрайонът може да е грешен
+            unknown_for_address_informative: Подрайонът може да е грешен
+          warnings:
+            contains_too_many_words: Препоръчително е подрайонът да съдържа по-малко
+              от %{word_count} думи

--- a/data/regions/_default/cs.yml
+++ b/data/regions/_default/cs.yml
@@ -453,3 +453,75 @@ cs:
           errors:
             may_not_exist_instructional: Adresa nebyla nalezena nebo neexistuje.
             may_not_exist_informative: Adresu nebyla nalezena.
+        district:
+          label:
+            default: Okres
+            optional: Okres (nepovinné)
+          errors:
+            blank_instructional: Zadejte okres
+            blank_informative: Chybí okres
+            too_long_instructional: Okres je příliš dlouhý (maximálně %{limit} znaků)
+            too_long_informative: Okres je příliš dlouhý
+            contains_emojis_instructional: Okres nemůže obsahovat emotikony
+            contains_emojis_informative: Okres nemůže obsahovat emotikony
+            contains_mathematical_symbols_instructional: Okres nemůže obsahovat matematické
+              symboly
+            contains_mathematical_symbols_informative: Okres nemůže obsahovat matematické
+              symboly
+            contains_restricted_characters_instructional: Okres může obsahovat pouze
+              písmena, číslice, místní a speciální znaky
+            contains_restricted_characters_informative: Okres nesmí obsahovat nepovolené
+              znaky
+            contains_too_many_words_instructional: Okres musí mít méně než %{word_count}
+              slov
+            contains_too_many_words_informative: Okres musí mít méně než %{word_count}
+              slov
+            contains_html_tags_instructional: Okres nemůže obsahovat značky HTML
+            contains_html_tags_informative: Okres nemůže obsahovat značky HTML
+            contains_url_instructional: Okres nemůže obsahovat URL
+            contains_url_informative: Okres nemůže obsahovat URL
+            unknown_for_city_instructional: Zadejte platný název okresu pro %{city}
+            unknown_for_city_informative: Zadejte platný název okresu pro %{city}
+            unknown_for_zip_instructional: Zadejte platný název okresu pro %{zip}
+            unknown_for_zip_informative: Zadejte platný název okresu pro %{zip}
+            unknown_for_address_instructional: Okres může být nesprávný
+            unknown_for_address_informative: Okres může být nesprávný
+          warnings:
+            contains_too_many_words: Doporučujeme, aby okres obsahoval méně než %{word_count}
+              slov
+        subdistrict:
+          label:
+            default: Čtvrť
+            optional: Čtvrť (nepovinné)
+          errors:
+            blank_instructional: Zadejte čtvrť
+            blank_informative: Chybí čtvrť
+            too_long_instructional: Čtvrť je příliš dlouhá (maximálně %{limit} znaků)
+            too_long_informative: Čtvrť je příliš dlouhá
+            contains_emojis_instructional: Čtvrť nemůže obsahovat emotikony
+            contains_emojis_informative: Čtvrť nemůže obsahovat emotikony
+            contains_mathematical_symbols_instructional: Čtvrť nemůže obsahovat matematické
+              symboly
+            contains_mathematical_symbols_informative: Čtvrť nemůže obsahovat matematické
+              symboly
+            contains_restricted_characters_instructional: Čtvrť může obsahovat pouze
+              písmena, číslice, místní a speciální znaky
+            contains_restricted_characters_informative: Čtvrť nesmí obsahovat nepovolené
+              znaky
+            contains_too_many_words_instructional: Čtvrť musí mít méně než %{word_count}
+              slov
+            contains_too_many_words_informative: Čtvrť musí mít méně než %{word_count}
+              slov
+            contains_html_tags_instructional: Čtvrť nemůže obsahovat značky HTML
+            contains_html_tags_informative: Čtvrť nemůže obsahovat značky HTML
+            contains_url_instructional: Čtvrť nemůže obsahovat URL
+            contains_url_informative: Čtvrť nemůže obsahovat URL
+            unknown_for_city_instructional: Zadejte platný název čtvrti pro %{city}
+            unknown_for_city_informative: Zadejte platný název čtvrti pro %{city}
+            unknown_for_zip_instructional: Zadejte platný název čtvrti pro %{zip}
+            unknown_for_zip_informative: Zadejte platný název čtvrti pro %{zip}
+            unknown_for_address_instructional: Čtvrť může být nesprávná
+            unknown_for_address_informative: Čtvrť může být nesprávná
+          warnings:
+            contains_too_many_words: Doporučujeme, aby čtvrť obsahovala méně než %{word_count}
+              slov

--- a/data/regions/_default/cs.yml
+++ b/data/regions/_default/cs.yml
@@ -456,72 +456,79 @@ cs:
         district:
           label:
             default: Okres
-            optional: Okres (nepovinné)
+            optional: Okres (volitelné)
           errors:
             blank_instructional: Zadejte okres
             blank_informative: Chybí okres
-            too_long_instructional: Okres je příliš dlouhý (maximálně %{limit} znaků)
-            too_long_informative: Okres je příliš dlouhý
-            contains_emojis_instructional: Okres nemůže obsahovat emotikony
-            contains_emojis_informative: Okres nemůže obsahovat emotikony
-            contains_mathematical_symbols_instructional: Okres nemůže obsahovat matematické
-              symboly
-            contains_mathematical_symbols_informative: Okres nemůže obsahovat matematické
-              symboly
-            contains_restricted_characters_instructional: Okres může obsahovat pouze
-              písmena, číslice, místní a speciální znaky
-            contains_restricted_characters_informative: Okres nesmí obsahovat nepovolené
-              znaky
-            contains_too_many_words_instructional: Okres musí mít méně než %{word_count}
+            too_long_instructional: Název okresu je příliš dlouhý (maximum je %{limit}
+              znaků)
+            too_long_informative: Název okresu je příliš dlouhý
+            contains_emojis_instructional: Název okresu nesmí obsahovat emodži
+            contains_emojis_informative: Název okresu nesmí obsahovat emodži
+            contains_mathematical_symbols_instructional: Název okresu nesmí obsahovat
+              matematické symboly
+            contains_mathematical_symbols_informative: Název okresu nesmí obsahovat
+              matematické symboly
+            contains_restricted_characters_instructional: Název okresu smí obsahovat
+              pouze písmena, číslice, místní znaky a speciální znaky
+            contains_restricted_characters_informative: Název okresu nesmí obsahovat
+              nepovolené znaky
+            contains_too_many_words_instructional: Název okresu musí mít méně než
+              %{word_count} slov
+            contains_too_many_words_informative: Název okresu musí mít méně než %{word_count}
               slov
-            contains_too_many_words_informative: Okres musí mít méně než %{word_count}
-              slov
-            contains_html_tags_instructional: Okres nemůže obsahovat značky HTML
-            contains_html_tags_informative: Okres nemůže obsahovat značky HTML
-            contains_url_instructional: Okres nemůže obsahovat URL
-            contains_url_informative: Okres nemůže obsahovat URL
+            contains_html_tags_instructional: Název okresu nesmí obsahovat značky
+              HTML
+            contains_html_tags_informative: Název okresu nesmí obsahovat značky HTML
+            contains_url_instructional: Název okresu nesmí obsahovat adresy URL
+            contains_url_informative: Název okresu nesmí obsahovat adresy URL
             unknown_for_city_instructional: Zadejte platný název okresu pro %{city}
             unknown_for_city_informative: Zadejte platný název okresu pro %{city}
             unknown_for_zip_instructional: Zadejte platný název okresu pro %{zip}
             unknown_for_zip_informative: Zadejte platný název okresu pro %{zip}
-            unknown_for_address_instructional: Okres může být nesprávný
-            unknown_for_address_informative: Okres může být nesprávný
+            unknown_for_address_instructional: Název okresu je možná nesprávný
+            unknown_for_address_informative: Název okresu je možná nesprávný
           warnings:
-            contains_too_many_words: Doporučujeme, aby okres obsahoval méně než %{word_count}
-              slov
+            contains_too_many_words: Doporučujeme, aby název okresu obsahoval méně
+              než %{word_count} slov
         subdistrict:
           label:
-            default: Čtvrť
-            optional: Čtvrť (nepovinné)
+            default: Místní část
+            optional: Místní část (volitelné)
           errors:
-            blank_instructional: Zadejte čtvrť
-            blank_informative: Chybí čtvrť
-            too_long_instructional: Čtvrť je příliš dlouhá (maximálně %{limit} znaků)
-            too_long_informative: Čtvrť je příliš dlouhá
-            contains_emojis_instructional: Čtvrť nemůže obsahovat emotikony
-            contains_emojis_informative: Čtvrť nemůže obsahovat emotikony
-            contains_mathematical_symbols_instructional: Čtvrť nemůže obsahovat matematické
-              symboly
-            contains_mathematical_symbols_informative: Čtvrť nemůže obsahovat matematické
-              symboly
-            contains_restricted_characters_instructional: Čtvrť může obsahovat pouze
-              písmena, číslice, místní a speciální znaky
-            contains_restricted_characters_informative: Čtvrť nesmí obsahovat nepovolené
-              znaky
-            contains_too_many_words_instructional: Čtvrť musí mít méně než %{word_count}
-              slov
-            contains_too_many_words_informative: Čtvrť musí mít méně než %{word_count}
-              slov
-            contains_html_tags_instructional: Čtvrť nemůže obsahovat značky HTML
-            contains_html_tags_informative: Čtvrť nemůže obsahovat značky HTML
-            contains_url_instructional: Čtvrť nemůže obsahovat URL
-            contains_url_informative: Čtvrť nemůže obsahovat URL
-            unknown_for_city_instructional: Zadejte platný název čtvrti pro %{city}
-            unknown_for_city_informative: Zadejte platný název čtvrti pro %{city}
-            unknown_for_zip_instructional: Zadejte platný název čtvrti pro %{zip}
-            unknown_for_zip_informative: Zadejte platný název čtvrti pro %{zip}
-            unknown_for_address_instructional: Čtvrť může být nesprávná
-            unknown_for_address_informative: Čtvrť může být nesprávná
+            blank_instructional: Zadejte místní část
+            blank_informative: Chybí místní část
+            too_long_instructional: Název místní části je příliš dlouhý (maximum je
+              %{limit} znaků)
+            too_long_informative: Název místní části je příliš dlouhý
+            contains_emojis_instructional: Název místní části nesmí obsahovat emodži
+            contains_emojis_informative: Název místní části nesmí obsahovat emodži
+            contains_mathematical_symbols_instructional: Název místní části nesmí
+              obsahovat matematické symboly
+            contains_mathematical_symbols_informative: Název místní části nesmí obsahovat
+              matematické symboly
+            contains_restricted_characters_instructional: Název místní části smí obsahovat
+              pouze písmena, číslice, místní znaky a speciální znaky
+            contains_restricted_characters_informative: Název místní části nesmí obsahovat
+              nepovolené znaky
+            contains_too_many_words_instructional: Název místní části musí mít méně
+              než %{word_count} slov
+            contains_too_many_words_informative: Název místní části musí mít méně
+              než %{word_count} slov
+            contains_html_tags_instructional: Název místní části nesmí obsahovat značky
+              HTML
+            contains_html_tags_informative: Název místní části nesmí obsahovat značky
+              HTML
+            contains_url_instructional: Název místní části nesmí obsahovat adresy
+              URL
+            contains_url_informative: Název místní části nesmí obsahovat adresy URL
+            unknown_for_city_instructional: Zadejte platný název místní části pro
+              %{city}
+            unknown_for_city_informative: Zadejte platný název místní části pro %{city}
+            unknown_for_zip_instructional: Zadejte platný název místní části pro %{zip}
+            unknown_for_zip_informative: Zadejte platný název místní části pro %{zip}
+            unknown_for_address_instructional: Název místní části je možná nesprávný
+            unknown_for_address_informative: Název místní části je možná nesprávný
           warnings:
-            contains_too_many_words: Doporučujeme, aby čtvrť obsahovala méně než %{word_count}
-              slov
+            contains_too_many_words: Doporučujeme, aby název místní části obsahoval
+              méně než %{word_count} slov

--- a/data/regions/_default/da.yml
+++ b/data/regions/_default/da.yml
@@ -441,3 +441,77 @@ da:
           errors:
             may_not_exist_instructional: Adressen blev ikke fundet eller findes ikke
             may_not_exist_informative: Adressen blev ikke fundet
+        district:
+          label:
+            default: Distrikt
+            optional: Distrikt (valgfrit)
+          errors:
+            blank_instructional: Angiv et distrikt
+            blank_informative: Distrikt mangler
+            too_long_instructional: Distrikt er for langt (maks. %{limit} tegn)
+            too_long_informative: Distrikt er for langt
+            contains_emojis_instructional: Distrikt kan ikke indeholde emojis
+            contains_emojis_informative: Distrikt kan ikke indeholde emojis
+            contains_mathematical_symbols_instructional: Distrikt kan ikke indeholde
+              matematiske symboler
+            contains_mathematical_symbols_informative: Distrikt kan ikke indeholde
+              matematiske symboler
+            contains_restricted_characters_instructional: Distrikt kan kun indeholde
+              bogstaver, tal, lokale tegn og specialtegn
+            contains_restricted_characters_informative: Distrikt kan ikke indeholde
+              ikke-tilladte tegn
+            contains_too_many_words_instructional: Distrikt skal have færre end %{word_count}
+              ord
+            contains_too_many_words_informative: Distrikt skal have færre end %{word_count}
+              ord
+            contains_html_tags_instructional: Distrikt kan ikke indeholde HTML-tags
+            contains_html_tags_informative: Distrikt kan ikke indeholde HTML-tags
+            contains_url_instructional: Distrikt kan ikke indeholde webadresser
+            contains_url_informative: Distrikt kan ikke indeholde webadresser
+            unknown_for_city_instructional: Angiv et gyldigt distriktsnavn for %{city}
+            unknown_for_city_informative: Angiv et gyldigt distriktsnavn for %{city}
+            unknown_for_zip_instructional: Angiv et gyldigt distriktsnavn for %{zip}
+            unknown_for_zip_informative: Angiv et gyldigt distriktsnavn for %{zip}
+            unknown_for_address_instructional: Distrikt kan være forkert
+            unknown_for_address_informative: Distrikt kan være forkert
+          warnings:
+            contains_too_many_words: Distrikt bør have færre end %{word_count} ord
+        subdistrict:
+          label:
+            default: Underdistrikt
+            optional: Underdistrikt (valgfrit)
+          errors:
+            blank_instructional: Angiv et underdistrikt
+            blank_informative: Underdistrikt mangler
+            too_long_instructional: Underdistrikt er for langt (maks. %{limit} tegn)
+            too_long_informative: Underdistrikt er for langt
+            contains_emojis_instructional: Underdistrikt kan ikke indeholde emojis
+            contains_emojis_informative: Underdistrikt kan ikke indeholde emojis
+            contains_mathematical_symbols_instructional: Underdistrikt kan ikke indeholde
+              matematiske symboler
+            contains_mathematical_symbols_informative: Underdistrikt kan ikke indeholde
+              matematiske symboler
+            contains_restricted_characters_instructional: Underdistrikt kan kun indeholde
+              bogstaver, tal, lokale tegn og specialtegn
+            contains_restricted_characters_informative: Underdistrikt kan ikke indeholde
+              ikke-tilladte tegn
+            contains_too_many_words_instructional: Underdistrikt skal have færre end
+              %{word_count} ord
+            contains_too_many_words_informative: Underdistrikt skal have færre end
+              %{word_count} ord
+            contains_html_tags_instructional: Underdistrikt kan ikke indeholde HTML-tags
+            contains_html_tags_informative: Underdistrikt kan ikke indeholde HTML-tags
+            contains_url_instructional: Underdistrikt kan ikke indeholde webadresser
+            contains_url_informative: Underdistrikt kan ikke indeholde webadresser
+            unknown_for_city_instructional: Angiv et gyldigt underdistriktsnavn for
+              %{city}
+            unknown_for_city_informative: Angiv et gyldigt underdistriktsnavn for
+              %{city}
+            unknown_for_zip_instructional: Angiv et gyldigt underdistriktsnavn for
+              %{zip}
+            unknown_for_zip_informative: Angiv et gyldigt underdistriktsnavn for %{zip}
+            unknown_for_address_instructional: Underdistrikt kan være forkert
+            unknown_for_address_informative: Underdistrikt kan være forkert
+          warnings:
+            contains_too_many_words: Underdistrikt bør have færre end %{word_count}
+              ord

--- a/data/regions/_default/da.yml
+++ b/data/regions/_default/da.yml
@@ -446,72 +446,74 @@ da:
             default: Distrikt
             optional: Distrikt (valgfrit)
           errors:
-            blank_instructional: Angiv et distrikt
+            blank_instructional: Indtast et distrikt
             blank_informative: Distrikt mangler
-            too_long_instructional: Distrikt er for langt (maks. %{limit} tegn)
-            too_long_informative: Distrikt er for langt
-            contains_emojis_instructional: Distrikt kan ikke indeholde emojis
-            contains_emojis_informative: Distrikt kan ikke indeholde emojis
-            contains_mathematical_symbols_instructional: Distrikt kan ikke indeholde
+            too_long_instructional: Distriktet er for langt (maks. %{limit} tegn)
+            too_long_informative: Distriktet er for langt
+            contains_emojis_instructional: Distriktet kan ikke indeholde emojis
+            contains_emojis_informative: Distriktet kan ikke indeholde emojis
+            contains_mathematical_symbols_instructional: Distriktet kan ikke indeholde
               matematiske symboler
-            contains_mathematical_symbols_informative: Distrikt kan ikke indeholde
+            contains_mathematical_symbols_informative: Distriktet kan ikke indeholde
               matematiske symboler
-            contains_restricted_characters_instructional: Distrikt kan kun indeholde
+            contains_restricted_characters_instructional: Distriktet kan kun indeholde
               bogstaver, tal, lokale tegn og specialtegn
-            contains_restricted_characters_informative: Distrikt kan ikke indeholde
+            contains_restricted_characters_informative: Distriktet kan ikke indeholde
               ikke-tilladte tegn
-            contains_too_many_words_instructional: Distrikt skal have færre end %{word_count}
+            contains_too_many_words_instructional: Distriktet skal have færre end
+              %{word_count} ord
+            contains_too_many_words_informative: Distriktet skal have færre end %{word_count}
               ord
-            contains_too_many_words_informative: Distrikt skal have færre end %{word_count}
-              ord
-            contains_html_tags_instructional: Distrikt kan ikke indeholde HTML-tags
-            contains_html_tags_informative: Distrikt kan ikke indeholde HTML-tags
-            contains_url_instructional: Distrikt kan ikke indeholde webadresser
-            contains_url_informative: Distrikt kan ikke indeholde webadresser
-            unknown_for_city_instructional: Angiv et gyldigt distriktsnavn for %{city}
-            unknown_for_city_informative: Angiv et gyldigt distriktsnavn for %{city}
-            unknown_for_zip_instructional: Angiv et gyldigt distriktsnavn for %{zip}
-            unknown_for_zip_informative: Angiv et gyldigt distriktsnavn for %{zip}
-            unknown_for_address_instructional: Distrikt kan være forkert
-            unknown_for_address_informative: Distrikt kan være forkert
+            contains_html_tags_instructional: Distriktet kan ikke indeholde HTML-tags
+            contains_html_tags_informative: Distriktet kan ikke indeholde HTML-tags
+            contains_url_instructional: Distriktet kan ikke indeholde webadresser
+            contains_url_informative: Distriktet kan ikke indeholde webadresser
+            unknown_for_city_instructional: Indtast et gyldigt distriktsnavn for %{city}
+            unknown_for_city_informative: Indtast et gyldigt distriktsnavn for %{city}
+            unknown_for_zip_instructional: Indtast et gyldigt distriktsnavn for %{zip}
+            unknown_for_zip_informative: Indtast et gyldigt distriktsnavn for %{zip}
+            unknown_for_address_instructional: Distriktet er muligvis forkert
+            unknown_for_address_informative: Distriktet er muligvis forkert
           warnings:
-            contains_too_many_words: Distrikt bør have færre end %{word_count} ord
+            contains_too_many_words: Det anbefales, at distriktet har færre end %{word_count}
+              ord
         subdistrict:
           label:
             default: Underdistrikt
             optional: Underdistrikt (valgfrit)
           errors:
-            blank_instructional: Angiv et underdistrikt
+            blank_instructional: Indtast et underdistrikt
             blank_informative: Underdistrikt mangler
-            too_long_instructional: Underdistrikt er for langt (maks. %{limit} tegn)
-            too_long_informative: Underdistrikt er for langt
-            contains_emojis_instructional: Underdistrikt kan ikke indeholde emojis
-            contains_emojis_informative: Underdistrikt kan ikke indeholde emojis
-            contains_mathematical_symbols_instructional: Underdistrikt kan ikke indeholde
+            too_long_instructional: Underdistriktet er for langt (maks. %{limit} tegn)
+            too_long_informative: Underdistriktet er for langt
+            contains_emojis_instructional: Underdistriktet kan ikke indeholde emojis
+            contains_emojis_informative: Underdistriktet kan ikke indeholde emojis
+            contains_mathematical_symbols_instructional: Underdistriktet kan ikke
+              indeholde matematiske symboler
+            contains_mathematical_symbols_informative: Underdistriktet kan ikke indeholde
               matematiske symboler
-            contains_mathematical_symbols_informative: Underdistrikt kan ikke indeholde
-              matematiske symboler
-            contains_restricted_characters_instructional: Underdistrikt kan kun indeholde
-              bogstaver, tal, lokale tegn og specialtegn
-            contains_restricted_characters_informative: Underdistrikt kan ikke indeholde
+            contains_restricted_characters_instructional: Underdistriktet kan kun
+              indeholde bogstaver, tal, lokale tegn og specialtegn
+            contains_restricted_characters_informative: Underdistriktet kan ikke indeholde
               ikke-tilladte tegn
-            contains_too_many_words_instructional: Underdistrikt skal have færre end
+            contains_too_many_words_instructional: Underdistriktet skal have færre
+              end %{word_count} ord
+            contains_too_many_words_informative: Underdistriktet skal have færre end
               %{word_count} ord
-            contains_too_many_words_informative: Underdistrikt skal have færre end
-              %{word_count} ord
-            contains_html_tags_instructional: Underdistrikt kan ikke indeholde HTML-tags
-            contains_html_tags_informative: Underdistrikt kan ikke indeholde HTML-tags
-            contains_url_instructional: Underdistrikt kan ikke indeholde webadresser
-            contains_url_informative: Underdistrikt kan ikke indeholde webadresser
-            unknown_for_city_instructional: Angiv et gyldigt underdistriktsnavn for
+            contains_html_tags_instructional: Underdistriktet kan ikke indeholde HTML-tags
+            contains_html_tags_informative: Underdistriktet kan ikke indeholde HTML-tags
+            contains_url_instructional: Underdistriktet kan ikke indeholde webadresser
+            contains_url_informative: Underdistriktet kan ikke indeholde webadresser
+            unknown_for_city_instructional: Indtast et gyldigt underdistriktsnavn
+              for %{city}
+            unknown_for_city_informative: Indtast et gyldigt underdistriktsnavn for
               %{city}
-            unknown_for_city_informative: Angiv et gyldigt underdistriktsnavn for
-              %{city}
-            unknown_for_zip_instructional: Angiv et gyldigt underdistriktsnavn for
+            unknown_for_zip_instructional: Indtast et gyldigt underdistriktsnavn for
               %{zip}
-            unknown_for_zip_informative: Angiv et gyldigt underdistriktsnavn for %{zip}
-            unknown_for_address_instructional: Underdistrikt kan være forkert
-            unknown_for_address_informative: Underdistrikt kan være forkert
+            unknown_for_zip_informative: Indtast et gyldigt underdistriktsnavn for
+              %{zip}
+            unknown_for_address_instructional: Underdistriktet er muligvis forkert
+            unknown_for_address_informative: Underdistriktet er muligvis forkert
           warnings:
-            contains_too_many_words: Underdistrikt bør have færre end %{word_count}
-              ord
+            contains_too_many_words: Det anbefales, at underdistriktet har færre end
+              %{word_count} ord

--- a/data/regions/_default/de.yml
+++ b/data/regions/_default/de.yml
@@ -451,3 +451,83 @@ de:
           errors:
             may_not_exist_instructional: Adresse nicht gefunden oder existiert nicht
             may_not_exist_informative: Adresse nicht gefunden
+        district:
+          label:
+            default: Bezirk
+            optional: Bezirk (optional)
+          errors:
+            blank_instructional: Gib einen Bezirk ein
+            blank_informative: Bezirk fehlt
+            too_long_instructional: Bezirk ist zu lang (maximal %{limit} Zeichen)
+            too_long_informative: Bezirk ist zu lang
+            contains_emojis_instructional: Bezirk darf keine Emojis enthalten
+            contains_emojis_informative: Bezirk darf keine Emojis enthalten
+            contains_mathematical_symbols_instructional: Bezirk darf keine mathematischen
+              Symbole enthalten
+            contains_mathematical_symbols_informative: Bezirk darf keine mathematischen
+              Symbole enthalten
+            contains_restricted_characters_instructional: Bezirk darf nur Buchstaben,
+              Zahlen, lokale Zeichen und Sonderzeichen enthalten
+            contains_restricted_characters_informative: Bezirk darf keine unzulässigen
+              Zeichen enthalten
+            contains_too_many_words_instructional: Bezirk muss aus weniger als %{word_count}
+              Wörtern bestehen
+            contains_too_many_words_informative: Bezirk muss aus weniger als %{word_count}
+              Wörtern bestehen
+            contains_html_tags_instructional: Bezirk darf keine HTML-Tags enthalten
+            contains_html_tags_informative: Bezirk darf keine HTML-Tags enthalten
+            contains_url_instructional: Bezirk darf keine URLs enthalten
+            contains_url_informative: Bezirk darf keine URLs enthalten
+            unknown_for_city_instructional: Gib einen gültigen Bezirksnamen für %{city}
+              ein
+            unknown_for_city_informative: Gib einen gültigen Bezirksnamen für %{city}
+              ein
+            unknown_for_zip_instructional: Gib einen gültigen Bezirksnamen für %{zip}
+              ein
+            unknown_for_zip_informative: Gib einen gültigen Bezirksnamen für %{zip}
+              ein
+            unknown_for_address_instructional: Bezirk ist möglicherweise falsch
+            unknown_for_address_informative: Bezirk ist möglicherweise falsch
+          warnings:
+            contains_too_many_words: Bezirk sollte aus weniger als %{word_count} Wörtern
+              bestehen
+        subdistrict:
+          label:
+            default: Unterbezirk
+            optional: Unterbezirk (optional)
+          errors:
+            blank_instructional: Gib einen Unterbezirk ein
+            blank_informative: Unterbezirk fehlt
+            too_long_instructional: Unterbezirk ist zu lang (maximal %{limit} Zeichen)
+            too_long_informative: Unterbezirk ist zu lang
+            contains_emojis_instructional: Unterbezirk darf keine Emojis enthalten
+            contains_emojis_informative: Unterbezirk darf keine Emojis enthalten
+            contains_mathematical_symbols_instructional: Unterbezirk darf keine mathematischen
+              Symbole enthalten
+            contains_mathematical_symbols_informative: Unterbezirk darf keine mathematischen
+              Symbole enthalten
+            contains_restricted_characters_instructional: Unterbezirk darf nur Buchstaben,
+              Zahlen, lokale Zeichen und Sonderzeichen enthalten
+            contains_restricted_characters_informative: Unterbezirk darf keine unzulässigen
+              Zeichen enthalten
+            contains_too_many_words_instructional: Unterbezirk muss aus weniger als
+              %{word_count} Wörtern bestehen
+            contains_too_many_words_informative: Unterbezirk muss aus weniger als
+              %{word_count} Wörtern bestehen
+            contains_html_tags_instructional: Unterbezirk darf keine HTML-Tags enthalten
+            contains_html_tags_informative: Unterbezirk darf keine HTML-Tags enthalten
+            contains_url_instructional: Unterbezirk darf keine URLs enthalten
+            contains_url_informative: Unterbezirk darf keine URLs enthalten
+            unknown_for_city_instructional: Gib einen gültigen Unterbezirksnamen für
+              %{city} ein
+            unknown_for_city_informative: Gib einen gültigen Unterbezirksnamen für
+              %{city} ein
+            unknown_for_zip_instructional: Gib einen gültigen Unterbezirksnamen für
+              %{zip} ein
+            unknown_for_zip_informative: Gib einen gültigen Unterbezirksnamen für
+              %{zip} ein
+            unknown_for_address_instructional: Unterbezirk ist möglicherweise falsch
+            unknown_for_address_informative: Unterbezirk ist möglicherweise falsch
+          warnings:
+            contains_too_many_words: Unterbezirk sollte aus weniger als %{word_count}
+              Wörtern bestehen

--- a/data/regions/_default/el.yml
+++ b/data/regions/_default/el.yml
@@ -507,3 +507,89 @@ el:
           errors:
             may_not_exist_instructional: Η διεύθυνση δεν βρέθηκε ή δεν υπάρχει
             may_not_exist_informative: Η διεύθυνση δεν βρέθηκε
+        district:
+          label:
+            default: Περιοχή
+            optional: Περιοχή (προαιρετικό)
+          errors:
+            blank_instructional: Καταχωρίστε περιοχή
+            blank_informative: Λείπει η περιοχή
+            too_long_instructional: Η περιοχή είναι πολύ μεγάλη (το μέγιστο είναι
+              %{limit} χαρακτήρες)
+            too_long_informative: Η περιοχή είναι πολύ μεγάλη
+            contains_emojis_instructional: Η περιοχή δεν μπορεί να περιέχει emoji
+            contains_emojis_informative: Η περιοχή δεν μπορεί να περιέχει emoji
+            contains_mathematical_symbols_instructional: Η περιοχή δεν μπορεί να περιέχει
+              μαθηματικά σύμβολα
+            contains_mathematical_symbols_informative: Η περιοχή δεν μπορεί να περιέχει
+              μαθηματικά σύμβολα
+            contains_restricted_characters_instructional: Η περιοχή μπορεί να περιέχει
+              μόνο γράμματα, αριθμούς, τοπικούς και ειδικούς χαρακτήρες
+            contains_restricted_characters_informative: Η περιοχή δεν μπορεί να περιέχει
+              μη επιτρεπόμενους χαρακτήρες
+            contains_too_many_words_instructional: Η περιοχή πρέπει να έχει λιγότερες
+              από %{word_count} λέξεις
+            contains_too_many_words_informative: Η περιοχή πρέπει να έχει λιγότερες
+              από %{word_count} λέξεις
+            contains_html_tags_instructional: Η περιοχή δεν μπορεί να περιέχει ετικέτες
+              HTML
+            contains_html_tags_informative: Η περιοχή δεν μπορεί να περιέχει ετικέτες
+              HTML
+            contains_url_instructional: Η περιοχή δεν μπορεί να περιέχει URL
+            contains_url_informative: Η περιοχή δεν μπορεί να περιέχει URL
+            unknown_for_city_instructional: Καταχωρίστε ένα έγκυρο όνομα περιοχής
+              για %{city}
+            unknown_for_city_informative: Καταχωρίστε ένα έγκυρο όνομα περιοχής για
+              %{city}
+            unknown_for_zip_instructional: Καταχωρίστε ένα έγκυρο όνομα περιοχής για
+              τον Τ.Κ. %{zip}
+            unknown_for_zip_informative: Καταχωρίστε ένα έγκυρο όνομα περιοχής για
+              τον Τ.Κ. %{zip}
+            unknown_for_address_instructional: Η περιοχή ενδέχεται να είναι εσφαλμένη
+            unknown_for_address_informative: Η περιοχή ενδέχεται να είναι εσφαλμένη
+          warnings:
+            contains_too_many_words: Συνιστάται η περιοχή να έχει λιγότερες από %{word_count}
+              λέξεις
+        subdistrict:
+          label:
+            default: Υποπεριοχή
+            optional: Υποπεριοχή (προαιρετικό)
+          errors:
+            blank_instructional: Καταχωρίστε υποπεριοχή
+            blank_informative: Λείπει η υποπεριοχή
+            too_long_instructional: Η υποπεριοχή είναι πολύ μεγάλη (το μέγιστο είναι
+              %{limit} χαρακτήρες)
+            too_long_informative: Η υποπεριοχή είναι πολύ μεγάλη
+            contains_emojis_instructional: Η υποπεριοχή δεν μπορεί να περιέχει emoji
+            contains_emojis_informative: Η υποπεριοχή δεν μπορεί να περιέχει emoji
+            contains_mathematical_symbols_instructional: Η υποπεριοχή δεν μπορεί να
+              περιέχει μαθηματικά σύμβολα
+            contains_mathematical_symbols_informative: Η υποπεριοχή δεν μπορεί να
+              περιέχει μαθηματικά σύμβολα
+            contains_restricted_characters_instructional: Η υποπεριοχή μπορεί να περιέχει
+              μόνο γράμματα, αριθμούς, τοπικούς και ειδικούς χαρακτήρες
+            contains_restricted_characters_informative: Η υποπεριοχή δεν μπορεί να
+              περιέχει μη επιτρεπόμενους χαρακτήρες
+            contains_too_many_words_instructional: Η υποπεριοχή πρέπει να έχει λιγότερες
+              από %{word_count} λέξεις
+            contains_too_many_words_informative: Η υποπεριοχή πρέπει να έχει λιγότερες
+              από %{word_count} λέξεις
+            contains_html_tags_instructional: Η υποπεριοχή δεν μπορεί να περιέχει
+              ετικέτες HTML
+            contains_html_tags_informative: Η υποπεριοχή δεν μπορεί να περιέχει ετικέτες
+              HTML
+            contains_url_instructional: Η υποπεριοχή δεν μπορεί να περιέχει URL
+            contains_url_informative: Η υποπεριοχή δεν μπορεί να περιέχει URL
+            unknown_for_city_instructional: Καταχωρίστε ένα έγκυρο όνομα υποπεριοχής
+              για %{city}
+            unknown_for_city_informative: Καταχωρίστε ένα έγκυρο όνομα υποπεριοχής
+              για %{city}
+            unknown_for_zip_instructional: Καταχωρίστε ένα έγκυρο όνομα υποπεριοχής
+              για τον Τ.Κ. %{zip}
+            unknown_for_zip_informative: Καταχωρίστε ένα έγκυρο όνομα υποπεριοχής
+              για τον Τ.Κ. %{zip}
+            unknown_for_address_instructional: Η υποπεριοχή ενδέχεται να είναι εσφαλμένη
+            unknown_for_address_informative: Η υποπεριοχή ενδέχεται να είναι εσφαλμένη
+          warnings:
+            contains_too_many_words: Συνιστάται η υποπεριοχή να έχει λιγότερες από
+              %{word_count} λέξεις

--- a/data/regions/_default/el.yml
+++ b/data/regions/_default/el.yml
@@ -512,7 +512,7 @@ el:
             default: Περιοχή
             optional: Περιοχή (προαιρετικό)
           errors:
-            blank_instructional: Καταχωρίστε περιοχή
+            blank_instructional: Εισαγάγετε μια περιοχή
             blank_informative: Λείπει η περιοχή
             too_long_instructional: Η περιοχή είναι πολύ μεγάλη (το μέγιστο είναι
               %{limit} χαρακτήρες)
@@ -524,7 +524,7 @@ el:
             contains_mathematical_symbols_informative: Η περιοχή δεν μπορεί να περιέχει
               μαθηματικά σύμβολα
             contains_restricted_characters_instructional: Η περιοχή μπορεί να περιέχει
-              μόνο γράμματα, αριθμούς, τοπικούς και ειδικούς χαρακτήρες
+              μόνο γράμματα, αριθμούς, τοπικούς χαρακτήρες και ειδικούς χαρακτήρες
             contains_restricted_characters_informative: Η περιοχή δεν μπορεί να περιέχει
               μη επιτρεπόμενους χαρακτήρες
             contains_too_many_words_instructional: Η περιοχή πρέπει να έχει λιγότερες
@@ -537,16 +537,16 @@ el:
               HTML
             contains_url_instructional: Η περιοχή δεν μπορεί να περιέχει URL
             contains_url_informative: Η περιοχή δεν μπορεί να περιέχει URL
-            unknown_for_city_instructional: Καταχωρίστε ένα έγκυρο όνομα περιοχής
-              για %{city}
-            unknown_for_city_informative: Καταχωρίστε ένα έγκυρο όνομα περιοχής για
+            unknown_for_city_instructional: Εισαγάγετε ένα έγκυρο όνομα περιοχής για
               %{city}
-            unknown_for_zip_instructional: Καταχωρίστε ένα έγκυρο όνομα περιοχής για
-              τον Τ.Κ. %{zip}
-            unknown_for_zip_informative: Καταχωρίστε ένα έγκυρο όνομα περιοχής για
-              τον Τ.Κ. %{zip}
-            unknown_for_address_instructional: Η περιοχή ενδέχεται να είναι εσφαλμένη
-            unknown_for_address_informative: Η περιοχή ενδέχεται να είναι εσφαλμένη
+            unknown_for_city_informative: Εισαγάγετε ένα έγκυρο όνομα περιοχής για
+              %{city}
+            unknown_for_zip_instructional: Εισαγάγετε ένα έγκυρο όνομα περιοχής για
+              %{zip}
+            unknown_for_zip_informative: Εισαγάγετε ένα έγκυρο όνομα περιοχής για
+              %{zip}
+            unknown_for_address_instructional: Η περιοχή ενδέχεται να είναι λανθασμένη
+            unknown_for_address_informative: Η περιοχή ενδέχεται να είναι λανθασμένη
           warnings:
             contains_too_many_words: Συνιστάται η περιοχή να έχει λιγότερες από %{word_count}
               λέξεις
@@ -555,7 +555,7 @@ el:
             default: Υποπεριοχή
             optional: Υποπεριοχή (προαιρετικό)
           errors:
-            blank_instructional: Καταχωρίστε υποπεριοχή
+            blank_instructional: Εισαγάγετε μια υποπεριοχή
             blank_informative: Λείπει η υποπεριοχή
             too_long_instructional: Η υποπεριοχή είναι πολύ μεγάλη (το μέγιστο είναι
               %{limit} χαρακτήρες)
@@ -567,7 +567,7 @@ el:
             contains_mathematical_symbols_informative: Η υποπεριοχή δεν μπορεί να
               περιέχει μαθηματικά σύμβολα
             contains_restricted_characters_instructional: Η υποπεριοχή μπορεί να περιέχει
-              μόνο γράμματα, αριθμούς, τοπικούς και ειδικούς χαρακτήρες
+              μόνο γράμματα, αριθμούς, τοπικούς χαρακτήρες και ειδικούς χαρακτήρες
             contains_restricted_characters_informative: Η υποπεριοχή δεν μπορεί να
               περιέχει μη επιτρεπόμενους χαρακτήρες
             contains_too_many_words_instructional: Η υποπεριοχή πρέπει να έχει λιγότερες
@@ -580,16 +580,16 @@ el:
               HTML
             contains_url_instructional: Η υποπεριοχή δεν μπορεί να περιέχει URL
             contains_url_informative: Η υποπεριοχή δεν μπορεί να περιέχει URL
-            unknown_for_city_instructional: Καταχωρίστε ένα έγκυρο όνομα υποπεριοχής
+            unknown_for_city_instructional: Εισαγάγετε ένα έγκυρο όνομα υποπεριοχής
               για %{city}
-            unknown_for_city_informative: Καταχωρίστε ένα έγκυρο όνομα υποπεριοχής
+            unknown_for_city_informative: Εισαγάγετε ένα έγκυρο όνομα υποπεριοχής
               για %{city}
-            unknown_for_zip_instructional: Καταχωρίστε ένα έγκυρο όνομα υποπεριοχής
-              για τον Τ.Κ. %{zip}
-            unknown_for_zip_informative: Καταχωρίστε ένα έγκυρο όνομα υποπεριοχής
-              για τον Τ.Κ. %{zip}
-            unknown_for_address_instructional: Η υποπεριοχή ενδέχεται να είναι εσφαλμένη
-            unknown_for_address_informative: Η υποπεριοχή ενδέχεται να είναι εσφαλμένη
+            unknown_for_zip_instructional: Εισαγάγετε ένα έγκυρο όνομα υποπεριοχής
+              για %{zip}
+            unknown_for_zip_informative: Εισαγάγετε ένα έγκυρο όνομα υποπεριοχής για
+              %{zip}
+            unknown_for_address_instructional: Η υποπεριοχή ενδέχεται να είναι λανθασμένη
+            unknown_for_address_informative: Η υποπεριοχή ενδέχεται να είναι λανθασμένη
           warnings:
             contains_too_many_words: Συνιστάται η υποπεριοχή να έχει λιγότερες από
               %{word_count} λέξεις

--- a/data/regions/_default/en.yml
+++ b/data/regions/_default/en.yml
@@ -248,6 +248,66 @@ en:
             unknown_for_address_informative: Neighborhood may be incorrect
           warnings:
             contains_too_many_words: Neighborhood is recommended to have less than %{word_count} words
+        district:
+          label:
+            default: District
+            optional: District (optional)
+          errors:
+            blank_instructional: Enter a district
+            blank_informative: District is missing
+            too_long_instructional: District is too long (maximum is %{limit} characters)
+            too_long_informative: District is too long
+            contains_emojis_instructional: District can't contain emojis
+            contains_emojis_informative: District can't contain emojis
+            contains_mathematical_symbols_instructional: District can't contain mathematical symbols
+            contains_mathematical_symbols_informative: District can't contain mathematical symbols
+            contains_restricted_characters_instructional: District can only contain letters, numbers,
+              local characters, and special characters
+            contains_restricted_characters_informative: District can't contain restricted characters
+            contains_too_many_words_instructional: District must have fewer than %{word_count} words
+            contains_too_many_words_informative: District must have fewer than %{word_count} words
+            contains_html_tags_instructional: District can't contain HTML tags
+            contains_html_tags_informative: District can't contain HTML tags
+            contains_url_instructional: District can't contain URLs
+            contains_url_informative: District can't contain URLs
+            unknown_for_city_instructional: Enter a valid district name for %{city}
+            unknown_for_city_informative: Enter a valid district name for %{city}
+            unknown_for_zip_instructional: Enter a valid district name for %{zip}
+            unknown_for_zip_informative: Enter a valid district name for %{zip}
+            unknown_for_address_instructional: District may be incorrect
+            unknown_for_address_informative: District may be incorrect
+          warnings:
+            contains_too_many_words: District is recommended to have less than %{word_count} words
+        subdistrict:
+          label:
+            default: Subdistrict
+            optional: Subdistrict (optional)
+          errors:
+            blank_instructional: Enter a subdistrict
+            blank_informative: Subdistrict is missing
+            too_long_instructional: Subdistrict is too long (maximum is %{limit} characters)
+            too_long_informative: Subdistrict is too long
+            contains_emojis_instructional: Subdistrict can't contain emojis
+            contains_emojis_informative: Subdistrict can't contain emojis
+            contains_mathematical_symbols_instructional: Subdistrict can't contain mathematical symbols
+            contains_mathematical_symbols_informative: Subdistrict can't contain mathematical symbols
+            contains_restricted_characters_instructional: Subdistrict can only contain letters, numbers,
+              local characters, and special characters
+            contains_restricted_characters_informative: Subdistrict can't contain restricted characters
+            contains_too_many_words_instructional: Subdistrict must have fewer than %{word_count} words
+            contains_too_many_words_informative: Subdistrict must have fewer than %{word_count} words
+            contains_html_tags_instructional: Subdistrict can't contain HTML tags
+            contains_html_tags_informative: Subdistrict can't contain HTML tags
+            contains_url_instructional: Subdistrict can't contain URLs
+            contains_url_informative: Subdistrict can't contain URLs
+            unknown_for_city_instructional: Enter a valid subdistrict name for %{city}
+            unknown_for_city_informative: Enter a valid subdistrict name for %{city}
+            unknown_for_zip_instructional: Enter a valid subdistrict name for %{zip}
+            unknown_for_zip_informative: Enter a valid subdistrict name for %{zip}
+            unknown_for_address_instructional: Subdistrict may be incorrect
+            unknown_for_address_informative: Subdistrict may be incorrect
+          warnings:
+            contains_too_many_words: Subdistrict is recommended to have less than %{word_count} words
         city:
           label:
             default: City

--- a/data/regions/_default/es.yml
+++ b/data/regions/_default/es.yml
@@ -518,3 +518,89 @@ es:
           errors:
             may_not_exist_instructional: La dirección no se ha encontrado o no existe.
             may_not_exist_informative: La dirección no se ha encontrado.
+        district:
+          label:
+            default: Distrito
+            optional: Distrito (opcional)
+          errors:
+            blank_instructional: Ingresa un distrito
+            blank_informative: Falta el distrito
+            too_long_instructional: El distrito es demasiado largo (el máximo es de
+              %{limit} caracteres)
+            too_long_informative: El distrito es demasiado largo
+            contains_emojis_instructional: El distrito no puede contener emojis
+            contains_emojis_informative: El distrito no puede contener emojis
+            contains_mathematical_symbols_instructional: El distrito no puede contener
+              símbolos matemáticos
+            contains_mathematical_symbols_informative: El distrito no puede contener
+              símbolos matemáticos
+            contains_restricted_characters_instructional: El distrito solo puede contener
+              letras, números, caracteres locales y caracteres especiales
+            contains_restricted_characters_informative: El distrito no puede contener
+              caracteres restringidos
+            contains_too_many_words_instructional: El distrito debe tener menos de
+              %{word_count} palabras
+            contains_too_many_words_informative: El distrito debe tener menos de %{word_count}
+              palabras
+            contains_html_tags_instructional: El distrito no puede contener etiquetas
+              HTML
+            contains_html_tags_informative: El distrito no puede contener etiquetas
+              HTML
+            contains_url_instructional: El distrito no puede contener URL
+            contains_url_informative: El distrito no puede contener URL
+            unknown_for_city_instructional: Ingresa un nombre de distrito válido para
+              %{city}
+            unknown_for_city_informative: Ingresa un nombre de distrito válido para
+              %{city}
+            unknown_for_zip_instructional: Ingresa un nombre de distrito válido para
+              %{zip}
+            unknown_for_zip_informative: Ingresa un nombre de distrito válido para
+              %{zip}
+            unknown_for_address_instructional: El distrito podría ser incorrecto
+            unknown_for_address_informative: El distrito podría ser incorrecto
+          warnings:
+            contains_too_many_words: Se recomienda que el distrito tenga menos de
+              %{word_count} palabras
+        subdistrict:
+          label:
+            default: Subdistrito
+            optional: Subdistrito (opcional)
+          errors:
+            blank_instructional: Ingresa un subdistrito
+            blank_informative: Falta el subdistrito
+            too_long_instructional: El subdistrito es demasiado largo (el máximo es
+              de %{limit} caracteres)
+            too_long_informative: El subdistrito es demasiado largo
+            contains_emojis_instructional: El subdistrito no puede contener emojis
+            contains_emojis_informative: El subdistrito no puede contener emojis
+            contains_mathematical_symbols_instructional: El subdistrito no puede contener
+              símbolos matemáticos
+            contains_mathematical_symbols_informative: El subdistrito no puede contener
+              símbolos matemáticos
+            contains_restricted_characters_instructional: El subdistrito solo puede
+              contener letras, números, caracteres locales y caracteres especiales
+            contains_restricted_characters_informative: El subdistrito no puede contener
+              caracteres restringidos
+            contains_too_many_words_instructional: El subdistrito debe tener menos
+              de %{word_count} palabras
+            contains_too_many_words_informative: El subdistrito debe tener menos de
+              %{word_count} palabras
+            contains_html_tags_instructional: El subdistrito no puede contener etiquetas
+              HTML
+            contains_html_tags_informative: El subdistrito no puede contener etiquetas
+              HTML
+            contains_url_instructional: El subdistrito no puede contener URL
+            contains_url_informative: El subdistrito no puede contener URL
+            unknown_for_city_instructional: Ingresa un nombre de subdistrito válido
+              para %{city}
+            unknown_for_city_informative: Ingresa un nombre de subdistrito válido
+              para %{city}
+            unknown_for_zip_instructional: Ingresa un nombre de subdistrito válido
+              para %{zip}
+            unknown_for_zip_informative: Ingresa un nombre de subdistrito válido para
+              %{zip}
+            unknown_for_address_instructional: El subdistrito podría ser incorrecto
+            unknown_for_address_informative: El subdistrito podría ser incorrecto
+          warnings:
+            contains_too_many_words: Se recomienda que el subdistrito tenga menos
+              de %{word_count} palabras

--- a/data/regions/_default/fi.yml
+++ b/data/regions/_default/fi.yml
@@ -458,81 +458,76 @@ fi:
             may_not_exist_informative: Osoitetta ei löydy
         district:
           label:
-            default: Alue
-            optional: Alue (valinnainen)
+            default: Piiri
+            optional: Piiri (valinnainen)
           errors:
-            blank_instructional: Anna alue
-            blank_informative: Alue puuttuu
-            too_long_instructional: Alue on liian pitkä (enintään %{limit} merkkiä)
-            too_long_informative: Alue on liian pitkä
-            contains_emojis_instructional: Alue ei voi sisältää emojeita
-            contains_emojis_informative: Alue ei voi sisältää emojeita
-            contains_mathematical_symbols_instructional: Alue ei voi sisältää matemaattisia
-              symboleita
-            contains_mathematical_symbols_informative: Alue ei voi sisältää matemaattisia
-              symboleita
-            contains_restricted_characters_instructional: Alue voi sisältää vain kirjaimia,
-              numeroita, paikallisia merkkejä ja erikoismerkkejä
-            contains_restricted_characters_informative: Alue ei voi sisältää rajoitettuja
+            blank_instructional: Anna piiri
+            blank_informative: Piiri puuttuu
+            too_long_instructional: Piiri on liian pitkä (enintään %{limit} merkkiä)
+            too_long_informative: Piiri on liian pitkä
+            contains_emojis_instructional: Piiri ei voi sisältää emojeja
+            contains_emojis_informative: Piiri ei voi sisältää emojeja
+            contains_mathematical_symbols_instructional: Piiri ei voi sisältää matemaattisia
+              symboleja
+            contains_mathematical_symbols_informative: Piiri ei voi sisältää matemaattisia
+              symboleja
+            contains_restricted_characters_instructional: Piiri voi sisältää vain
+              kirjaimia, numeroita, paikallisia merkkejä ja erikoismerkkejä
+            contains_restricted_characters_informative: Piiri ei voi sisältää kiellettyjä
               merkkejä
-            contains_too_many_words_instructional: Alueessa on oltava alle %{word_count}
+            contains_too_many_words_instructional: Piirissä on oltava alle %{word_count}
               sanaa
-            contains_too_many_words_informative: Alueessa on oltava alle %{word_count}
+            contains_too_many_words_informative: Piirissä on oltava alle %{word_count}
               sanaa
-            contains_html_tags_instructional: Alue ei voi sisältää HTML-tunnisteita
-            contains_html_tags_informative: Alue ei voi sisältää HTML-tunnisteita
-            contains_url_instructional: Alue ei voi sisältää URL-osoitteita
-            contains_url_informative: Alue ei voi sisältää URL-osoitteita
-            unknown_for_city_instructional: Anna kelvollinen alueen nimi kaupungille
-              %{city}
-            unknown_for_city_informative: Anna kelvollinen alueen nimi kaupungille
-              %{city}
-            unknown_for_zip_instructional: Anna kelvollinen alueen nimi postinumerolle
-              %{zip}
-            unknown_for_zip_informative: Anna kelvollinen alueen nimi postinumerolle
-              %{zip}
-            unknown_for_address_instructional: Alue saattaa olla virheellinen
-            unknown_for_address_informative: Alue saattaa olla virheellinen
+            contains_html_tags_instructional: Piiri ei voi sisältää HTML-tunnisteita
+            contains_html_tags_informative: Piiri ei voi sisältää HTML-tunnisteita
+            contains_url_instructional: Piiri ei voi sisältää URL-osoitteita
+            contains_url_informative: Piiri ei voi sisältää URL-osoitteita
+            unknown_for_city_instructional: Anna kelvollinen piiri kaupungille %{city}
+            unknown_for_city_informative: Anna kelvollinen piiri kaupungille %{city}
+            unknown_for_zip_instructional: Anna kelvollinen piiri postinumerolle %{zip}
+            unknown_for_zip_informative: Anna kelvollinen piiri postinumerolle %{zip}
+            unknown_for_address_instructional: Piiri saattaa olla virheellinen
+            unknown_for_address_informative: Piiri saattaa olla virheellinen
           warnings:
-            contains_too_many_words: Alueessa suositellaan olevan alle %{word_count}
+            contains_too_many_words: Piirissä suositellaan olevan alle %{word_count}
               sanaa
         subdistrict:
           label:
-            default: Osa-alue
-            optional: Osa-alue (valinnainen)
+            default: Alapiiri
+            optional: Alapiiri (valinnainen)
           errors:
-            blank_instructional: Anna osa-alue
-            blank_informative: Osa-alue puuttuu
-            too_long_instructional: Osa-alue on liian pitkä (enintään %{limit} merkkiä)
-            too_long_informative: Osa-alue on liian pitkä
-            contains_emojis_instructional: Osa-alue ei voi sisältää emojeita
-            contains_emojis_informative: Osa-alue ei voi sisältää emojeita
-            contains_mathematical_symbols_instructional: Osa-alue ei voi sisältää
-              matemaattisia symboleita
-            contains_mathematical_symbols_informative: Osa-alue ei voi sisältää matemaattisia
-              symboleita
-            contains_restricted_characters_instructional: Osa-alue voi sisältää vain
+            blank_instructional: Anna alapiiri
+            blank_informative: Alapiiri puuttuu
+            too_long_instructional: Alapiiri on liian pitkä (enintään %{limit} merkkiä)
+            too_long_informative: Alapiiri on liian pitkä
+            contains_emojis_instructional: Alapiiri ei voi sisältää emojeja
+            contains_emojis_informative: Alapiiri ei voi sisältää emojeja
+            contains_mathematical_symbols_instructional: Alapiiri ei voi sisältää
+              matemaattisia symboleja
+            contains_mathematical_symbols_informative: Alapiiri ei voi sisältää matemaattisia
+              symboleja
+            contains_restricted_characters_instructional: Alapiiri voi sisältää vain
               kirjaimia, numeroita, paikallisia merkkejä ja erikoismerkkejä
-            contains_restricted_characters_informative: Osa-alue ei voi sisältää rajoitettuja
+            contains_restricted_characters_informative: Alapiiri ei voi sisältää kiellettyjä
               merkkejä
-            contains_too_many_words_instructional: Osa-alueessa on oltava alle %{word_count}
+            contains_too_many_words_instructional: Alapiirissä on oltava alle %{word_count}
               sanaa
-            contains_too_many_words_informative: Osa-alueessa on oltava alle %{word_count}
+            contains_too_many_words_informative: Alapiirissä on oltava alle %{word_count}
               sanaa
-            contains_html_tags_instructional: Osa-alue ei voi sisältää HTML-tunnisteita
-            contains_html_tags_informative: Osa-alue ei voi sisältää HTML-tunnisteita
-            contains_url_instructional: Osa-alue ei voi sisältää URL-osoitteita
-            contains_url_informative: Osa-alue ei voi sisältää URL-osoitteita
-            unknown_for_city_instructional: Anna kelvollinen osa-alueen nimi kaupungille
+            contains_html_tags_instructional: Alapiiri ei voi sisältää HTML-tunnisteita
+            contains_html_tags_informative: Alapiiri ei voi sisältää HTML-tunnisteita
+            contains_url_instructional: Alapiiri ei voi sisältää URL-osoitteita
+            contains_url_informative: Alapiiri ei voi sisältää URL-osoitteita
+            unknown_for_city_instructional: Anna kelvollinen alapiiri kaupungille
               %{city}
-            unknown_for_city_informative: Anna kelvollinen osa-alueen nimi kaupungille
-              %{city}
-            unknown_for_zip_instructional: Anna kelvollinen osa-alueen nimi postinumerolle
+            unknown_for_city_informative: Anna kelvollinen alapiiri kaupungille %{city}
+            unknown_for_zip_instructional: Anna kelvollinen alapiiri postinumerolle
               %{zip}
-            unknown_for_zip_informative: Anna kelvollinen osa-alueen nimi postinumerolle
+            unknown_for_zip_informative: Anna kelvollinen alapiiri postinumerolle
               %{zip}
-            unknown_for_address_instructional: Osa-alue saattaa olla virheellinen
-            unknown_for_address_informative: Osa-alue saattaa olla virheellinen
+            unknown_for_address_instructional: Alapiiri saattaa olla virheellinen
+            unknown_for_address_informative: Alapiiri saattaa olla virheellinen
           warnings:
-            contains_too_many_words: Osa-alueessa suositellaan olevan alle %{word_count}
+            contains_too_many_words: Alapiirissä suositellaan olevan alle %{word_count}
               sanaa

--- a/data/regions/_default/fi.yml
+++ b/data/regions/_default/fi.yml
@@ -456,3 +456,83 @@ fi:
           errors:
             may_not_exist_instructional: Osoitetta ei löydy tai sitä ei ole
             may_not_exist_informative: Osoitetta ei löydy
+        district:
+          label:
+            default: Alue
+            optional: Alue (valinnainen)
+          errors:
+            blank_instructional: Anna alue
+            blank_informative: Alue puuttuu
+            too_long_instructional: Alue on liian pitkä (enintään %{limit} merkkiä)
+            too_long_informative: Alue on liian pitkä
+            contains_emojis_instructional: Alue ei voi sisältää emojeita
+            contains_emojis_informative: Alue ei voi sisältää emojeita
+            contains_mathematical_symbols_instructional: Alue ei voi sisältää matemaattisia
+              symboleita
+            contains_mathematical_symbols_informative: Alue ei voi sisältää matemaattisia
+              symboleita
+            contains_restricted_characters_instructional: Alue voi sisältää vain kirjaimia,
+              numeroita, paikallisia merkkejä ja erikoismerkkejä
+            contains_restricted_characters_informative: Alue ei voi sisältää rajoitettuja
+              merkkejä
+            contains_too_many_words_instructional: Alueessa on oltava alle %{word_count}
+              sanaa
+            contains_too_many_words_informative: Alueessa on oltava alle %{word_count}
+              sanaa
+            contains_html_tags_instructional: Alue ei voi sisältää HTML-tunnisteita
+            contains_html_tags_informative: Alue ei voi sisältää HTML-tunnisteita
+            contains_url_instructional: Alue ei voi sisältää URL-osoitteita
+            contains_url_informative: Alue ei voi sisältää URL-osoitteita
+            unknown_for_city_instructional: Anna kelvollinen alueen nimi kaupungille
+              %{city}
+            unknown_for_city_informative: Anna kelvollinen alueen nimi kaupungille
+              %{city}
+            unknown_for_zip_instructional: Anna kelvollinen alueen nimi postinumerolle
+              %{zip}
+            unknown_for_zip_informative: Anna kelvollinen alueen nimi postinumerolle
+              %{zip}
+            unknown_for_address_instructional: Alue saattaa olla virheellinen
+            unknown_for_address_informative: Alue saattaa olla virheellinen
+          warnings:
+            contains_too_many_words: Alueessa suositellaan olevan alle %{word_count}
+              sanaa
+        subdistrict:
+          label:
+            default: Osa-alue
+            optional: Osa-alue (valinnainen)
+          errors:
+            blank_instructional: Anna osa-alue
+            blank_informative: Osa-alue puuttuu
+            too_long_instructional: Osa-alue on liian pitkä (enintään %{limit} merkkiä)
+            too_long_informative: Osa-alue on liian pitkä
+            contains_emojis_instructional: Osa-alue ei voi sisältää emojeita
+            contains_emojis_informative: Osa-alue ei voi sisältää emojeita
+            contains_mathematical_symbols_instructional: Osa-alue ei voi sisältää
+              matemaattisia symboleita
+            contains_mathematical_symbols_informative: Osa-alue ei voi sisältää matemaattisia
+              symboleita
+            contains_restricted_characters_instructional: Osa-alue voi sisältää vain
+              kirjaimia, numeroita, paikallisia merkkejä ja erikoismerkkejä
+            contains_restricted_characters_informative: Osa-alue ei voi sisältää rajoitettuja
+              merkkejä
+            contains_too_many_words_instructional: Osa-alueessa on oltava alle %{word_count}
+              sanaa
+            contains_too_many_words_informative: Osa-alueessa on oltava alle %{word_count}
+              sanaa
+            contains_html_tags_instructional: Osa-alue ei voi sisältää HTML-tunnisteita
+            contains_html_tags_informative: Osa-alue ei voi sisältää HTML-tunnisteita
+            contains_url_instructional: Osa-alue ei voi sisältää URL-osoitteita
+            contains_url_informative: Osa-alue ei voi sisältää URL-osoitteita
+            unknown_for_city_instructional: Anna kelvollinen osa-alueen nimi kaupungille
+              %{city}
+            unknown_for_city_informative: Anna kelvollinen osa-alueen nimi kaupungille
+              %{city}
+            unknown_for_zip_instructional: Anna kelvollinen osa-alueen nimi postinumerolle
+              %{zip}
+            unknown_for_zip_informative: Anna kelvollinen osa-alueen nimi postinumerolle
+              %{zip}
+            unknown_for_address_instructional: Osa-alue saattaa olla virheellinen
+            unknown_for_address_informative: Osa-alue saattaa olla virheellinen
+          warnings:
+            contains_too_many_words: Osa-alueessa suositellaan olevan alle %{word_count}
+              sanaa

--- a/data/regions/_default/fr.yml
+++ b/data/regions/_default/fr.yml
@@ -497,3 +497,91 @@ fr:
           errors:
             may_not_exist_instructional: Adresse introuvable ou inexistante
             may_not_exist_informative: Adresse introuvable
+        district:
+          label:
+            default: District
+            optional: District (facultatif)
+          errors:
+            blank_instructional: Saisissez un district
+            blank_informative: Le district est manquant
+            too_long_instructional: Le district est trop long (%{limit} caractères
+              maximum)
+            too_long_informative: Le district est trop long
+            contains_emojis_instructional: Le district ne peut pas contenir d’emojis
+            contains_emojis_informative: Le district ne peut pas contenir d’emojis
+            contains_mathematical_symbols_instructional: Le district ne peut pas contenir
+              de symboles mathématiques
+            contains_mathematical_symbols_informative: Le district ne peut pas contenir
+              de symboles mathématiques
+            contains_restricted_characters_instructional: Le district ne peut contenir
+              que des lettres, des chiffres, des caractères locaux et des caractères
+              spéciaux
+            contains_restricted_characters_informative: Le district ne peut pas contenir
+              de caractères restreints
+            contains_too_many_words_instructional: Le district doit contenir moins
+              de %{word_count} mots
+            contains_too_many_words_informative: Le district doit contenir moins de
+              %{word_count} mots
+            contains_html_tags_instructional: Le district ne peut pas contenir de
+              balises HTML
+            contains_html_tags_informative: Le district ne peut pas contenir de balises
+              HTML
+            contains_url_instructional: Le district ne peut pas contenir d’URL
+            contains_url_informative: Le district ne peut pas contenir d’URL
+            unknown_for_city_instructional: Saisissez un nom de district valide pour
+              %{city}
+            unknown_for_city_informative: Saisissez un nom de district valide pour
+              %{city}
+            unknown_for_zip_instructional: Saisissez un nom de district valide pour
+              %{zip}
+            unknown_for_zip_informative: Saisissez un nom de district valide pour
+              %{zip}
+            unknown_for_address_instructional: Le district est peut-être incorrect
+            unknown_for_address_informative: Le district est peut-être incorrect
+          warnings:
+            contains_too_many_words: Il est recommandé que le district contienne moins
+              de %{word_count} mots
+        subdistrict:
+          label:
+            default: Sous-district
+            optional: Sous-district (facultatif)
+          errors:
+            blank_instructional: Saisissez un sous-district
+            blank_informative: Le sous-district est manquant
+            too_long_instructional: Le sous-district est trop long (%{limit} caractères
+              maximum)
+            too_long_informative: Le sous-district est trop long
+            contains_emojis_instructional: Le sous-district ne peut pas contenir d’emojis
+            contains_emojis_informative: Le sous-district ne peut pas contenir d’emojis
+            contains_mathematical_symbols_instructional: Le sous-district ne peut
+              pas contenir de symboles mathématiques
+            contains_mathematical_symbols_informative: Le sous-district ne peut pas
+              contenir de symboles mathématiques
+            contains_restricted_characters_instructional: Le sous-district ne peut
+              contenir que des lettres, des chiffres, des caractères locaux et des
+              caractères spéciaux
+            contains_restricted_characters_informative: Le sous-district ne peut pas
+              contenir de caractères restreints
+            contains_too_many_words_instructional: Le sous-district doit contenir
+              moins de %{word_count} mots
+            contains_too_many_words_informative: Le sous-district doit contenir moins
+              de %{word_count} mots
+            contains_html_tags_instructional: Le sous-district ne peut pas contenir
+              de balises HTML
+            contains_html_tags_informative: Le sous-district ne peut pas contenir
+              de balises HTML
+            contains_url_instructional: Le sous-district ne peut pas contenir d’URL
+            contains_url_informative: Le sous-district ne peut pas contenir d’URL
+            unknown_for_city_instructional: Saisissez un nom de sous-district valide
+              pour %{city}
+            unknown_for_city_informative: Saisissez un nom de sous-district valide
+              pour %{city}
+            unknown_for_zip_instructional: Saisissez un nom de sous-district valide
+              pour %{zip}
+            unknown_for_zip_informative: Saisissez un nom de sous-district valide
+              pour %{zip}
+            unknown_for_address_instructional: Le sous-district est peut-être incorrect
+            unknown_for_address_informative: Le sous-district est peut-être incorrect
+          warnings:
+            contains_too_many_words: Il est recommandé que le sous-district contienne
+              moins de %{word_count} mots

--- a/data/regions/_default/fr.yml
+++ b/data/regions/_default/fr.yml
@@ -504,24 +504,24 @@ fr:
           errors:
             blank_instructional: Saisissez un district
             blank_informative: Le district est manquant
-            too_long_instructional: Le district est trop long (%{limit} caractères
-              maximum)
+            too_long_instructional: Le district est trop long (maximum de %{limit}
+              caractères)
             too_long_informative: Le district est trop long
-            contains_emojis_instructional: Le district ne peut pas contenir d’emojis
-            contains_emojis_informative: Le district ne peut pas contenir d’emojis
+            contains_emojis_instructional: Le district ne peut pas contenir d’émojis
+            contains_emojis_informative: Le district ne peut pas contenir d’émojis
             contains_mathematical_symbols_instructional: Le district ne peut pas contenir
               de symboles mathématiques
             contains_mathematical_symbols_informative: Le district ne peut pas contenir
               de symboles mathématiques
-            contains_restricted_characters_instructional: Le district ne peut contenir
-              que des lettres, des chiffres, des caractères locaux et des caractères
+            contains_restricted_characters_instructional: Le district peut uniquement
+              contenir des lettres, des chiffres, des caractères locaux et des caractères
               spéciaux
             contains_restricted_characters_informative: Le district ne peut pas contenir
               de caractères restreints
-            contains_too_many_words_instructional: Le district doit contenir moins
+            contains_too_many_words_instructional: Le district doit comporter moins
               de %{word_count} mots
-            contains_too_many_words_informative: Le district doit contenir moins de
-              %{word_count} mots
+            contains_too_many_words_informative: Le district doit comporter moins
+              de %{word_count} mots
             contains_html_tags_instructional: Le district ne peut pas contenir de
               balises HTML
             contains_html_tags_informative: Le district ne peut pas contenir de balises
@@ -539,7 +539,7 @@ fr:
             unknown_for_address_instructional: Le district est peut-être incorrect
             unknown_for_address_informative: Le district est peut-être incorrect
           warnings:
-            contains_too_many_words: Il est recommandé que le district contienne moins
+            contains_too_many_words: Il est recommandé que le district comporte moins
               de %{word_count} mots
         subdistrict:
           label:
@@ -548,23 +548,23 @@ fr:
           errors:
             blank_instructional: Saisissez un sous-district
             blank_informative: Le sous-district est manquant
-            too_long_instructional: Le sous-district est trop long (%{limit} caractères
-              maximum)
+            too_long_instructional: Le sous-district est trop long (maximum de %{limit}
+              caractères)
             too_long_informative: Le sous-district est trop long
-            contains_emojis_instructional: Le sous-district ne peut pas contenir d’emojis
-            contains_emojis_informative: Le sous-district ne peut pas contenir d’emojis
+            contains_emojis_instructional: Le sous-district ne peut pas contenir d’émojis
+            contains_emojis_informative: Le sous-district ne peut pas contenir d’émojis
             contains_mathematical_symbols_instructional: Le sous-district ne peut
               pas contenir de symboles mathématiques
             contains_mathematical_symbols_informative: Le sous-district ne peut pas
               contenir de symboles mathématiques
-            contains_restricted_characters_instructional: Le sous-district ne peut
-              contenir que des lettres, des chiffres, des caractères locaux et des
-              caractères spéciaux
+            contains_restricted_characters_instructional: Le sous-district peut uniquement
+              contenir des lettres, des chiffres, des caractères locaux et des caractères
+              spéciaux
             contains_restricted_characters_informative: Le sous-district ne peut pas
               contenir de caractères restreints
-            contains_too_many_words_instructional: Le sous-district doit contenir
+            contains_too_many_words_instructional: Le sous-district doit comporter
               moins de %{word_count} mots
-            contains_too_many_words_informative: Le sous-district doit contenir moins
+            contains_too_many_words_informative: Le sous-district doit comporter moins
               de %{word_count} mots
             contains_html_tags_instructional: Le sous-district ne peut pas contenir
               de balises HTML
@@ -583,5 +583,5 @@ fr:
             unknown_for_address_instructional: Le sous-district est peut-être incorrect
             unknown_for_address_informative: Le sous-district est peut-être incorrect
           warnings:
-            contains_too_many_words: Il est recommandé que le sous-district contienne
+            contains_too_many_words: Il est recommandé que le sous-district comporte
               moins de %{word_count} mots

--- a/data/regions/_default/hi.yml
+++ b/data/regions/_default/hi.yml
@@ -458,80 +458,75 @@ hi:
             default: ज़िला
             optional: ज़िला (वैकल्पिक)
           errors:
-            blank_instructional: कोई ज़िला दर्ज करें
-            blank_informative: ज़िला मौजूद नहीं है
+            blank_instructional: कोई ज़िला दर्ज करें.
+            blank_informative: ज़िला मौजूद नहीं है.
             too_long_instructional: ज़िला बहुत लंबा है (अधिकतम %{limit} वर्ण होने
-              चाहिए)
-            too_long_informative: ज़िला बहुत लंबा है
-            contains_emojis_instructional: ज़िले में इमोजी नहीं हो सकते
-            contains_emojis_informative: ज़िले में इमोजी नहीं हो सकते
+              चाहिए).
+            too_long_informative: ज़िला बहुत लंबा है.
+            contains_emojis_instructional: ज़िले में इमोजी नहीं हो सकते.
+            contains_emojis_informative: ज़िले में इमोजी नहीं हो सकते.
             contains_mathematical_symbols_instructional: ज़िले में गणितीय चिह्न नहीं
-              हो सकते
+              हो सकते.
             contains_mathematical_symbols_informative: ज़िले में गणितीय चिह्न नहीं
-              हो सकते
-            contains_restricted_characters_instructional: ज़िले में केवल अक्षर, संख्याएं,
-              स्थानीय वर्ण और विशेष वर्ण शामिल हो सकते हैं
+              हो सकते.
+            contains_restricted_characters_instructional: ज़िले में केवल अक्षर, अंक,
+              स्थानीय वर्ण और विशेष वर्ण हो सकते हैं.
             contains_restricted_characters_informative: ज़िले में प्रतिबंधित वर्ण
-              नहीं हो सकते
+              नहीं हो सकते.
             contains_too_many_words_instructional: ज़िले में %{word_count} से कम शब्द
-              होने चाहिए
+              होने चाहिए.
             contains_too_many_words_informative: ज़िले में %{word_count} से कम शब्द
-              होने चाहिए
-            contains_html_tags_instructional: ज़िले में HTML टैग नहीं हो सकते
-            contains_html_tags_informative: ज़िले में HTML टैग नहीं हो सकते
-            contains_url_instructional: ज़िले में URL नहीं हो सकते
-            contains_url_informative: ज़िले में URL नहीं हो सकते
-            unknown_for_city_instructional: "%{city} के लिए एक मान्य ज़िले का नाम
-              दर्ज करें"
-            unknown_for_city_informative: "%{city} के लिए एक मान्य ज़िले का नाम दर्ज
-              करें"
-            unknown_for_zip_instructional: "%{zip} के लिए एक मान्य ज़िले का नाम दर्ज
-              करें"
-            unknown_for_zip_informative: "%{zip} के लिए एक मान्य ज़िले का नाम दर्ज
-              करें"
-            unknown_for_address_instructional: ज़िला गलत हो सकता है
-            unknown_for_address_informative: ज़िला गलत हो सकता है
+              होने चाहिए.
+            contains_html_tags_instructional: ज़िले में HTML टैग नहीं हो सकते.
+            contains_html_tags_informative: ज़िले में HTML टैग नहीं हो सकते.
+            contains_url_instructional: ज़िले में URL नहीं हो सकते.
+            contains_url_informative: ज़िले में URL नहीं हो सकते.
+            unknown_for_city_instructional: "%{city} के लिए कोई मान्य ज़िला दर्ज करें."
+            unknown_for_city_informative: "%{city} के लिए कोई मान्य ज़िला दर्ज करें."
+            unknown_for_zip_instructional: "%{zip} के लिए कोई मान्य ज़िला दर्ज करें."
+            unknown_for_zip_informative: "%{zip} के लिए कोई मान्य ज़िला दर्ज करें."
+            unknown_for_address_instructional: ज़िला गलत हो सकता है.
+            unknown_for_address_informative: ज़िला गलत हो सकता है.
           warnings:
-            contains_too_many_words: यह सुझाव दिया जाता है कि ज़िले में %{word_count}
-              से कम शब्द हों
+            contains_too_many_words: सुझाव है कि ज़िले में %{word_count} से कम शब्द
+              हों.
         subdistrict:
           label:
             default: उप-ज़िला
             optional: उप-ज़िला (वैकल्पिक)
           errors:
-            blank_instructional: कोई उप-ज़िला दर्ज करें
-            blank_informative: उप-ज़िला मौजूद नहीं है
+            blank_instructional: कोई उप-ज़िला दर्ज करें.
+            blank_informative: उप-ज़िला मौजूद नहीं है.
             too_long_instructional: उप-ज़िला बहुत लंबा है (अधिकतम %{limit} वर्ण होने
-              चाहिए)
-            too_long_informative: उप-ज़िला बहुत लंबा है
-            contains_emojis_instructional: उप-ज़िले में इमोजी नहीं हो सकते
-            contains_emojis_informative: उप-ज़िले में इमोजी नहीं हो सकते
+              चाहिए).
+            too_long_informative: उप-ज़िला बहुत लंबा है.
+            contains_emojis_instructional: उप-ज़िले में इमोजी नहीं हो सकते.
+            contains_emojis_informative: उप-ज़िले में इमोजी नहीं हो सकते.
             contains_mathematical_symbols_instructional: उप-ज़िले में गणितीय चिह्न
-              नहीं हो सकते
+              नहीं हो सकते.
             contains_mathematical_symbols_informative: उप-ज़िले में गणितीय चिह्न नहीं
-              हो सकते
+              हो सकते.
             contains_restricted_characters_instructional: उप-ज़िले में केवल अक्षर,
-              संख्याएं, स्थानीय वर्ण और विशेष वर्ण शामिल हो सकते हैं
+              अंक, स्थानीय वर्ण और विशेष वर्ण हो सकते हैं.
             contains_restricted_characters_informative: उप-ज़िले में प्रतिबंधित वर्ण
-              नहीं हो सकते
+              नहीं हो सकते.
             contains_too_many_words_instructional: उप-ज़िले में %{word_count} से कम
-              शब्द होने चाहिए
+              शब्द होने चाहिए.
             contains_too_many_words_informative: उप-ज़िले में %{word_count} से कम
-              शब्द होने चाहिए
-            contains_html_tags_instructional: उप-ज़िले में HTML टैग नहीं हो सकते
-            contains_html_tags_informative: उप-ज़िले में HTML टैग नहीं हो सकते
-            contains_url_instructional: उप-ज़िले में URL नहीं हो सकते
-            contains_url_informative: उप-ज़िले में URL नहीं हो सकते
-            unknown_for_city_instructional: "%{city} के लिए एक मान्य उप-ज़िले का नाम
-              दर्ज करें"
-            unknown_for_city_informative: "%{city} के लिए एक मान्य उप-ज़िले का नाम
-              दर्ज करें"
-            unknown_for_zip_instructional: "%{zip} के लिए एक मान्य उप-ज़िले का नाम
-              दर्ज करें"
-            unknown_for_zip_informative: "%{zip} के लिए एक मान्य उप-ज़िले का नाम दर्ज
-              करें"
-            unknown_for_address_instructional: उप-ज़िला गलत हो सकता है
-            unknown_for_address_informative: उप-ज़िला गलत हो सकता है
+              शब्द होने चाहिए.
+            contains_html_tags_instructional: उप-ज़िले में HTML टैग नहीं हो सकते.
+            contains_html_tags_informative: उप-ज़िले में HTML टैग नहीं हो सकते.
+            contains_url_instructional: उप-ज़िले में URL नहीं हो सकते.
+            contains_url_informative: उप-ज़िले में URL नहीं हो सकते.
+            unknown_for_city_instructional: "%{city} के लिए कोई मान्य उप-ज़िला दर्ज
+              करें."
+            unknown_for_city_informative: "%{city} के लिए कोई मान्य उप-ज़िला दर्ज
+              करें."
+            unknown_for_zip_instructional: "%{zip} के लिए कोई मान्य उप-ज़िला दर्ज
+              करें."
+            unknown_for_zip_informative: "%{zip} के लिए कोई मान्य उप-ज़िला दर्ज करें."
+            unknown_for_address_instructional: उप-ज़िला गलत हो सकता है.
+            unknown_for_address_informative: उप-ज़िला गलत हो सकता है.
           warnings:
-            contains_too_many_words: यह सुझाव दिया जाता है कि उप-ज़िले में %{word_count}
-              से कम शब्द हों
+            contains_too_many_words: सुझाव है कि उप-ज़िले में %{word_count} से कम
+              शब्द हों.

--- a/data/regions/_default/hi.yml
+++ b/data/regions/_default/hi.yml
@@ -453,3 +453,85 @@ hi:
           errors:
             may_not_exist_instructional: पता नहीं मिला या यहां मौजूद नहीं है
             may_not_exist_informative: पता नहीं मिला
+        district:
+          label:
+            default: ज़िला
+            optional: ज़िला (वैकल्पिक)
+          errors:
+            blank_instructional: कोई ज़िला दर्ज करें
+            blank_informative: ज़िला मौजूद नहीं है
+            too_long_instructional: ज़िला बहुत लंबा है (अधिकतम %{limit} वर्ण होने
+              चाहिए)
+            too_long_informative: ज़िला बहुत लंबा है
+            contains_emojis_instructional: ज़िले में इमोजी नहीं हो सकते
+            contains_emojis_informative: ज़िले में इमोजी नहीं हो सकते
+            contains_mathematical_symbols_instructional: ज़िले में गणितीय चिह्न नहीं
+              हो सकते
+            contains_mathematical_symbols_informative: ज़िले में गणितीय चिह्न नहीं
+              हो सकते
+            contains_restricted_characters_instructional: ज़िले में केवल अक्षर, संख्याएं,
+              स्थानीय वर्ण और विशेष वर्ण शामिल हो सकते हैं
+            contains_restricted_characters_informative: ज़िले में प्रतिबंधित वर्ण
+              नहीं हो सकते
+            contains_too_many_words_instructional: ज़िले में %{word_count} से कम शब्द
+              होने चाहिए
+            contains_too_many_words_informative: ज़िले में %{word_count} से कम शब्द
+              होने चाहिए
+            contains_html_tags_instructional: ज़िले में HTML टैग नहीं हो सकते
+            contains_html_tags_informative: ज़िले में HTML टैग नहीं हो सकते
+            contains_url_instructional: ज़िले में URL नहीं हो सकते
+            contains_url_informative: ज़िले में URL नहीं हो सकते
+            unknown_for_city_instructional: "%{city} के लिए एक मान्य ज़िले का नाम
+              दर्ज करें"
+            unknown_for_city_informative: "%{city} के लिए एक मान्य ज़िले का नाम दर्ज
+              करें"
+            unknown_for_zip_instructional: "%{zip} के लिए एक मान्य ज़िले का नाम दर्ज
+              करें"
+            unknown_for_zip_informative: "%{zip} के लिए एक मान्य ज़िले का नाम दर्ज
+              करें"
+            unknown_for_address_instructional: ज़िला गलत हो सकता है
+            unknown_for_address_informative: ज़िला गलत हो सकता है
+          warnings:
+            contains_too_many_words: यह सुझाव दिया जाता है कि ज़िले में %{word_count}
+              से कम शब्द हों
+        subdistrict:
+          label:
+            default: उप-ज़िला
+            optional: उप-ज़िला (वैकल्पिक)
+          errors:
+            blank_instructional: कोई उप-ज़िला दर्ज करें
+            blank_informative: उप-ज़िला मौजूद नहीं है
+            too_long_instructional: उप-ज़िला बहुत लंबा है (अधिकतम %{limit} वर्ण होने
+              चाहिए)
+            too_long_informative: उप-ज़िला बहुत लंबा है
+            contains_emojis_instructional: उप-ज़िले में इमोजी नहीं हो सकते
+            contains_emojis_informative: उप-ज़िले में इमोजी नहीं हो सकते
+            contains_mathematical_symbols_instructional: उप-ज़िले में गणितीय चिह्न
+              नहीं हो सकते
+            contains_mathematical_symbols_informative: उप-ज़िले में गणितीय चिह्न नहीं
+              हो सकते
+            contains_restricted_characters_instructional: उप-ज़िले में केवल अक्षर,
+              संख्याएं, स्थानीय वर्ण और विशेष वर्ण शामिल हो सकते हैं
+            contains_restricted_characters_informative: उप-ज़िले में प्रतिबंधित वर्ण
+              नहीं हो सकते
+            contains_too_many_words_instructional: उप-ज़िले में %{word_count} से कम
+              शब्द होने चाहिए
+            contains_too_many_words_informative: उप-ज़िले में %{word_count} से कम
+              शब्द होने चाहिए
+            contains_html_tags_instructional: उप-ज़िले में HTML टैग नहीं हो सकते
+            contains_html_tags_informative: उप-ज़िले में HTML टैग नहीं हो सकते
+            contains_url_instructional: उप-ज़िले में URL नहीं हो सकते
+            contains_url_informative: उप-ज़िले में URL नहीं हो सकते
+            unknown_for_city_instructional: "%{city} के लिए एक मान्य उप-ज़िले का नाम
+              दर्ज करें"
+            unknown_for_city_informative: "%{city} के लिए एक मान्य उप-ज़िले का नाम
+              दर्ज करें"
+            unknown_for_zip_instructional: "%{zip} के लिए एक मान्य उप-ज़िले का नाम
+              दर्ज करें"
+            unknown_for_zip_informative: "%{zip} के लिए एक मान्य उप-ज़िले का नाम दर्ज
+              करें"
+            unknown_for_address_instructional: उप-ज़िला गलत हो सकता है
+            unknown_for_address_informative: उप-ज़िला गलत हो सकता है
+          warnings:
+            contains_too_many_words: यह सुझाव दिया जाता है कि उप-ज़िले में %{word_count}
+              से कम शब्द हों

--- a/data/regions/_default/hr.yml
+++ b/data/regions/_default/hr.yml
@@ -463,11 +463,11 @@ hr:
         district:
           label:
             default: Okrug
-            optional: Okrug (neobavezno)
+            optional: Okrug (nije obavezno)
           errors:
             blank_instructional: Unesite okrug
             blank_informative: Nedostaje okrug
-            too_long_instructional: 'Okrug je predug (najviše znakova: %{limit})'
+            too_long_instructional: 'Okrug je predug (maksimalan broj znakova: %{limit})'
             too_long_informative: Okrug je predug
             contains_emojis_instructional: Okrug ne može sadržavati emojije
             contains_emojis_informative: Okrug ne može sadržavati emojije
@@ -477,7 +477,7 @@ hr:
               simbole
             contains_restricted_characters_instructional: Okrug može sadržavati samo
               slova, brojeve, lokalne znakove i posebne znakove
-            contains_restricted_characters_informative: Okrug ne može sadržavati nedopuštene
+            contains_restricted_characters_informative: Okrug ne može sadržavati zabranjene
               znakove
             contains_too_many_words_instructional: Okrug mora imati manje od %{word_count}
               riječi
@@ -487,25 +487,24 @@ hr:
             contains_html_tags_informative: Okrug ne može sadržavati HTML oznake
             contains_url_instructional: Okrug ne može sadržavati URL-ove
             contains_url_informative: Okrug ne može sadržavati URL-ove
-            unknown_for_city_instructional: Unesite važeći naziv okruga za grad %{city}
-            unknown_for_city_informative: Unesite važeći naziv okruga za grad %{city}
-            unknown_for_zip_instructional: Unesite važeći naziv okruga za poštanski
-              broj %{zip}
-            unknown_for_zip_informative: Unesite važeći naziv okruga za poštanski
-              broj %{zip}
+            unknown_for_city_instructional: Unesite važeći naziv okruga za %{city}
+            unknown_for_city_informative: Unesite važeći naziv okruga za %{city}
+            unknown_for_zip_instructional: Unesite važeći naziv okruga za %{zip}
+            unknown_for_zip_informative: Unesite važeći naziv okruga za %{zip}
             unknown_for_address_instructional: Okrug je možda netočan
             unknown_for_address_informative: Okrug je možda netočan
           warnings:
-            contains_too_many_words: Preporučuje se da okrug ima manje od %{word_count}
+            contains_too_many_words: Preporučuje se da naziv okruga ima manje od %{word_count}
               riječi
         subdistrict:
           label:
             default: Podokrug
-            optional: Podokrug (neobavezno)
+            optional: Podokrug (nije obavezno)
           errors:
             blank_instructional: Unesite podokrug
             blank_informative: Nedostaje podokrug
-            too_long_instructional: 'Podokrug je predug (najviše znakova: %{limit})'
+            too_long_instructional: 'Podokrug je predug (maksimalan broj znakova:
+              %{limit})'
             too_long_informative: Podokrug je predug
             contains_emojis_instructional: Podokrug ne može sadržavati emojije
             contains_emojis_informative: Podokrug ne može sadržavati emojije
@@ -516,7 +515,7 @@ hr:
             contains_restricted_characters_instructional: Podokrug može sadržavati
               samo slova, brojeve, lokalne znakove i posebne znakove
             contains_restricted_characters_informative: Podokrug ne može sadržavati
-              nedopuštene znakove
+              zabranjene znakove
             contains_too_many_words_instructional: Podokrug mora imati manje od %{word_count}
               riječi
             contains_too_many_words_informative: Podokrug mora imati manje od %{word_count}
@@ -525,15 +524,12 @@ hr:
             contains_html_tags_informative: Podokrug ne može sadržavati HTML oznake
             contains_url_instructional: Podokrug ne može sadržavati URL-ove
             contains_url_informative: Podokrug ne može sadržavati URL-ove
-            unknown_for_city_instructional: Unesite važeći naziv podokruga za grad
-              %{city}
-            unknown_for_city_informative: Unesite važeći naziv podokruga za grad %{city}
-            unknown_for_zip_instructional: Unesite važeći naziv podokruga za poštanski
-              broj %{zip}
-            unknown_for_zip_informative: Unesite važeći naziv podokruga za poštanski
-              broj %{zip}
+            unknown_for_city_instructional: Unesite važeći naziv podokruga za %{city}
+            unknown_for_city_informative: Unesite važeći naziv podokruga za %{city}
+            unknown_for_zip_instructional: Unesite važeći naziv podokruga za %{zip}
+            unknown_for_zip_informative: Unesite važeći naziv podokruga za %{zip}
             unknown_for_address_instructional: Podokrug je možda netočan
             unknown_for_address_informative: Podokrug je možda netočan
           warnings:
-            contains_too_many_words: Preporučuje se da podokrug ima manje od %{word_count}
-              riječi
+            contains_too_many_words: Preporučuje se da naziv podokruga ima manje od
+              %{word_count} riječi

--- a/data/regions/_default/hr.yml
+++ b/data/regions/_default/hr.yml
@@ -460,3 +460,80 @@ hr:
           errors:
             may_not_exist_instructional: Adresa nije pronađena ili ne postoji
             may_not_exist_informative: Adresa nije pronađena
+        district:
+          label:
+            default: Okrug
+            optional: Okrug (neobavezno)
+          errors:
+            blank_instructional: Unesite okrug
+            blank_informative: Nedostaje okrug
+            too_long_instructional: 'Okrug je predug (najviše znakova: %{limit})'
+            too_long_informative: Okrug je predug
+            contains_emojis_instructional: Okrug ne može sadržavati emojije
+            contains_emojis_informative: Okrug ne može sadržavati emojije
+            contains_mathematical_symbols_instructional: Okrug ne može sadržavati
+              matematičke simbole
+            contains_mathematical_symbols_informative: Okrug ne može sadržavati matematičke
+              simbole
+            contains_restricted_characters_instructional: Okrug može sadržavati samo
+              slova, brojeve, lokalne znakove i posebne znakove
+            contains_restricted_characters_informative: Okrug ne može sadržavati nedopuštene
+              znakove
+            contains_too_many_words_instructional: Okrug mora imati manje od %{word_count}
+              riječi
+            contains_too_many_words_informative: Okrug mora imati manje od %{word_count}
+              riječi
+            contains_html_tags_instructional: Okrug ne može sadržavati HTML oznake
+            contains_html_tags_informative: Okrug ne može sadržavati HTML oznake
+            contains_url_instructional: Okrug ne može sadržavati URL-ove
+            contains_url_informative: Okrug ne može sadržavati URL-ove
+            unknown_for_city_instructional: Unesite važeći naziv okruga za grad %{city}
+            unknown_for_city_informative: Unesite važeći naziv okruga za grad %{city}
+            unknown_for_zip_instructional: Unesite važeći naziv okruga za poštanski
+              broj %{zip}
+            unknown_for_zip_informative: Unesite važeći naziv okruga za poštanski
+              broj %{zip}
+            unknown_for_address_instructional: Okrug je možda netočan
+            unknown_for_address_informative: Okrug je možda netočan
+          warnings:
+            contains_too_many_words: Preporučuje se da okrug ima manje od %{word_count}
+              riječi
+        subdistrict:
+          label:
+            default: Podokrug
+            optional: Podokrug (neobavezno)
+          errors:
+            blank_instructional: Unesite podokrug
+            blank_informative: Nedostaje podokrug
+            too_long_instructional: 'Podokrug je predug (najviše znakova: %{limit})'
+            too_long_informative: Podokrug je predug
+            contains_emojis_instructional: Podokrug ne može sadržavati emojije
+            contains_emojis_informative: Podokrug ne može sadržavati emojije
+            contains_mathematical_symbols_instructional: Podokrug ne može sadržavati
+              matematičke simbole
+            contains_mathematical_symbols_informative: Podokrug ne može sadržavati
+              matematičke simbole
+            contains_restricted_characters_instructional: Podokrug može sadržavati
+              samo slova, brojeve, lokalne znakove i posebne znakove
+            contains_restricted_characters_informative: Podokrug ne može sadržavati
+              nedopuštene znakove
+            contains_too_many_words_instructional: Podokrug mora imati manje od %{word_count}
+              riječi
+            contains_too_many_words_informative: Podokrug mora imati manje od %{word_count}
+              riječi
+            contains_html_tags_instructional: Podokrug ne može sadržavati HTML oznake
+            contains_html_tags_informative: Podokrug ne može sadržavati HTML oznake
+            contains_url_instructional: Podokrug ne može sadržavati URL-ove
+            contains_url_informative: Podokrug ne može sadržavati URL-ove
+            unknown_for_city_instructional: Unesite važeći naziv podokruga za grad
+              %{city}
+            unknown_for_city_informative: Unesite važeći naziv podokruga za grad %{city}
+            unknown_for_zip_instructional: Unesite važeći naziv podokruga za poštanski
+              broj %{zip}
+            unknown_for_zip_informative: Unesite važeći naziv podokruga za poštanski
+              broj %{zip}
+            unknown_for_address_instructional: Podokrug je možda netočan
+            unknown_for_address_informative: Podokrug je možda netočan
+          warnings:
+            contains_too_many_words: Preporučuje se da podokrug ima manje od %{word_count}
+              riječi

--- a/data/regions/_default/hu.yml
+++ b/data/regions/_default/hu.yml
@@ -481,27 +481,27 @@ hu:
               számokat, helyi karaktereket és speciális karaktereket tartalmazhat
             contains_restricted_characters_informative: A kerület nem tartalmazhat
               tiltott karaktereket
-            contains_too_many_words_instructional: A kerület kevesebb mint %{word_count}
-              szóból állhat
-            contains_too_many_words_informative: A kerület kevesebb mint %{word_count}
-              szóból állhat
+            contains_too_many_words_instructional: A kerület nevének kevesebb mint
+              %{word_count} szóból kell állnia
+            contains_too_many_words_informative: A kerület nevének kevesebb mint %{word_count}
+              szóból kell állnia
             contains_html_tags_instructional: A kerület nem tartalmazhat HTML-címkéket
             contains_html_tags_informative: A kerület nem tartalmazhat HTML-címkéket
             contains_url_instructional: A kerület nem tartalmazhat URL-eket
             contains_url_informative: A kerület nem tartalmazhat URL-eket
-            unknown_for_city_instructional: 'Adjon meg egy érvényes kerületnevet a
-              következőhöz: %{city}'
-            unknown_for_city_informative: 'Adjon meg egy érvényes kerületnevet a következőhöz:
+            unknown_for_city_instructional: 'Adjon meg egy érvényes kerületnevet itt:
               %{city}'
-            unknown_for_zip_instructional: 'Adjon meg egy érvényes kerületnevet a
-              következőhöz: %{zip}'
-            unknown_for_zip_informative: 'Adjon meg egy érvényes kerületnevet a következőhöz:
-              %{zip}'
-            unknown_for_address_instructional: A kerület helytelen lehet
-            unknown_for_address_informative: A kerület helytelen lehet
+            unknown_for_city_informative: 'Adjon meg egy érvényes kerületnevet itt:
+              %{city}'
+            unknown_for_zip_instructional: 'Adjon meg egy érvényes kerületnevet ehhez
+              az irányítószámhoz: %{zip}'
+            unknown_for_zip_informative: 'Adjon meg egy érvényes kerületnevet ehhez
+              az irányítószámhoz: %{zip}'
+            unknown_for_address_instructional: Lehet, hogy a kerület hibás
+            unknown_for_address_informative: Lehet, hogy a kerület hibás
           warnings:
-            contains_too_many_words: Javasoljuk, hogy a kerület kevesebb mint %{word_count}
-              szóból álljon
+            contains_too_many_words: Javasoljuk, hogy a kerület neve kevesebb mint
+              %{word_count} szóból álljon
         subdistrict:
           label:
             default: Alkerület
@@ -522,24 +522,24 @@ hu:
               számokat, helyi karaktereket és speciális karaktereket tartalmazhat
             contains_restricted_characters_informative: Az alkerület nem tartalmazhat
               tiltott karaktereket
-            contains_too_many_words_instructional: Az alkerület kevesebb mint %{word_count}
-              szóból állhat
-            contains_too_many_words_informative: Az alkerület kevesebb mint %{word_count}
-              szóból állhat
+            contains_too_many_words_instructional: Az alkerület nevének kevesebb mint
+              %{word_count} szóból kell állnia
+            contains_too_many_words_informative: Az alkerület nevének kevesebb mint
+              %{word_count} szóból kell állnia
             contains_html_tags_instructional: Az alkerület nem tartalmazhat HTML-címkéket
             contains_html_tags_informative: Az alkerület nem tartalmazhat HTML-címkéket
             contains_url_instructional: Az alkerület nem tartalmazhat URL-eket
             contains_url_informative: Az alkerület nem tartalmazhat URL-eket
             unknown_for_city_instructional: 'Adjon meg egy érvényes alkerületnevet
-              a következőhöz: %{city}'
-            unknown_for_city_informative: 'Adjon meg egy érvényes alkerületnevet a
-              következőhöz: %{city}'
+              itt: %{city}'
+            unknown_for_city_informative: 'Adjon meg egy érvényes alkerületnevet itt:
+              %{city}'
             unknown_for_zip_instructional: 'Adjon meg egy érvényes alkerületnevet
-              a következőhöz: %{zip}'
-            unknown_for_zip_informative: 'Adjon meg egy érvényes alkerületnevet a
-              következőhöz: %{zip}'
-            unknown_for_address_instructional: Az alkerület helytelen lehet
-            unknown_for_address_informative: Az alkerület helytelen lehet
+              ehhez az irányítószámhoz: %{zip}'
+            unknown_for_zip_informative: 'Adjon meg egy érvényes alkerületnevet ehhez
+              az irányítószámhoz: %{zip}'
+            unknown_for_address_instructional: Lehet, hogy az alkerület hibás
+            unknown_for_address_informative: Lehet, hogy az alkerület hibás
           warnings:
-            contains_too_many_words: Javasoljuk, hogy az alkerület kevesebb mint %{word_count}
-              szóból álljon
+            contains_too_many_words: Javasoljuk, hogy az alkerület neve kevesebb mint
+              %{word_count} szóból álljon

--- a/data/regions/_default/hu.yml
+++ b/data/regions/_default/hu.yml
@@ -461,3 +461,85 @@ hu:
           errors:
             may_not_exist_instructional: A cím nem található, vagy nem létezik
             may_not_exist_informative: A cím nem található
+        district:
+          label:
+            default: Kerület
+            optional: Kerület (opcionális)
+          errors:
+            blank_instructional: Adjon meg egy kerületet
+            blank_informative: A kerület hiányzik
+            too_long_instructional: A kerület túl hosszú (legfeljebb %{limit} karakter
+              lehet)
+            too_long_informative: A kerület túl hosszú
+            contains_emojis_instructional: A kerület nem tartalmazhat emojikat
+            contains_emojis_informative: A kerület nem tartalmazhat emojikat
+            contains_mathematical_symbols_instructional: A kerület nem tartalmazhat
+              matematikai szimbólumokat
+            contains_mathematical_symbols_informative: A kerület nem tartalmazhat
+              matematikai szimbólumokat
+            contains_restricted_characters_instructional: A kerület csak betűket,
+              számokat, helyi karaktereket és speciális karaktereket tartalmazhat
+            contains_restricted_characters_informative: A kerület nem tartalmazhat
+              tiltott karaktereket
+            contains_too_many_words_instructional: A kerület kevesebb mint %{word_count}
+              szóból állhat
+            contains_too_many_words_informative: A kerület kevesebb mint %{word_count}
+              szóból állhat
+            contains_html_tags_instructional: A kerület nem tartalmazhat HTML-címkéket
+            contains_html_tags_informative: A kerület nem tartalmazhat HTML-címkéket
+            contains_url_instructional: A kerület nem tartalmazhat URL-eket
+            contains_url_informative: A kerület nem tartalmazhat URL-eket
+            unknown_for_city_instructional: 'Adjon meg egy érvényes kerületnevet a
+              következőhöz: %{city}'
+            unknown_for_city_informative: 'Adjon meg egy érvényes kerületnevet a következőhöz:
+              %{city}'
+            unknown_for_zip_instructional: 'Adjon meg egy érvényes kerületnevet a
+              következőhöz: %{zip}'
+            unknown_for_zip_informative: 'Adjon meg egy érvényes kerületnevet a következőhöz:
+              %{zip}'
+            unknown_for_address_instructional: A kerület helytelen lehet
+            unknown_for_address_informative: A kerület helytelen lehet
+          warnings:
+            contains_too_many_words: Javasoljuk, hogy a kerület kevesebb mint %{word_count}
+              szóból álljon
+        subdistrict:
+          label:
+            default: Alkerület
+            optional: Alkerület (opcionális)
+          errors:
+            blank_instructional: Adjon meg egy alkerületet
+            blank_informative: Az alkerület hiányzik
+            too_long_instructional: Az alkerület túl hosszú (legfeljebb %{limit} karakter
+              lehet)
+            too_long_informative: Az alkerület túl hosszú
+            contains_emojis_instructional: Az alkerület nem tartalmazhat emojikat
+            contains_emojis_informative: Az alkerület nem tartalmazhat emojikat
+            contains_mathematical_symbols_instructional: Az alkerület nem tartalmazhat
+              matematikai szimbólumokat
+            contains_mathematical_symbols_informative: Az alkerület nem tartalmazhat
+              matematikai szimbólumokat
+            contains_restricted_characters_instructional: Az alkerület csak betűket,
+              számokat, helyi karaktereket és speciális karaktereket tartalmazhat
+            contains_restricted_characters_informative: Az alkerület nem tartalmazhat
+              tiltott karaktereket
+            contains_too_many_words_instructional: Az alkerület kevesebb mint %{word_count}
+              szóból állhat
+            contains_too_many_words_informative: Az alkerület kevesebb mint %{word_count}
+              szóból állhat
+            contains_html_tags_instructional: Az alkerület nem tartalmazhat HTML-címkéket
+            contains_html_tags_informative: Az alkerület nem tartalmazhat HTML-címkéket
+            contains_url_instructional: Az alkerület nem tartalmazhat URL-eket
+            contains_url_informative: Az alkerület nem tartalmazhat URL-eket
+            unknown_for_city_instructional: 'Adjon meg egy érvényes alkerületnevet
+              a következőhöz: %{city}'
+            unknown_for_city_informative: 'Adjon meg egy érvényes alkerületnevet a
+              következőhöz: %{city}'
+            unknown_for_zip_instructional: 'Adjon meg egy érvényes alkerületnevet
+              a következőhöz: %{zip}'
+            unknown_for_zip_informative: 'Adjon meg egy érvényes alkerületnevet a
+              következőhöz: %{zip}'
+            unknown_for_address_instructional: Az alkerület helytelen lehet
+            unknown_for_address_informative: Az alkerület helytelen lehet
+          warnings:
+            contains_too_many_words: Javasoljuk, hogy az alkerület kevesebb mint %{word_count}
+              szóból álljon

--- a/data/regions/_default/id.yml
+++ b/data/regions/_default/id.yml
@@ -458,81 +458,80 @@ id:
             may_not_exist_informative: Alamat tidak ditemukan
         district:
           label:
-            default: Kecamatan
-            optional: Kecamatan (opsional)
+            default: Distrik
+            optional: Distrik (opsional)
           errors:
-            blank_instructional: Masukkan kecamatan
-            blank_informative: Kecamatan belum diisi
-            too_long_instructional: Kecamatan terlalu panjang (maksimal %{limit} karakter)
-            too_long_informative: Kecamatan terlalu panjang
-            contains_emojis_instructional: Kecamatan tidak boleh berisi emoji
-            contains_emojis_informative: Kecamatan tidak boleh berisi emoji
-            contains_mathematical_symbols_instructional: Kecamatan tidak boleh berisi
+            blank_instructional: Masukkan distrik
+            blank_informative: Distrik belum diisi
+            too_long_instructional: Distrik terlalu panjang (maksimal %{limit} karakter)
+            too_long_informative: Distrik terlalu panjang
+            contains_emojis_instructional: Distrik tidak boleh berisi emoji
+            contains_emojis_informative: Distrik tidak boleh berisi emoji
+            contains_mathematical_symbols_instructional: Distrik tidak boleh berisi
               simbol matematika
-            contains_mathematical_symbols_informative: Kecamatan tidak boleh berisi
+            contains_mathematical_symbols_informative: Distrik tidak boleh berisi
               simbol matematika
-            contains_restricted_characters_instructional: Kecamatan hanya boleh berisi
+            contains_restricted_characters_instructional: Distrik hanya boleh berisi
               huruf, angka, karakter lokal, dan karakter khusus
-            contains_restricted_characters_informative: Kecamatan tidak boleh berisi
-              karakter yang dibatasi
-            contains_too_many_words_instructional: Kecamatan harus kurang dari %{word_count}
+            contains_restricted_characters_informative: Distrik tidak boleh berisi
+              karakter yang dilarang
+            contains_too_many_words_instructional: Distrik harus kurang dari %{word_count}
               kata
-            contains_too_many_words_informative: Kecamatan harus kurang dari %{word_count}
+            contains_too_many_words_informative: Distrik harus kurang dari %{word_count}
               kata
-            contains_html_tags_instructional: Kecamatan tidak boleh berisi tag HTML
-            contains_html_tags_informative: Kecamatan tidak boleh berisi tag HTML
-            contains_url_instructional: Kecamatan tidak boleh berisi URL
-            contains_url_informative: Kecamatan tidak boleh berisi URL
-            unknown_for_city_instructional: Masukkan nama kecamatan yang valid untuk
+            contains_html_tags_instructional: Distrik tidak boleh berisi tag HTML
+            contains_html_tags_informative: Distrik tidak boleh berisi tag HTML
+            contains_url_instructional: Distrik tidak boleh berisi URL
+            contains_url_informative: Distrik tidak boleh berisi URL
+            unknown_for_city_instructional: Masukkan nama distrik yang valid untuk
               %{city}
-            unknown_for_city_informative: Masukkan nama kecamatan yang valid untuk
-              %{city}
-            unknown_for_zip_instructional: Masukkan nama kecamatan yang valid untuk
+            unknown_for_city_informative: Masukkan nama distrik yang valid untuk %{city}
+            unknown_for_zip_instructional: Masukkan nama distrik yang valid untuk
               %{zip}
-            unknown_for_zip_informative: Masukkan nama kecamatan yang valid untuk
-              %{zip}
-            unknown_for_address_instructional: Kecamatan mungkin salah
-            unknown_for_address_informative: Kecamatan mungkin salah
+            unknown_for_zip_informative: Masukkan nama distrik yang valid untuk %{zip}
+            unknown_for_address_instructional: Distrik mungkin salah
+            unknown_for_address_informative: Distrik mungkin salah
           warnings:
-            contains_too_many_words: Kecamatan disarankan kurang dari %{word_count}
+            contains_too_many_words: Distrik disarankan kurang dari %{word_count}
               kata
         subdistrict:
           label:
-            default: Kelurahan
-            optional: Kelurahan (opsional)
+            default: Subdistrik
+            optional: Subdistrik (opsional)
           errors:
-            blank_instructional: Masukkan kelurahan
-            blank_informative: Kelurahan belum diisi
-            too_long_instructional: Kelurahan terlalu panjang (maksimal %{limit} karakter)
-            too_long_informative: Kelurahan terlalu panjang
-            contains_emojis_instructional: Kelurahan tidak boleh berisi emoji
-            contains_emojis_informative: Kelurahan tidak boleh berisi emoji
-            contains_mathematical_symbols_instructional: Kelurahan tidak boleh berisi
+            blank_instructional: Masukkan subdistrik
+            blank_informative: Subdistrik belum diisi
+            too_long_instructional: Subdistrik terlalu panjang (maksimal %{limit}
+              karakter)
+            too_long_informative: Subdistrik terlalu panjang
+            contains_emojis_instructional: Subdistrik tidak boleh berisi emoji
+            contains_emojis_informative: Subdistrik tidak boleh berisi emoji
+            contains_mathematical_symbols_instructional: Subdistrik tidak boleh berisi
               simbol matematika
-            contains_mathematical_symbols_informative: Kelurahan tidak boleh berisi
+            contains_mathematical_symbols_informative: Subdistrik tidak boleh berisi
               simbol matematika
-            contains_restricted_characters_instructional: Kelurahan hanya boleh berisi
+            contains_restricted_characters_instructional: Subdistrik hanya boleh berisi
               huruf, angka, karakter lokal, dan karakter khusus
-            contains_restricted_characters_informative: Kelurahan tidak boleh berisi
-              karakter yang dibatasi
-            contains_too_many_words_instructional: Kelurahan harus kurang dari %{word_count}
+            contains_restricted_characters_informative: Subdistrik tidak boleh berisi
+              karakter yang dilarang
+            contains_too_many_words_instructional: Subdistrik harus kurang dari %{word_count}
               kata
-            contains_too_many_words_informative: Kelurahan harus kurang dari %{word_count}
+            contains_too_many_words_informative: Subdistrik harus kurang dari %{word_count}
               kata
-            contains_html_tags_instructional: Kelurahan tidak boleh berisi tag HTML
-            contains_html_tags_informative: Kelurahan tidak boleh berisi tag HTML
-            contains_url_instructional: Kelurahan tidak boleh berisi URL
-            contains_url_informative: Kelurahan tidak boleh berisi URL
-            unknown_for_city_instructional: Masukkan nama kelurahan yang valid untuk
+            contains_html_tags_instructional: Subdistrik tidak boleh berisi tag HTML
+            contains_html_tags_informative: Subdistrik tidak boleh berisi tag HTML
+            contains_url_instructional: Subdistrik tidak boleh berisi URL
+            contains_url_informative: Subdistrik tidak boleh berisi URL
+            unknown_for_city_instructional: Masukkan nama subdistrik yang valid untuk
               %{city}
-            unknown_for_city_informative: Masukkan nama kelurahan yang valid untuk
+            unknown_for_city_informative: Masukkan nama subdistrik yang valid untuk
               %{city}
-            unknown_for_zip_instructional: Masukkan nama kelurahan yang valid untuk
+            unknown_for_zip_instructional: Masukkan nama subdistrik yang valid untuk
               %{zip}
-            unknown_for_zip_informative: Masukkan nama kelurahan yang valid untuk
+            unknown_for_zip_informative: Masukkan nama subdistrik yang valid untuk
               %{zip}
-            unknown_for_address_instructional: Kelurahan mungkin salah
-            unknown_for_address_informative: Kelurahan mungkin salah
+            unknown_for_address_instructional: Subdistrik mungkin salah
+            unknown_for_address_informative: Subdistrik mungkin salah
           warnings:
-            contains_too_many_words: Kelurahan disarankan kurang dari %{word_count}
+            contains_too_many_words: Subdistrik disarankan kurang dari %{word_count}
               kata

--- a/data/regions/_default/id.yml
+++ b/data/regions/_default/id.yml
@@ -456,3 +456,83 @@ id:
           errors:
             may_not_exist_instructional: Alamat tidak ditemukan atau tidak ada
             may_not_exist_informative: Alamat tidak ditemukan
+        district:
+          label:
+            default: Kecamatan
+            optional: Kecamatan (opsional)
+          errors:
+            blank_instructional: Masukkan kecamatan
+            blank_informative: Kecamatan belum diisi
+            too_long_instructional: Kecamatan terlalu panjang (maksimal %{limit} karakter)
+            too_long_informative: Kecamatan terlalu panjang
+            contains_emojis_instructional: Kecamatan tidak boleh berisi emoji
+            contains_emojis_informative: Kecamatan tidak boleh berisi emoji
+            contains_mathematical_symbols_instructional: Kecamatan tidak boleh berisi
+              simbol matematika
+            contains_mathematical_symbols_informative: Kecamatan tidak boleh berisi
+              simbol matematika
+            contains_restricted_characters_instructional: Kecamatan hanya boleh berisi
+              huruf, angka, karakter lokal, dan karakter khusus
+            contains_restricted_characters_informative: Kecamatan tidak boleh berisi
+              karakter yang dibatasi
+            contains_too_many_words_instructional: Kecamatan harus kurang dari %{word_count}
+              kata
+            contains_too_many_words_informative: Kecamatan harus kurang dari %{word_count}
+              kata
+            contains_html_tags_instructional: Kecamatan tidak boleh berisi tag HTML
+            contains_html_tags_informative: Kecamatan tidak boleh berisi tag HTML
+            contains_url_instructional: Kecamatan tidak boleh berisi URL
+            contains_url_informative: Kecamatan tidak boleh berisi URL
+            unknown_for_city_instructional: Masukkan nama kecamatan yang valid untuk
+              %{city}
+            unknown_for_city_informative: Masukkan nama kecamatan yang valid untuk
+              %{city}
+            unknown_for_zip_instructional: Masukkan nama kecamatan yang valid untuk
+              %{zip}
+            unknown_for_zip_informative: Masukkan nama kecamatan yang valid untuk
+              %{zip}
+            unknown_for_address_instructional: Kecamatan mungkin salah
+            unknown_for_address_informative: Kecamatan mungkin salah
+          warnings:
+            contains_too_many_words: Kecamatan disarankan kurang dari %{word_count}
+              kata
+        subdistrict:
+          label:
+            default: Kelurahan
+            optional: Kelurahan (opsional)
+          errors:
+            blank_instructional: Masukkan kelurahan
+            blank_informative: Kelurahan belum diisi
+            too_long_instructional: Kelurahan terlalu panjang (maksimal %{limit} karakter)
+            too_long_informative: Kelurahan terlalu panjang
+            contains_emojis_instructional: Kelurahan tidak boleh berisi emoji
+            contains_emojis_informative: Kelurahan tidak boleh berisi emoji
+            contains_mathematical_symbols_instructional: Kelurahan tidak boleh berisi
+              simbol matematika
+            contains_mathematical_symbols_informative: Kelurahan tidak boleh berisi
+              simbol matematika
+            contains_restricted_characters_instructional: Kelurahan hanya boleh berisi
+              huruf, angka, karakter lokal, dan karakter khusus
+            contains_restricted_characters_informative: Kelurahan tidak boleh berisi
+              karakter yang dibatasi
+            contains_too_many_words_instructional: Kelurahan harus kurang dari %{word_count}
+              kata
+            contains_too_many_words_informative: Kelurahan harus kurang dari %{word_count}
+              kata
+            contains_html_tags_instructional: Kelurahan tidak boleh berisi tag HTML
+            contains_html_tags_informative: Kelurahan tidak boleh berisi tag HTML
+            contains_url_instructional: Kelurahan tidak boleh berisi URL
+            contains_url_informative: Kelurahan tidak boleh berisi URL
+            unknown_for_city_instructional: Masukkan nama kelurahan yang valid untuk
+              %{city}
+            unknown_for_city_informative: Masukkan nama kelurahan yang valid untuk
+              %{city}
+            unknown_for_zip_instructional: Masukkan nama kelurahan yang valid untuk
+              %{zip}
+            unknown_for_zip_informative: Masukkan nama kelurahan yang valid untuk
+              %{zip}
+            unknown_for_address_instructional: Kelurahan mungkin salah
+            unknown_for_address_informative: Kelurahan mungkin salah
+          warnings:
+            contains_too_many_words: Kelurahan disarankan kurang dari %{word_count}
+              kata

--- a/data/regions/_default/it.yml
+++ b/data/regions/_default/it.yml
@@ -503,7 +503,7 @@ it:
             optional: Distretto (facoltativo)
           errors:
             blank_instructional: Inserisci un distretto
-            blank_informative: Distretto mancante
+            blank_informative: Manca il distretto
             too_long_instructional: Il distretto è troppo lungo (massimo %{limit}
               caratteri)
             too_long_informative: Il distretto è troppo lungo
@@ -517,10 +517,10 @@ it:
               solo lettere, numeri, caratteri locali e caratteri speciali
             contains_restricted_characters_informative: Il distretto non può contenere
               caratteri non consentiti
-            contains_too_many_words_instructional: Il distretto deve contenere meno
-              di %{word_count} parole
-            contains_too_many_words_informative: Il distretto deve contenere meno
-              di %{word_count} parole
+            contains_too_many_words_instructional: Il distretto deve avere meno di
+              %{word_count} parole
+            contains_too_many_words_informative: Il distretto deve avere meno di %{word_count}
+              parole
             contains_html_tags_instructional: Il distretto non può contenere tag HTML
             contains_html_tags_informative: Il distretto non può contenere tag HTML
             contains_url_instructional: Il distretto non può contenere URL
@@ -536,7 +536,7 @@ it:
             unknown_for_address_instructional: Il distretto potrebbe essere errato
             unknown_for_address_informative: Il distretto potrebbe essere errato
           warnings:
-            contains_too_many_words: È consigliabile che il distretto contenga meno
+            contains_too_many_words: Si consiglia di inserire un distretto con meno
               di %{word_count} parole
         subdistrict:
           label:
@@ -544,7 +544,7 @@ it:
             optional: Sottodistretto (facoltativo)
           errors:
             blank_instructional: Inserisci un sottodistretto
-            blank_informative: Sottodistretto mancante
+            blank_informative: Manca il sottodistretto
             too_long_instructional: Il sottodistretto è troppo lungo (massimo %{limit}
               caratteri)
             too_long_informative: Il sottodistretto è troppo lungo
@@ -558,10 +558,10 @@ it:
               solo lettere, numeri, caratteri locali e caratteri speciali
             contains_restricted_characters_informative: Il sottodistretto non può
               contenere caratteri non consentiti
-            contains_too_many_words_instructional: Il sottodistretto deve contenere
-              meno di %{word_count} parole
-            contains_too_many_words_informative: Il sottodistretto deve contenere
-              meno di %{word_count} parole
+            contains_too_many_words_instructional: Il sottodistretto deve avere meno
+              di %{word_count} parole
+            contains_too_many_words_informative: Il sottodistretto deve avere meno
+              di %{word_count} parole
             contains_html_tags_instructional: Il sottodistretto non può contenere
               tag HTML
             contains_html_tags_informative: Il sottodistretto non può contenere tag
@@ -579,5 +579,5 @@ it:
             unknown_for_address_instructional: Il sottodistretto potrebbe essere errato
             unknown_for_address_informative: Il sottodistretto potrebbe essere errato
           warnings:
-            contains_too_many_words: È consigliabile che il sottodistretto contenga
+            contains_too_many_words: Si consiglia di inserire un sottodistretto con
               meno di %{word_count} parole

--- a/data/regions/_default/it.yml
+++ b/data/regions/_default/it.yml
@@ -497,3 +497,87 @@ it:
           errors:
             may_not_exist_instructional: Indirizzo non trovato o non esistente
             may_not_exist_informative: Indirizzo non trovato
+        district:
+          label:
+            default: Distretto
+            optional: Distretto (facoltativo)
+          errors:
+            blank_instructional: Inserisci un distretto
+            blank_informative: Distretto mancante
+            too_long_instructional: Il distretto è troppo lungo (massimo %{limit}
+              caratteri)
+            too_long_informative: Il distretto è troppo lungo
+            contains_emojis_instructional: Il distretto non può contenere emoji
+            contains_emojis_informative: Il distretto non può contenere emoji
+            contains_mathematical_symbols_instructional: Il distretto non può contenere
+              simboli matematici
+            contains_mathematical_symbols_informative: Il distretto non può contenere
+              simboli matematici
+            contains_restricted_characters_instructional: Il distretto può contenere
+              solo lettere, numeri, caratteri locali e caratteri speciali
+            contains_restricted_characters_informative: Il distretto non può contenere
+              caratteri non consentiti
+            contains_too_many_words_instructional: Il distretto deve contenere meno
+              di %{word_count} parole
+            contains_too_many_words_informative: Il distretto deve contenere meno
+              di %{word_count} parole
+            contains_html_tags_instructional: Il distretto non può contenere tag HTML
+            contains_html_tags_informative: Il distretto non può contenere tag HTML
+            contains_url_instructional: Il distretto non può contenere URL
+            contains_url_informative: Il distretto non può contenere URL
+            unknown_for_city_instructional: Inserisci un nome di distretto valido
+              per %{city}
+            unknown_for_city_informative: Inserisci un nome di distretto valido per
+              %{city}
+            unknown_for_zip_instructional: Inserisci un nome di distretto valido per
+              %{zip}
+            unknown_for_zip_informative: Inserisci un nome di distretto valido per
+              %{zip}
+            unknown_for_address_instructional: Il distretto potrebbe essere errato
+            unknown_for_address_informative: Il distretto potrebbe essere errato
+          warnings:
+            contains_too_many_words: È consigliabile che il distretto contenga meno
+              di %{word_count} parole
+        subdistrict:
+          label:
+            default: Sottodistretto
+            optional: Sottodistretto (facoltativo)
+          errors:
+            blank_instructional: Inserisci un sottodistretto
+            blank_informative: Sottodistretto mancante
+            too_long_instructional: Il sottodistretto è troppo lungo (massimo %{limit}
+              caratteri)
+            too_long_informative: Il sottodistretto è troppo lungo
+            contains_emojis_instructional: Il sottodistretto non può contenere emoji
+            contains_emojis_informative: Il sottodistretto non può contenere emoji
+            contains_mathematical_symbols_instructional: Il sottodistretto non può
+              contenere simboli matematici
+            contains_mathematical_symbols_informative: Il sottodistretto non può contenere
+              simboli matematici
+            contains_restricted_characters_instructional: Il sottodistretto può contenere
+              solo lettere, numeri, caratteri locali e caratteri speciali
+            contains_restricted_characters_informative: Il sottodistretto non può
+              contenere caratteri non consentiti
+            contains_too_many_words_instructional: Il sottodistretto deve contenere
+              meno di %{word_count} parole
+            contains_too_many_words_informative: Il sottodistretto deve contenere
+              meno di %{word_count} parole
+            contains_html_tags_instructional: Il sottodistretto non può contenere
+              tag HTML
+            contains_html_tags_informative: Il sottodistretto non può contenere tag
+              HTML
+            contains_url_instructional: Il sottodistretto non può contenere URL
+            contains_url_informative: Il sottodistretto non può contenere URL
+            unknown_for_city_instructional: Inserisci un nome di sottodistretto valido
+              per %{city}
+            unknown_for_city_informative: Inserisci un nome di sottodistretto valido
+              per %{city}
+            unknown_for_zip_instructional: Inserisci un nome di sottodistretto valido
+              per %{zip}
+            unknown_for_zip_informative: Inserisci un nome di sottodistretto valido
+              per %{zip}
+            unknown_for_address_instructional: Il sottodistretto potrebbe essere errato
+            unknown_for_address_informative: Il sottodistretto potrebbe essere errato
+          warnings:
+            contains_too_many_words: È consigliabile che il sottodistretto contenga
+              meno di %{word_count} parole

--- a/data/regions/_default/ja.yml
+++ b/data/regions/_default/ja.yml
@@ -352,16 +352,16 @@ ja:
         district:
           label:
             default: 地区
-            optional: 地区 (オプション)
+            optional: 地区（オプション）
           errors:
             blank_instructional: 地区を入力してください
             blank_informative: 地区が入力されていません
-            too_long_instructional: 地区が長すぎます (最大 %{limit} 文字)
+            too_long_instructional: 地区が長すぎます（最大 %{limit} 文字）
             too_long_informative: 地区が長すぎます
             contains_emojis_instructional: 地区に絵文字を含めることはできません
             contains_emojis_informative: 地区に絵文字を含めることはできません
-            contains_mathematical_symbols_instructional: 地区に数学記号を含めることはできません
-            contains_mathematical_symbols_informative: 地区に数学記号を含めることはできません
+            contains_mathematical_symbols_instructional: 地区に算術記号を含めることはできません
+            contains_mathematical_symbols_informative: 地区に算術記号を含めることはできません
             contains_restricted_characters_instructional: 地区には、文字、数字、現地の文字、特殊文字のみを使用できます
             contains_restricted_characters_informative: 地区に制限された文字を含めることはできません
             contains_too_many_words_instructional: 地区は %{word_count} 語未満にする必要があります
@@ -370,27 +370,27 @@ ja:
             contains_html_tags_informative: 地区に HTML タグを含めることはできません
             contains_url_instructional: 地区に URL を含めることはできません
             contains_url_informative: 地区に URL を含めることはできません
-            unknown_for_city_instructional: "%{city} に有効な地区名を入力してください"
-            unknown_for_city_informative: "%{city} に有効な地区名を入力してください"
-            unknown_for_zip_instructional: "%{zip} に有効な地区名を入力してください"
-            unknown_for_zip_informative: "%{zip} に有効な地区名を入力してください"
-            unknown_for_address_instructional: 地区が間違っている可能性があります
-            unknown_for_address_informative: 地区が間違っている可能性があります
+            unknown_for_city_instructional: "%{city} の有効な地区名を入力してください"
+            unknown_for_city_informative: "%{city} の有効な地区名を入力してください"
+            unknown_for_zip_instructional: "%{zip} の有効な地区名を入力してください"
+            unknown_for_zip_informative: "%{zip} の有効な地区名を入力してください"
+            unknown_for_address_instructional: 地区に誤りがある可能性があります
+            unknown_for_address_informative: 地区に誤りがある可能性があります
           warnings:
             contains_too_many_words: 地区は %{word_count} 語未満にすることをおすすめします
         subdistrict:
           label:
             default: 小地区
-            optional: 小地区 (オプション)
+            optional: 小地区（オプション）
           errors:
             blank_instructional: 小地区を入力してください
             blank_informative: 小地区が入力されていません
-            too_long_instructional: 小地区が長すぎます (最大 %{limit} 文字)
+            too_long_instructional: 小地区が長すぎます（最大 %{limit} 文字）
             too_long_informative: 小地区が長すぎます
             contains_emojis_instructional: 小地区に絵文字を含めることはできません
             contains_emojis_informative: 小地区に絵文字を含めることはできません
-            contains_mathematical_symbols_instructional: 小地区に数学記号を含めることはできません
-            contains_mathematical_symbols_informative: 小地区に数学記号を含めることはできません
+            contains_mathematical_symbols_instructional: 小地区に算術記号を含めることはできません
+            contains_mathematical_symbols_informative: 小地区に算術記号を含めることはできません
             contains_restricted_characters_instructional: 小地区には、文字、数字、現地の文字、特殊文字のみを使用できます
             contains_restricted_characters_informative: 小地区に制限された文字を含めることはできません
             contains_too_many_words_instructional: 小地区は %{word_count} 語未満にする必要があります
@@ -399,11 +399,11 @@ ja:
             contains_html_tags_informative: 小地区に HTML タグを含めることはできません
             contains_url_instructional: 小地区に URL を含めることはできません
             contains_url_informative: 小地区に URL を含めることはできません
-            unknown_for_city_instructional: "%{city} に有効な小地区名を入力してください"
-            unknown_for_city_informative: "%{city} に有効な小地区名を入力してください"
-            unknown_for_zip_instructional: "%{zip} に有効な小地区名を入力してください"
-            unknown_for_zip_informative: "%{zip} に有効な小地区名を入力してください"
-            unknown_for_address_instructional: 小地区が間違っている可能性があります
-            unknown_for_address_informative: 小地区が間違っている可能性があります
+            unknown_for_city_instructional: "%{city} の有効な小地区名を入力してください"
+            unknown_for_city_informative: "%{city} の有効な小地区名を入力してください"
+            unknown_for_zip_instructional: "%{zip} の有効な小地区名を入力してください"
+            unknown_for_zip_informative: "%{zip} の有効な小地区名を入力してください"
+            unknown_for_address_instructional: 小地区に誤りがある可能性があります
+            unknown_for_address_informative: 小地区に誤りがある可能性があります
           warnings:
             contains_too_many_words: 小地区は %{word_count} 語未満にすることをおすすめします

--- a/data/regions/_default/ja.yml
+++ b/data/regions/_default/ja.yml
@@ -349,3 +349,61 @@ ja:
           errors:
             may_not_exist_instructional: 住所が見つからない、または存在しません
             may_not_exist_informative: 住所が見つかりません
+        district:
+          label:
+            default: 地区
+            optional: 地区 (オプション)
+          errors:
+            blank_instructional: 地区を入力してください
+            blank_informative: 地区が入力されていません
+            too_long_instructional: 地区が長すぎます (最大 %{limit} 文字)
+            too_long_informative: 地区が長すぎます
+            contains_emojis_instructional: 地区に絵文字を含めることはできません
+            contains_emojis_informative: 地区に絵文字を含めることはできません
+            contains_mathematical_symbols_instructional: 地区に数学記号を含めることはできません
+            contains_mathematical_symbols_informative: 地区に数学記号を含めることはできません
+            contains_restricted_characters_instructional: 地区には、文字、数字、現地の文字、特殊文字のみを使用できます
+            contains_restricted_characters_informative: 地区に制限された文字を含めることはできません
+            contains_too_many_words_instructional: 地区は %{word_count} 語未満にする必要があります
+            contains_too_many_words_informative: 地区は %{word_count} 語未満にする必要があります
+            contains_html_tags_instructional: 地区に HTML タグを含めることはできません
+            contains_html_tags_informative: 地区に HTML タグを含めることはできません
+            contains_url_instructional: 地区に URL を含めることはできません
+            contains_url_informative: 地区に URL を含めることはできません
+            unknown_for_city_instructional: "%{city} に有効な地区名を入力してください"
+            unknown_for_city_informative: "%{city} に有効な地区名を入力してください"
+            unknown_for_zip_instructional: "%{zip} に有効な地区名を入力してください"
+            unknown_for_zip_informative: "%{zip} に有効な地区名を入力してください"
+            unknown_for_address_instructional: 地区が間違っている可能性があります
+            unknown_for_address_informative: 地区が間違っている可能性があります
+          warnings:
+            contains_too_many_words: 地区は %{word_count} 語未満にすることをおすすめします
+        subdistrict:
+          label:
+            default: 小地区
+            optional: 小地区 (オプション)
+          errors:
+            blank_instructional: 小地区を入力してください
+            blank_informative: 小地区が入力されていません
+            too_long_instructional: 小地区が長すぎます (最大 %{limit} 文字)
+            too_long_informative: 小地区が長すぎます
+            contains_emojis_instructional: 小地区に絵文字を含めることはできません
+            contains_emojis_informative: 小地区に絵文字を含めることはできません
+            contains_mathematical_symbols_instructional: 小地区に数学記号を含めることはできません
+            contains_mathematical_symbols_informative: 小地区に数学記号を含めることはできません
+            contains_restricted_characters_instructional: 小地区には、文字、数字、現地の文字、特殊文字のみを使用できます
+            contains_restricted_characters_informative: 小地区に制限された文字を含めることはできません
+            contains_too_many_words_instructional: 小地区は %{word_count} 語未満にする必要があります
+            contains_too_many_words_informative: 小地区は %{word_count} 語未満にする必要があります
+            contains_html_tags_instructional: 小地区に HTML タグを含めることはできません
+            contains_html_tags_informative: 小地区に HTML タグを含めることはできません
+            contains_url_instructional: 小地区に URL を含めることはできません
+            contains_url_informative: 小地区に URL を含めることはできません
+            unknown_for_city_instructional: "%{city} に有効な小地区名を入力してください"
+            unknown_for_city_informative: "%{city} に有効な小地区名を入力してください"
+            unknown_for_zip_instructional: "%{zip} に有効な小地区名を入力してください"
+            unknown_for_zip_informative: "%{zip} に有効な小地区名を入力してください"
+            unknown_for_address_instructional: 小地区が間違っている可能性があります
+            unknown_for_address_informative: 小地区が間違っている可能性があります
+          warnings:
+            contains_too_many_words: 小地区は %{word_count} 語未満にすることをおすすめします

--- a/data/regions/_default/ko.yml
+++ b/data/regions/_default/ko.yml
@@ -374,65 +374,61 @@ ko:
             may_not_exist_informative: 주소를 찾을 수 없습니다
         district:
           label:
-            default: 구역
-            optional: 구역(선택 사항)
+            default: 구/군
+            optional: 구/군(선택 사항)
           errors:
-            blank_instructional: 구역을 입력하십시오.
-            blank_informative: 구역이 누락되었습니다.
-            too_long_instructional: 구역이 너무 깁니다(최대 %{limit}자).
-            too_long_informative: 구역이 너무 깁니다.
-            contains_emojis_instructional: 구역에는 이모티콘을 포함할 수 없습니다.
-            contains_emojis_informative: 구역에는 이모티콘을 포함할 수 없습니다.
-            contains_mathematical_symbols_instructional: 구역에는 수학 기호를 포함할 수 없습니다.
-            contains_mathematical_symbols_informative: 구역에는 수학 기호를 포함할 수 없습니다.
-            contains_restricted_characters_instructional: 구역에는 문자, 숫자, 현지 문자, 특수 문자만
-              포함할 수 있습니다.
-            contains_restricted_characters_informative: 구역에는 제한된 문자를 포함할 수 없습니다.
-            contains_too_many_words_instructional: 구역은 %{word_count}개 미만의 단어로 구성되어야
-              합니다.
-            contains_too_many_words_informative: 구역은 %{word_count}개 미만의 단어로 구성되어야
-              합니다.
-            contains_html_tags_instructional: 구역에는 HTML 태그를 포함할 수 없습니다.
-            contains_html_tags_informative: 구역에는 HTML 태그를 포함할 수 없습니다.
-            contains_url_instructional: 구역에는 URL을 포함할 수 없습니다.
-            contains_url_informative: 구역에는 URL을 포함할 수 없습니다.
-            unknown_for_city_instructional: "%{city}의 유효한 구역 이름을 입력하십시오."
-            unknown_for_city_informative: "%{city}의 유효한 구역 이름을 입력하십시오."
-            unknown_for_zip_instructional: "%{zip}의 유효한 구역 이름을 입력하십시오."
-            unknown_for_zip_informative: "%{zip}의 유효한 구역 이름을 입력하십시오."
-            unknown_for_address_instructional: 구역이 올바르지 않을 수 있습니다.
-            unknown_for_address_informative: 구역이 올바르지 않을 수 있습니다.
+            blank_instructional: 구/군을 입력하십시오.
+            blank_informative: 구/군이 누락되었습니다.
+            too_long_instructional: 구/군이 너무 깁니다(최대 %{limit}자).
+            too_long_informative: 구/군이 너무 깁니다.
+            contains_emojis_instructional: 구/군에는 이모지를 포함할 수 없습니다.
+            contains_emojis_informative: 구/군에는 이모지를 포함할 수 없습니다.
+            contains_mathematical_symbols_instructional: 구/군에는 수학 기호를 포함할 수 없습니다.
+            contains_mathematical_symbols_informative: 구/군에는 수학 기호를 포함할 수 없습니다.
+            contains_restricted_characters_instructional: 구/군에는 문자, 숫자, 현지 문자 및 특수
+              문자만 포함할 수 있습니다.
+            contains_restricted_characters_informative: 구/군에는 제한된 문자를 포함할 수 없습니다.
+            contains_too_many_words_instructional: 구/군은 %{word_count}단어 미만이어야 합니다.
+            contains_too_many_words_informative: 구/군은 %{word_count}단어 미만이어야 합니다.
+            contains_html_tags_instructional: 구/군에는 HTML 태그를 포함할 수 없습니다.
+            contains_html_tags_informative: 구/군에는 HTML 태그를 포함할 수 없습니다.
+            contains_url_instructional: 구/군에는 URL을 포함할 수 없습니다.
+            contains_url_informative: 구/군에는 URL을 포함할 수 없습니다.
+            unknown_for_city_instructional: "%{city}의 유효한 구/군 이름을 입력하십시오."
+            unknown_for_city_informative: "%{city}의 유효한 구/군 이름을 입력하십시오."
+            unknown_for_zip_instructional: "%{zip}의 유효한 구/군 이름을 입력하십시오."
+            unknown_for_zip_informative: "%{zip}의 유효한 구/군 이름을 입력하십시오."
+            unknown_for_address_instructional: 구/군이 올바르지 않을 수 있습니다.
+            unknown_for_address_informative: 구/군이 올바르지 않을 수 있습니다.
           warnings:
-            contains_too_many_words: 구역은 %{word_count}개 미만의 단어로 구성하는 것이 좋습니다.
+            contains_too_many_words: 구/군은 %{word_count}단어 미만으로 입력하는 것이 좋습니다.
         subdistrict:
           label:
-            default: 하위 구역
-            optional: 하위 구역(선택 사항)
+            default: 동/면/읍
+            optional: 동/면/읍(선택 사항)
           errors:
-            blank_instructional: 하위 구역을 입력하십시오.
-            blank_informative: 하위 구역이 누락되었습니다.
-            too_long_instructional: 하위 구역이 너무 깁니다(최대 %{limit}자).
-            too_long_informative: 하위 구역이 너무 깁니다.
-            contains_emojis_instructional: 하위 구역에는 이모티콘을 포함할 수 없습니다.
-            contains_emojis_informative: 하위 구역에는 이모티콘을 포함할 수 없습니다.
-            contains_mathematical_symbols_instructional: 하위 구역에는 수학 기호를 포함할 수 없습니다.
-            contains_mathematical_symbols_informative: 하위 구역에는 수학 기호를 포함할 수 없습니다.
-            contains_restricted_characters_instructional: 하위 구역에는 문자, 숫자, 현지 문자, 특수
-              문자만 포함할 수 있습니다.
-            contains_restricted_characters_informative: 하위 구역에는 제한된 문자를 포함할 수 없습니다.
-            contains_too_many_words_instructional: 하위 구역은 %{word_count}개 미만의 단어로 구성되어야
-              합니다.
-            contains_too_many_words_informative: 하위 구역은 %{word_count}개 미만의 단어로 구성되어야
-              합니다.
-            contains_html_tags_instructional: 하위 구역에는 HTML 태그를 포함할 수 없습니다.
-            contains_html_tags_informative: 하위 구역에는 HTML 태그를 포함할 수 없습니다.
-            contains_url_instructional: 하위 구역에는 URL을 포함할 수 없습니다.
-            contains_url_informative: 하위 구역에는 URL을 포함할 수 없습니다.
-            unknown_for_city_instructional: "%{city}의 유효한 하위 구역 이름을 입력하십시오."
-            unknown_for_city_informative: "%{city}의 유효한 하위 구역 이름을 입력하십시오."
-            unknown_for_zip_instructional: "%{zip}의 유효한 하위 구역 이름을 입력하십시오."
-            unknown_for_zip_informative: "%{zip}의 유효한 하위 구역 이름을 입력하십시오."
-            unknown_for_address_instructional: 하위 구역이 올바르지 않을 수 있습니다.
-            unknown_for_address_informative: 하위 구역이 올바르지 않을 수 있습니다.
+            blank_instructional: 동/면/읍을 입력하십시오.
+            blank_informative: 동/면/읍이 누락되었습니다.
+            too_long_instructional: 동/면/읍이 너무 깁니다(최대 %{limit}자).
+            too_long_informative: 동/면/읍이 너무 깁니다.
+            contains_emojis_instructional: 동/면/읍에는 이모지를 포함할 수 없습니다.
+            contains_emojis_informative: 동/면/읍에는 이모지를 포함할 수 없습니다.
+            contains_mathematical_symbols_instructional: 동/면/읍에는 수학 기호를 포함할 수 없습니다.
+            contains_mathematical_symbols_informative: 동/면/읍에는 수학 기호를 포함할 수 없습니다.
+            contains_restricted_characters_instructional: 동/면/읍에는 문자, 숫자, 현지 문자 및
+              특수 문자만 포함할 수 있습니다.
+            contains_restricted_characters_informative: 동/면/읍에는 제한된 문자를 포함할 수 없습니다.
+            contains_too_many_words_instructional: 동/면/읍은 %{word_count}단어 미만이어야 합니다.
+            contains_too_many_words_informative: 동/면/읍은 %{word_count}단어 미만이어야 합니다.
+            contains_html_tags_instructional: 동/면/읍에는 HTML 태그를 포함할 수 없습니다.
+            contains_html_tags_informative: 동/면/읍에는 HTML 태그를 포함할 수 없습니다.
+            contains_url_instructional: 동/면/읍에는 URL을 포함할 수 없습니다.
+            contains_url_informative: 동/면/읍에는 URL을 포함할 수 없습니다.
+            unknown_for_city_instructional: "%{city}의 유효한 동/면/읍 이름을 입력하십시오."
+            unknown_for_city_informative: "%{city}의 유효한 동/면/읍 이름을 입력하십시오."
+            unknown_for_zip_instructional: "%{zip}의 유효한 동/면/읍 이름을 입력하십시오."
+            unknown_for_zip_informative: "%{zip}의 유효한 동/면/읍 이름을 입력하십시오."
+            unknown_for_address_instructional: 동/면/읍이 올바르지 않을 수 있습니다.
+            unknown_for_address_informative: 동/면/읍이 올바르지 않을 수 있습니다.
           warnings:
-            contains_too_many_words: 하위 구역은 %{word_count}개 미만의 단어로 구성하는 것이 좋습니다.
+            contains_too_many_words: 동/면/읍은 %{word_count}단어 미만으로 입력하는 것이 좋습니다.

--- a/data/regions/_default/ko.yml
+++ b/data/regions/_default/ko.yml
@@ -372,3 +372,67 @@ ko:
           errors:
             may_not_exist_instructional: 주소를 찾을 수 없거나 없습니다
             may_not_exist_informative: 주소를 찾을 수 없습니다
+        district:
+          label:
+            default: 구역
+            optional: 구역(선택 사항)
+          errors:
+            blank_instructional: 구역을 입력하십시오.
+            blank_informative: 구역이 누락되었습니다.
+            too_long_instructional: 구역이 너무 깁니다(최대 %{limit}자).
+            too_long_informative: 구역이 너무 깁니다.
+            contains_emojis_instructional: 구역에는 이모티콘을 포함할 수 없습니다.
+            contains_emojis_informative: 구역에는 이모티콘을 포함할 수 없습니다.
+            contains_mathematical_symbols_instructional: 구역에는 수학 기호를 포함할 수 없습니다.
+            contains_mathematical_symbols_informative: 구역에는 수학 기호를 포함할 수 없습니다.
+            contains_restricted_characters_instructional: 구역에는 문자, 숫자, 현지 문자, 특수 문자만
+              포함할 수 있습니다.
+            contains_restricted_characters_informative: 구역에는 제한된 문자를 포함할 수 없습니다.
+            contains_too_many_words_instructional: 구역은 %{word_count}개 미만의 단어로 구성되어야
+              합니다.
+            contains_too_many_words_informative: 구역은 %{word_count}개 미만의 단어로 구성되어야
+              합니다.
+            contains_html_tags_instructional: 구역에는 HTML 태그를 포함할 수 없습니다.
+            contains_html_tags_informative: 구역에는 HTML 태그를 포함할 수 없습니다.
+            contains_url_instructional: 구역에는 URL을 포함할 수 없습니다.
+            contains_url_informative: 구역에는 URL을 포함할 수 없습니다.
+            unknown_for_city_instructional: "%{city}의 유효한 구역 이름을 입력하십시오."
+            unknown_for_city_informative: "%{city}의 유효한 구역 이름을 입력하십시오."
+            unknown_for_zip_instructional: "%{zip}의 유효한 구역 이름을 입력하십시오."
+            unknown_for_zip_informative: "%{zip}의 유효한 구역 이름을 입력하십시오."
+            unknown_for_address_instructional: 구역이 올바르지 않을 수 있습니다.
+            unknown_for_address_informative: 구역이 올바르지 않을 수 있습니다.
+          warnings:
+            contains_too_many_words: 구역은 %{word_count}개 미만의 단어로 구성하는 것이 좋습니다.
+        subdistrict:
+          label:
+            default: 하위 구역
+            optional: 하위 구역(선택 사항)
+          errors:
+            blank_instructional: 하위 구역을 입력하십시오.
+            blank_informative: 하위 구역이 누락되었습니다.
+            too_long_instructional: 하위 구역이 너무 깁니다(최대 %{limit}자).
+            too_long_informative: 하위 구역이 너무 깁니다.
+            contains_emojis_instructional: 하위 구역에는 이모티콘을 포함할 수 없습니다.
+            contains_emojis_informative: 하위 구역에는 이모티콘을 포함할 수 없습니다.
+            contains_mathematical_symbols_instructional: 하위 구역에는 수학 기호를 포함할 수 없습니다.
+            contains_mathematical_symbols_informative: 하위 구역에는 수학 기호를 포함할 수 없습니다.
+            contains_restricted_characters_instructional: 하위 구역에는 문자, 숫자, 현지 문자, 특수
+              문자만 포함할 수 있습니다.
+            contains_restricted_characters_informative: 하위 구역에는 제한된 문자를 포함할 수 없습니다.
+            contains_too_many_words_instructional: 하위 구역은 %{word_count}개 미만의 단어로 구성되어야
+              합니다.
+            contains_too_many_words_informative: 하위 구역은 %{word_count}개 미만의 단어로 구성되어야
+              합니다.
+            contains_html_tags_instructional: 하위 구역에는 HTML 태그를 포함할 수 없습니다.
+            contains_html_tags_informative: 하위 구역에는 HTML 태그를 포함할 수 없습니다.
+            contains_url_instructional: 하위 구역에는 URL을 포함할 수 없습니다.
+            contains_url_informative: 하위 구역에는 URL을 포함할 수 없습니다.
+            unknown_for_city_instructional: "%{city}의 유효한 하위 구역 이름을 입력하십시오."
+            unknown_for_city_informative: "%{city}의 유효한 하위 구역 이름을 입력하십시오."
+            unknown_for_zip_instructional: "%{zip}의 유효한 하위 구역 이름을 입력하십시오."
+            unknown_for_zip_informative: "%{zip}의 유효한 하위 구역 이름을 입력하십시오."
+            unknown_for_address_instructional: 하위 구역이 올바르지 않을 수 있습니다.
+            unknown_for_address_informative: 하위 구역이 올바르지 않을 수 있습니다.
+          warnings:
+            contains_too_many_words: 하위 구역은 %{word_count}개 미만의 단어로 구성하는 것이 좋습니다.

--- a/data/regions/_default/lt.yml
+++ b/data/regions/_default/lt.yml
@@ -481,3 +481,87 @@ lt:
           errors:
             may_not_exist_instructional: Adresas nerastas arba neegzistuoja
             may_not_exist_informative: Adresas nerastas
+        district:
+          label:
+            default: Rajonas
+            optional: Rajonas (neprivaloma)
+          errors:
+            blank_instructional: Įveskite rajoną
+            blank_informative: Nenurodytas rajonas
+            too_long_instructional: Rajono pavadinimas per ilgas (daugiausia %{limit}
+              simbolių)
+            too_long_informative: Rajono pavadinimas per ilgas
+            contains_emojis_instructional: Rajono pavadinime negali būti jaustukų
+            contains_emojis_informative: Rajono pavadinime negali būti jaustukų
+            contains_mathematical_symbols_instructional: Rajono pavadinime negali
+              būti matematinių simbolių
+            contains_mathematical_symbols_informative: Rajono pavadinime negali būti
+              matematinių simbolių
+            contains_restricted_characters_instructional: Rajono pavadinime gali būti
+              tik raidės, skaičiai, vietiniai ir specialieji simboliai
+            contains_restricted_characters_informative: Rajono pavadinime negali būti
+              draudžiamų simbolių
+            contains_too_many_words_instructional: Rajono pavadinimą turi sudaryti
+              mažiau nei %{word_count} žodžių
+            contains_too_many_words_informative: Rajono pavadinimą turi sudaryti mažiau
+              nei %{word_count} žodžių
+            contains_html_tags_instructional: Rajono pavadinime negali būti HTML žymų
+            contains_html_tags_informative: Rajono pavadinime negali būti HTML žymų
+            contains_url_instructional: Rajono pavadinime negali būti URL
+            contains_url_informative: Rajono pavadinime negali būti URL
+            unknown_for_city_instructional: Įveskite tinkamą rajono pavadinimą miestui
+              %{city}
+            unknown_for_city_informative: Įveskite tinkamą rajono pavadinimą miestui
+              %{city}
+            unknown_for_zip_instructional: Įveskite tinkamą rajono pavadinimą pašto
+              kodui %{zip}
+            unknown_for_zip_informative: Įveskite tinkamą rajono pavadinimą pašto
+              kodui %{zip}
+            unknown_for_address_instructional: Rajonas gali būti nurodytas neteisingai
+            unknown_for_address_informative: Rajonas gali būti nurodytas neteisingai
+          warnings:
+            contains_too_many_words: Rekomenduojama, kad rajono pavadinimą sudarytų
+              mažiau nei %{word_count} žodžių
+        subdistrict:
+          label:
+            default: Mikrorajonas
+            optional: Mikrorajonas (neprivaloma)
+          errors:
+            blank_instructional: Įveskite mikrorajoną
+            blank_informative: Nenurodytas mikrorajonas
+            too_long_instructional: Mikrorajono pavadinimas per ilgas (daugiausia
+              %{limit} simbolių)
+            too_long_informative: Mikrorajono pavadinimas per ilgas
+            contains_emojis_instructional: Mikrorajono pavadinime negali būti jaustukų
+            contains_emojis_informative: Mikrorajono pavadinime negali būti jaustukų
+            contains_mathematical_symbols_instructional: Mikrorajono pavadinime negali
+              būti matematinių simbolių
+            contains_mathematical_symbols_informative: Mikrorajono pavadinime negali
+              būti matematinių simbolių
+            contains_restricted_characters_instructional: Mikrorajono pavadinime gali
+              būti tik raidės, skaičiai, vietiniai ir specialieji simboliai
+            contains_restricted_characters_informative: Mikrorajono pavadinime negali
+              būti draudžiamų simbolių
+            contains_too_many_words_instructional: Mikrorajono pavadinimą turi sudaryti
+              mažiau nei %{word_count} žodžių
+            contains_too_many_words_informative: Mikrorajono pavadinimą turi sudaryti
+              mažiau nei %{word_count} žodžių
+            contains_html_tags_instructional: Mikrorajono pavadinime negali būti HTML
+              žymų
+            contains_html_tags_informative: Mikrorajono pavadinime negali būti HTML
+              žymų
+            contains_url_instructional: Mikrorajono pavadinime negali būti URL
+            contains_url_informative: Mikrorajono pavadinime negali būti URL
+            unknown_for_city_instructional: Įveskite tinkamą mikrorajono pavadinimą
+              miestui %{city}
+            unknown_for_city_informative: Įveskite tinkamą mikrorajono pavadinimą
+              miestui %{city}
+            unknown_for_zip_instructional: Įveskite tinkamą mikrorajono pavadinimą
+              pašto kodui %{zip}
+            unknown_for_zip_informative: Įveskite tinkamą mikrorajono pavadinimą pašto
+              kodui %{zip}
+            unknown_for_address_instructional: Mikrorajonas gali būti nurodytas neteisingai
+            unknown_for_address_informative: Mikrorajonas gali būti nurodytas neteisingai
+          warnings:
+            contains_too_many_words: Rekomenduojama, kad mikrorajono pavadinimą sudarytų
+              mažiau nei %{word_count} žodžių

--- a/data/regions/_default/lt.yml
+++ b/data/regions/_default/lt.yml
@@ -484,12 +484,12 @@ lt:
         district:
           label:
             default: Rajonas
-            optional: Rajonas (neprivaloma)
+            optional: Rajonas (pasirenkama)
           errors:
             blank_instructional: Įveskite rajoną
             blank_informative: Nenurodytas rajonas
             too_long_instructional: Rajono pavadinimas per ilgas (daugiausia %{limit}
-              simbolių)
+              simb.)
             too_long_informative: Rajono pavadinimas per ilgas
             contains_emojis_instructional: Rajono pavadinime negali būti jaustukų
             contains_emojis_informative: Rajono pavadinime negali būti jaustukų
@@ -502,66 +502,58 @@ lt:
             contains_restricted_characters_informative: Rajono pavadinime negali būti
               draudžiamų simbolių
             contains_too_many_words_instructional: Rajono pavadinimą turi sudaryti
-              mažiau nei %{word_count} žodžių
+              mažiau nei %{word_count} žodž.
             contains_too_many_words_informative: Rajono pavadinimą turi sudaryti mažiau
-              nei %{word_count} žodžių
+              nei %{word_count} žodž.
             contains_html_tags_instructional: Rajono pavadinime negali būti HTML žymų
             contains_html_tags_informative: Rajono pavadinime negali būti HTML žymų
             contains_url_instructional: Rajono pavadinime negali būti URL
             contains_url_informative: Rajono pavadinime negali būti URL
-            unknown_for_city_instructional: Įveskite tinkamą rajono pavadinimą miestui
-              %{city}
-            unknown_for_city_informative: Įveskite tinkamą rajono pavadinimą miestui
-              %{city}
-            unknown_for_zip_instructional: Įveskite tinkamą rajono pavadinimą pašto
-              kodui %{zip}
-            unknown_for_zip_informative: Įveskite tinkamą rajono pavadinimą pašto
-              kodui %{zip}
+            unknown_for_city_instructional: Įveskite tinkamą %{city} rajono pavadinimą
+            unknown_for_city_informative: Įveskite tinkamą %{city} rajono pavadinimą
+            unknown_for_zip_instructional: Įveskite tinkamą %{zip} rajono pavadinimą
+            unknown_for_zip_informative: Įveskite tinkamą %{zip} rajono pavadinimą
             unknown_for_address_instructional: Rajonas gali būti nurodytas neteisingai
             unknown_for_address_informative: Rajonas gali būti nurodytas neteisingai
           warnings:
             contains_too_many_words: Rekomenduojama, kad rajono pavadinimą sudarytų
-              mažiau nei %{word_count} žodžių
+              mažiau nei %{word_count} žodž.
         subdistrict:
           label:
-            default: Mikrorajonas
-            optional: Mikrorajonas (neprivaloma)
+            default: Seniūnija
+            optional: Seniūnija (pasirenkama)
           errors:
-            blank_instructional: Įveskite mikrorajoną
-            blank_informative: Nenurodytas mikrorajonas
-            too_long_instructional: Mikrorajono pavadinimas per ilgas (daugiausia
-              %{limit} simbolių)
-            too_long_informative: Mikrorajono pavadinimas per ilgas
-            contains_emojis_instructional: Mikrorajono pavadinime negali būti jaustukų
-            contains_emojis_informative: Mikrorajono pavadinime negali būti jaustukų
-            contains_mathematical_symbols_instructional: Mikrorajono pavadinime negali
+            blank_instructional: Įveskite seniūniją
+            blank_informative: Nenurodyta seniūnija
+            too_long_instructional: Seniūnijos pavadinimas per ilgas (daugiausia %{limit}
+              simb.)
+            too_long_informative: Seniūnijos pavadinimas per ilgas
+            contains_emojis_instructional: Seniūnijos pavadinime negali būti jaustukų
+            contains_emojis_informative: Seniūnijos pavadinime negali būti jaustukų
+            contains_mathematical_symbols_instructional: Seniūnijos pavadinime negali
               būti matematinių simbolių
-            contains_mathematical_symbols_informative: Mikrorajono pavadinime negali
+            contains_mathematical_symbols_informative: Seniūnijos pavadinime negali
               būti matematinių simbolių
-            contains_restricted_characters_instructional: Mikrorajono pavadinime gali
+            contains_restricted_characters_instructional: Seniūnijos pavadinime gali
               būti tik raidės, skaičiai, vietiniai ir specialieji simboliai
-            contains_restricted_characters_informative: Mikrorajono pavadinime negali
+            contains_restricted_characters_informative: Seniūnijos pavadinime negali
               būti draudžiamų simbolių
-            contains_too_many_words_instructional: Mikrorajono pavadinimą turi sudaryti
-              mažiau nei %{word_count} žodžių
-            contains_too_many_words_informative: Mikrorajono pavadinimą turi sudaryti
-              mažiau nei %{word_count} žodžių
-            contains_html_tags_instructional: Mikrorajono pavadinime negali būti HTML
+            contains_too_many_words_instructional: Seniūnijos pavadinimą turi sudaryti
+              mažiau nei %{word_count} žodž.
+            contains_too_many_words_informative: Seniūnijos pavadinimą turi sudaryti
+              mažiau nei %{word_count} žodž.
+            contains_html_tags_instructional: Seniūnijos pavadinime negali būti HTML
               žymų
-            contains_html_tags_informative: Mikrorajono pavadinime negali būti HTML
+            contains_html_tags_informative: Seniūnijos pavadinime negali būti HTML
               žymų
-            contains_url_instructional: Mikrorajono pavadinime negali būti URL
-            contains_url_informative: Mikrorajono pavadinime negali būti URL
-            unknown_for_city_instructional: Įveskite tinkamą mikrorajono pavadinimą
-              miestui %{city}
-            unknown_for_city_informative: Įveskite tinkamą mikrorajono pavadinimą
-              miestui %{city}
-            unknown_for_zip_instructional: Įveskite tinkamą mikrorajono pavadinimą
-              pašto kodui %{zip}
-            unknown_for_zip_informative: Įveskite tinkamą mikrorajono pavadinimą pašto
-              kodui %{zip}
-            unknown_for_address_instructional: Mikrorajonas gali būti nurodytas neteisingai
-            unknown_for_address_informative: Mikrorajonas gali būti nurodytas neteisingai
+            contains_url_instructional: Seniūnijos pavadinime negali būti URL
+            contains_url_informative: Seniūnijos pavadinime negali būti URL
+            unknown_for_city_instructional: Įveskite tinkamą %{city} seniūnijos pavadinimą
+            unknown_for_city_informative: Įveskite tinkamą %{city} seniūnijos pavadinimą
+            unknown_for_zip_instructional: Įveskite tinkamą %{zip} seniūnijos pavadinimą
+            unknown_for_zip_informative: Įveskite tinkamą %{zip} seniūnijos pavadinimą
+            unknown_for_address_instructional: Seniūnija gali būti nurodyta neteisingai
+            unknown_for_address_informative: Seniūnija gali būti nurodyta neteisingai
           warnings:
-            contains_too_many_words: Rekomenduojama, kad mikrorajono pavadinimą sudarytų
-              mažiau nei %{word_count} žodžių
+            contains_too_many_words: Rekomenduojama, kad seniūnijos pavadinimą sudarytų
+              mažiau nei %{word_count} žodž.

--- a/data/regions/_default/ms.yml
+++ b/data/regions/_default/ms.yml
@@ -465,3 +465,81 @@ ms:
           errors:
             may_not_exist_instructional: Alamat tidak ditemukan atau tidak wujud
             may_not_exist_informative: Alamat tidak ditemukan
+        district:
+          label:
+            default: Daerah
+            optional: Daerah (pilihan)
+          errors:
+            blank_instructional: Masukkan daerah
+            blank_informative: Daerah tiada
+            too_long_instructional: Daerah terlalu panjang (maksimum ialah %{limit}
+              aksara)
+            too_long_informative: Daerah terlalu panjang
+            contains_emojis_instructional: Daerah tidak boleh mengandungi emoji
+            contains_emojis_informative: Daerah tidak boleh mengandungi emoji
+            contains_mathematical_symbols_instructional: Daerah tidak boleh mengandungi
+              simbol matematik
+            contains_mathematical_symbols_informative: Daerah tidak boleh mengandungi
+              simbol matematik
+            contains_restricted_characters_instructional: Daerah hanya boleh mengandungi
+              huruf, nombor, aksara tempatan dan aksara khas
+            contains_restricted_characters_informative: Daerah tidak boleh mengandungi
+              aksara terhad
+            contains_too_many_words_instructional: Daerah mesti kurang daripada %{word_count}
+              perkataan
+            contains_too_many_words_informative: Daerah mesti kurang daripada %{word_count}
+              perkataan
+            contains_html_tags_instructional: Daerah tidak boleh mengandungi tag HTML
+            contains_html_tags_informative: Daerah tidak boleh mengandungi tag HTML
+            contains_url_instructional: Daerah tidak boleh mengandungi URL
+            contains_url_informative: Daerah tidak boleh mengandungi URL
+            unknown_for_city_instructional: Masukkan nama daerah yang sah untuk %{city}
+            unknown_for_city_informative: Masukkan nama daerah yang sah untuk %{city}
+            unknown_for_zip_instructional: Masukkan nama daerah yang sah untuk %{zip}
+            unknown_for_zip_informative: Masukkan nama daerah yang sah untuk %{zip}
+            unknown_for_address_instructional: Daerah mungkin tidak betul
+            unknown_for_address_informative: Daerah mungkin tidak betul
+          warnings:
+            contains_too_many_words: Daerah disyorkan agar kurang daripada %{word_count}
+              perkataan
+        subdistrict:
+          label:
+            default: Subdaerah
+            optional: Subdaerah (pilihan)
+          errors:
+            blank_instructional: Masukkan subdaerah
+            blank_informative: Subdaerah tiada
+            too_long_instructional: Subdaerah terlalu panjang (maksimum ialah %{limit}
+              aksara)
+            too_long_informative: Subdaerah terlalu panjang
+            contains_emojis_instructional: Subdaerah tidak boleh mengandungi emoji
+            contains_emojis_informative: Subdaerah tidak boleh mengandungi emoji
+            contains_mathematical_symbols_instructional: Subdaerah tidak boleh mengandungi
+              simbol matematik
+            contains_mathematical_symbols_informative: Subdaerah tidak boleh mengandungi
+              simbol matematik
+            contains_restricted_characters_instructional: Subdaerah hanya boleh mengandungi
+              huruf, nombor, aksara tempatan dan aksara khas
+            contains_restricted_characters_informative: Subdaerah tidak boleh mengandungi
+              aksara terhad
+            contains_too_many_words_instructional: Subdaerah mesti kurang daripada
+              %{word_count} perkataan
+            contains_too_many_words_informative: Subdaerah mesti kurang daripada %{word_count}
+              perkataan
+            contains_html_tags_instructional: Subdaerah tidak boleh mengandungi tag
+              HTML
+            contains_html_tags_informative: Subdaerah tidak boleh mengandungi tag
+              HTML
+            contains_url_instructional: Subdaerah tidak boleh mengandungi URL
+            contains_url_informative: Subdaerah tidak boleh mengandungi URL
+            unknown_for_city_instructional: Masukkan nama subdaerah yang sah untuk
+              %{city}
+            unknown_for_city_informative: Masukkan nama subdaerah yang sah untuk %{city}
+            unknown_for_zip_instructional: Masukkan nama subdaerah yang sah untuk
+              %{zip}
+            unknown_for_zip_informative: Masukkan nama subdaerah yang sah untuk %{zip}
+            unknown_for_address_instructional: Subdaerah mungkin tidak betul
+            unknown_for_address_informative: Subdaerah mungkin tidak betul
+          warnings:
+            contains_too_many_words: Subdaerah disyorkan agar kurang daripada %{word_count}
+              perkataan

--- a/data/regions/_default/ms.yml
+++ b/data/regions/_default/ms.yml
@@ -500,7 +500,7 @@ ms:
             unknown_for_address_instructional: Daerah mungkin tidak betul
             unknown_for_address_informative: Daerah mungkin tidak betul
           warnings:
-            contains_too_many_words: Daerah disyorkan agar kurang daripada %{word_count}
+            contains_too_many_words: Daerah disyorkan mempunyai kurang daripada %{word_count}
               perkataan
         subdistrict:
           label:
@@ -541,5 +541,5 @@ ms:
             unknown_for_address_instructional: Subdaerah mungkin tidak betul
             unknown_for_address_informative: Subdaerah mungkin tidak betul
           warnings:
-            contains_too_many_words: Subdaerah disyorkan agar kurang daripada %{word_count}
-              perkataan
+            contains_too_many_words: Subdaerah disyorkan mempunyai kurang daripada
+              %{word_count} perkataan

--- a/data/regions/_default/nb.yml
+++ b/data/regions/_default/nb.yml
@@ -463,8 +463,8 @@ nb:
           errors:
             blank_instructional: Angi et distrikt
             blank_informative: Distrikt mangler
-            too_long_instructional: Distrikt er for langt (maks %{limit} tegn)
-            too_long_informative: Distrikt er for langt
+            too_long_instructional: Distriktet er for langt (maksimalt %{limit} tegn)
+            too_long_informative: Distriktet er for langt
             contains_emojis_instructional: Distrikt kan ikke inneholde emojier
             contains_emojis_informative: Distrikt kan ikke inneholde emojier
             contains_mathematical_symbols_instructional: Distrikt kan ikke inneholde
@@ -474,7 +474,7 @@ nb:
             contains_restricted_characters_instructional: Distrikt kan bare inneholde
               bokstaver, tall, lokale tegn og spesialtegn
             contains_restricted_characters_informative: Distrikt kan ikke inneholde
-              begrensede tegn
+              ikke-tillatte tegn
             contains_too_many_words_instructional: Distrikt må ha færre enn %{word_count}
               ord
             contains_too_many_words_informative: Distrikt må ha færre enn %{word_count}
@@ -487,10 +487,10 @@ nb:
             unknown_for_city_informative: Angi et gyldig distriktsnavn for %{city}
             unknown_for_zip_instructional: Angi et gyldig distriktsnavn for %{zip}
             unknown_for_zip_informative: Angi et gyldig distriktsnavn for %{zip}
-            unknown_for_address_instructional: Distrikt kan være feil
-            unknown_for_address_informative: Distrikt kan være feil
+            unknown_for_address_instructional: Distriktet kan være feil
+            unknown_for_address_informative: Distriktet kan være feil
           warnings:
-            contains_too_many_words: Det anbefales at distrikt har færre enn %{word_count}
+            contains_too_many_words: Det anbefales at distriktet har færre enn %{word_count}
               ord
         subdistrict:
           label:
@@ -499,8 +499,9 @@ nb:
           errors:
             blank_instructional: Angi et underdistrikt
             blank_informative: Underdistrikt mangler
-            too_long_instructional: Underdistrikt er for langt (maks %{limit} tegn)
-            too_long_informative: Underdistrikt er for langt
+            too_long_instructional: Underdistriktet er for langt (maksimalt %{limit}
+              tegn)
+            too_long_informative: Underdistriktet er for langt
             contains_emojis_instructional: Underdistrikt kan ikke inneholde emojier
             contains_emojis_informative: Underdistrikt kan ikke inneholde emojier
             contains_mathematical_symbols_instructional: Underdistrikt kan ikke inneholde
@@ -510,7 +511,7 @@ nb:
             contains_restricted_characters_instructional: Underdistrikt kan bare inneholde
               bokstaver, tall, lokale tegn og spesialtegn
             contains_restricted_characters_informative: Underdistrikt kan ikke inneholde
-              begrensede tegn
+              ikke-tillatte tegn
             contains_too_many_words_instructional: Underdistrikt må ha færre enn %{word_count}
               ord
             contains_too_many_words_informative: Underdistrikt må ha færre enn %{word_count}
@@ -519,13 +520,16 @@ nb:
             contains_html_tags_informative: Underdistrikt kan ikke inneholde HTML-tagger
             contains_url_instructional: Underdistrikt kan ikke inneholde URL-adresser
             contains_url_informative: Underdistrikt kan ikke inneholde URL-adresser
-            unknown_for_city_instructional: Angi et gyldig underdistriktsnavn for
+            unknown_for_city_instructional: Angi et gyldig navn på underdistrikt for
               %{city}
-            unknown_for_city_informative: Angi et gyldig underdistriktsnavn for %{city}
-            unknown_for_zip_instructional: Angi et gyldig underdistriktsnavn for %{zip}
-            unknown_for_zip_informative: Angi et gyldig underdistriktsnavn for %{zip}
-            unknown_for_address_instructional: Underdistrikt kan være feil
-            unknown_for_address_informative: Underdistrikt kan være feil
+            unknown_for_city_informative: Angi et gyldig navn på underdistrikt for
+              %{city}
+            unknown_for_zip_instructional: Angi et gyldig navn på underdistrikt for
+              %{zip}
+            unknown_for_zip_informative: Angi et gyldig navn på underdistrikt for
+              %{zip}
+            unknown_for_address_instructional: Underdistriktet kan være feil
+            unknown_for_address_informative: Underdistriktet kan være feil
           warnings:
-            contains_too_many_words: Det anbefales at underdistrikt har færre enn
+            contains_too_many_words: Det anbefales at underdistriktet har færre enn
               %{word_count} ord

--- a/data/regions/_default/nb.yml
+++ b/data/regions/_default/nb.yml
@@ -456,3 +456,76 @@ nb:
           errors:
             may_not_exist_instructional: Adressen ble ikke funnet, eller finnes ikke
             may_not_exist_informative: Fant ikke adressen
+        district:
+          label:
+            default: Distrikt
+            optional: Distrikt (valgfritt)
+          errors:
+            blank_instructional: Angi et distrikt
+            blank_informative: Distrikt mangler
+            too_long_instructional: Distrikt er for langt (maks %{limit} tegn)
+            too_long_informative: Distrikt er for langt
+            contains_emojis_instructional: Distrikt kan ikke inneholde emojier
+            contains_emojis_informative: Distrikt kan ikke inneholde emojier
+            contains_mathematical_symbols_instructional: Distrikt kan ikke inneholde
+              matematiske symboler
+            contains_mathematical_symbols_informative: Distrikt kan ikke inneholde
+              matematiske symboler
+            contains_restricted_characters_instructional: Distrikt kan bare inneholde
+              bokstaver, tall, lokale tegn og spesialtegn
+            contains_restricted_characters_informative: Distrikt kan ikke inneholde
+              begrensede tegn
+            contains_too_many_words_instructional: Distrikt må ha færre enn %{word_count}
+              ord
+            contains_too_many_words_informative: Distrikt må ha færre enn %{word_count}
+              ord
+            contains_html_tags_instructional: Distrikt kan ikke inneholde HTML-tagger
+            contains_html_tags_informative: Distrikt kan ikke inneholde HTML-tagger
+            contains_url_instructional: Distrikt kan ikke inneholde URL-adresser
+            contains_url_informative: Distrikt kan ikke inneholde URL-adresser
+            unknown_for_city_instructional: Angi et gyldig distriktsnavn for %{city}
+            unknown_for_city_informative: Angi et gyldig distriktsnavn for %{city}
+            unknown_for_zip_instructional: Angi et gyldig distriktsnavn for %{zip}
+            unknown_for_zip_informative: Angi et gyldig distriktsnavn for %{zip}
+            unknown_for_address_instructional: Distrikt kan være feil
+            unknown_for_address_informative: Distrikt kan være feil
+          warnings:
+            contains_too_many_words: Det anbefales at distrikt har færre enn %{word_count}
+              ord
+        subdistrict:
+          label:
+            default: Underdistrikt
+            optional: Underdistrikt (valgfritt)
+          errors:
+            blank_instructional: Angi et underdistrikt
+            blank_informative: Underdistrikt mangler
+            too_long_instructional: Underdistrikt er for langt (maks %{limit} tegn)
+            too_long_informative: Underdistrikt er for langt
+            contains_emojis_instructional: Underdistrikt kan ikke inneholde emojier
+            contains_emojis_informative: Underdistrikt kan ikke inneholde emojier
+            contains_mathematical_symbols_instructional: Underdistrikt kan ikke inneholde
+              matematiske symboler
+            contains_mathematical_symbols_informative: Underdistrikt kan ikke inneholde
+              matematiske symboler
+            contains_restricted_characters_instructional: Underdistrikt kan bare inneholde
+              bokstaver, tall, lokale tegn og spesialtegn
+            contains_restricted_characters_informative: Underdistrikt kan ikke inneholde
+              begrensede tegn
+            contains_too_many_words_instructional: Underdistrikt må ha færre enn %{word_count}
+              ord
+            contains_too_many_words_informative: Underdistrikt må ha færre enn %{word_count}
+              ord
+            contains_html_tags_instructional: Underdistrikt kan ikke inneholde HTML-tagger
+            contains_html_tags_informative: Underdistrikt kan ikke inneholde HTML-tagger
+            contains_url_instructional: Underdistrikt kan ikke inneholde URL-adresser
+            contains_url_informative: Underdistrikt kan ikke inneholde URL-adresser
+            unknown_for_city_instructional: Angi et gyldig underdistriktsnavn for
+              %{city}
+            unknown_for_city_informative: Angi et gyldig underdistriktsnavn for %{city}
+            unknown_for_zip_instructional: Angi et gyldig underdistriktsnavn for %{zip}
+            unknown_for_zip_informative: Angi et gyldig underdistriktsnavn for %{zip}
+            unknown_for_address_instructional: Underdistrikt kan være feil
+            unknown_for_address_informative: Underdistrikt kan være feil
+          warnings:
+            contains_too_many_words: Det anbefales at underdistrikt har færre enn
+              %{word_count} ord

--- a/data/regions/_default/nl.yml
+++ b/data/regions/_default/nl.yml
@@ -465,12 +465,12 @@ nl:
               symbolen bevatten
             contains_restricted_characters_instructional: District mag alleen letters,
               cijfers, lokale tekens en speciale tekens bevatten
-            contains_restricted_characters_informative: District mag geen niet-toegestane
+            contains_restricted_characters_informative: District mag geen beperkte
               tekens bevatten
-            contains_too_many_words_instructional: District moet minder dan %{word_count}
-              woorden bevatten
-            contains_too_many_words_informative: District moet minder dan %{word_count}
-              woorden bevatten
+            contains_too_many_words_instructional: District moet uit minder dan %{word_count}
+              woorden bestaan
+            contains_too_many_words_informative: District moet uit minder dan %{word_count}
+              woorden bestaan
             contains_html_tags_instructional: District mag geen HTML-tags bevatten
             contains_html_tags_informative: District mag geen HTML-tags bevatten
             contains_url_instructional: District mag geen URL's bevatten
@@ -503,12 +503,12 @@ nl:
               symbolen bevatten
             contains_restricted_characters_instructional: Subdistrict mag alleen letters,
               cijfers, lokale tekens en speciale tekens bevatten
-            contains_restricted_characters_informative: Subdistrict mag geen niet-toegestane
+            contains_restricted_characters_informative: Subdistrict mag geen beperkte
               tekens bevatten
-            contains_too_many_words_instructional: Subdistrict moet minder dan %{word_count}
-              woorden bevatten
-            contains_too_many_words_informative: Subdistrict moet minder dan %{word_count}
-              woorden bevatten
+            contains_too_many_words_instructional: Subdistrict moet uit minder dan
+              %{word_count} woorden bestaan
+            contains_too_many_words_informative: Subdistrict moet uit minder dan %{word_count}
+              woorden bestaan
             contains_html_tags_instructional: Subdistrict mag geen HTML-tags bevatten
             contains_html_tags_informative: Subdistrict mag geen HTML-tags bevatten
             contains_url_instructional: Subdistrict mag geen URL's bevatten

--- a/data/regions/_default/nl.yml
+++ b/data/regions/_default/nl.yml
@@ -448,3 +448,81 @@ nl:
           errors:
             may_not_exist_instructional: Adres niet gevonden of bestaat niet
             may_not_exist_informative: Adres niet gevonden
+        district:
+          label:
+            default: District
+            optional: District (optioneel)
+          errors:
+            blank_instructional: Voer een district in
+            blank_informative: District ontbreekt
+            too_long_instructional: District is te lang (maximaal %{limit} tekens)
+            too_long_informative: District is te lang
+            contains_emojis_instructional: District mag geen emoji's bevatten
+            contains_emojis_informative: District mag geen emoji's bevatten
+            contains_mathematical_symbols_instructional: District mag geen wiskundige
+              symbolen bevatten
+            contains_mathematical_symbols_informative: District mag geen wiskundige
+              symbolen bevatten
+            contains_restricted_characters_instructional: District mag alleen letters,
+              cijfers, lokale tekens en speciale tekens bevatten
+            contains_restricted_characters_informative: District mag geen niet-toegestane
+              tekens bevatten
+            contains_too_many_words_instructional: District moet minder dan %{word_count}
+              woorden bevatten
+            contains_too_many_words_informative: District moet minder dan %{word_count}
+              woorden bevatten
+            contains_html_tags_instructional: District mag geen HTML-tags bevatten
+            contains_html_tags_informative: District mag geen HTML-tags bevatten
+            contains_url_instructional: District mag geen URL's bevatten
+            contains_url_informative: District mag geen URL's bevatten
+            unknown_for_city_instructional: Voer een geldige districtsnaam in voor
+              %{city}
+            unknown_for_city_informative: Voer een geldige districtsnaam in voor %{city}
+            unknown_for_zip_instructional: Voer een geldige districtsnaam in voor
+              %{zip}
+            unknown_for_zip_informative: Voer een geldige districtsnaam in voor %{zip}
+            unknown_for_address_instructional: District is mogelijk onjuist
+            unknown_for_address_informative: District is mogelijk onjuist
+          warnings:
+            contains_too_many_words: District bevat bij voorkeur minder dan %{word_count}
+              woorden
+        subdistrict:
+          label:
+            default: Subdistrict
+            optional: Subdistrict (optioneel)
+          errors:
+            blank_instructional: Voer een subdistrict in
+            blank_informative: Subdistrict ontbreekt
+            too_long_instructional: Subdistrict is te lang (maximaal %{limit} tekens)
+            too_long_informative: Subdistrict is te lang
+            contains_emojis_instructional: Subdistrict mag geen emoji's bevatten
+            contains_emojis_informative: Subdistrict mag geen emoji's bevatten
+            contains_mathematical_symbols_instructional: Subdistrict mag geen wiskundige
+              symbolen bevatten
+            contains_mathematical_symbols_informative: Subdistrict mag geen wiskundige
+              symbolen bevatten
+            contains_restricted_characters_instructional: Subdistrict mag alleen letters,
+              cijfers, lokale tekens en speciale tekens bevatten
+            contains_restricted_characters_informative: Subdistrict mag geen niet-toegestane
+              tekens bevatten
+            contains_too_many_words_instructional: Subdistrict moet minder dan %{word_count}
+              woorden bevatten
+            contains_too_many_words_informative: Subdistrict moet minder dan %{word_count}
+              woorden bevatten
+            contains_html_tags_instructional: Subdistrict mag geen HTML-tags bevatten
+            contains_html_tags_informative: Subdistrict mag geen HTML-tags bevatten
+            contains_url_instructional: Subdistrict mag geen URL's bevatten
+            contains_url_informative: Subdistrict mag geen URL's bevatten
+            unknown_for_city_instructional: Voer een geldige subdistrictsnaam in voor
+              %{city}
+            unknown_for_city_informative: Voer een geldige subdistrictsnaam in voor
+              %{city}
+            unknown_for_zip_instructional: Voer een geldige subdistrictsnaam in voor
+              %{zip}
+            unknown_for_zip_informative: Voer een geldige subdistrictsnaam in voor
+              %{zip}
+            unknown_for_address_instructional: Subdistrict is mogelijk onjuist
+            unknown_for_address_informative: Subdistrict is mogelijk onjuist
+          warnings:
+            contains_too_many_words: Subdistrict bevat bij voorkeur minder dan %{word_count}
+              woorden

--- a/data/regions/_default/pl.yml
+++ b/data/regions/_default/pl.yml
@@ -458,77 +458,81 @@ pl:
             optional: Okręg (opcjonalnie)
           errors:
             blank_instructional: Wprowadź okręg
-            blank_informative: Brakuje okręgu
-            too_long_instructional: Okręg jest za długi (maksymalnie %{limit} znaków)
-            too_long_informative: Okręg jest za długi
-            contains_emojis_instructional: Okręg nie może zawierać emoji
-            contains_emojis_informative: Okręg nie może zawierać emoji
-            contains_mathematical_symbols_instructional: Okręg nie może zawierać symboli
-              matematycznych
-            contains_mathematical_symbols_informative: Okręg nie może zawierać symboli
-              matematycznych
-            contains_restricted_characters_instructional: Okręg może zawierać tylko
-              litery, cyfry, znaki lokalne i znaki specjalne
-            contains_restricted_characters_informative: Okręg nie może zawierać niedozwolonych
-              znaków
-            contains_too_many_words_instructional: Okręg musi zawierać mniej niż %{word_count}
-              słów
-            contains_too_many_words_informative: Okręg musi zawierać mniej niż %{word_count}
-              słów
-            contains_html_tags_instructional: Okręg nie może zawierać tagów HTML
-            contains_html_tags_informative: Okręg nie może zawierać tagów HTML
-            contains_url_instructional: Okręg nie może zawierać adresów URL
-            contains_url_informative: Okręg nie może zawierać adresów URL
-            unknown_for_city_instructional: Wprowadź prawidłową nazwę okręgu dla miasta
-              %{city}
-            unknown_for_city_informative: Wprowadź prawidłową nazwę okręgu dla miasta
-              %{city}
-            unknown_for_zip_instructional: Wprowadź prawidłową nazwę okręgu dla kodu
-              pocztowego %{zip}
-            unknown_for_zip_informative: Wprowadź prawidłową nazwę okręgu dla kodu
-              pocztowego %{zip}
-            unknown_for_address_instructional: Okręg może być nieprawidłowy
-            unknown_for_address_informative: Okręg może być nieprawidłowy
+            blank_informative: Brak okręgu
+            too_long_instructional: Nazwa okręgu jest za długa (maksymalnie %{limit}
+              znaków)
+            too_long_informative: Nazwa okręgu jest za długa
+            contains_emojis_instructional: Nazwa okręgu nie może zawierać emoji
+            contains_emojis_informative: Nazwa okręgu nie może zawierać emoji
+            contains_mathematical_symbols_instructional: Nazwa okręgu nie może zawierać
+              symboli matematycznych
+            contains_mathematical_symbols_informative: Nazwa okręgu nie może zawierać
+              symboli matematycznych
+            contains_restricted_characters_instructional: Nazwa okręgu może zawierać
+              tylko litery, cyfry, znaki lokalne i znaki specjalne
+            contains_restricted_characters_informative: Nazwa okręgu nie może zawierać
+              niedozwolonych znaków
+            contains_too_many_words_instructional: Liczba słów w nazwie okręgu musi
+              być mniejsza niż %{word_count}
+            contains_too_many_words_informative: Liczba słów w nazwie okręgu musi
+              być mniejsza niż %{word_count}
+            contains_html_tags_instructional: Nazwa okręgu nie może zawierać tagów
+              HTML
+            contains_html_tags_informative: Nazwa okręgu nie może zawierać tagów HTML
+            contains_url_instructional: Nazwa okręgu nie może zawierać adresów URL
+            contains_url_informative: Nazwa okręgu nie może zawierać adresów URL
+            unknown_for_city_instructional: 'Wprowadź prawidłową nazwę okręgu dla:
+              %{city}'
+            unknown_for_city_informative: 'Wprowadź prawidłową nazwę okręgu dla: %{city}'
+            unknown_for_zip_instructional: 'Wprowadź prawidłową nazwę okręgu dla:
+              %{zip}'
+            unknown_for_zip_informative: 'Wprowadź prawidłową nazwę okręgu dla: %{zip}'
+            unknown_for_address_instructional: Nazwa okręgu może być nieprawidłowa
+            unknown_for_address_informative: Nazwa okręgu może być nieprawidłowa
           warnings:
-            contains_too_many_words: Zaleca się, aby okręg zawierał mniej niż %{word_count}
-              słów
+            contains_too_many_words: Zaleca się, aby liczba słów w nazwie okręgu była
+              mniejsza niż %{word_count}
         subdistrict:
           label:
             default: Podokręg
             optional: Podokręg (opcjonalnie)
           errors:
             blank_instructional: Wprowadź podokręg
-            blank_informative: Brakuje podokręgu
-            too_long_instructional: Podokręg jest za długi (maksymalnie %{limit} znaków)
-            too_long_informative: Podokręg jest za długi
-            contains_emojis_instructional: Podokręg nie może zawierać emoji
-            contains_emojis_informative: Podokręg nie może zawierać emoji
-            contains_mathematical_symbols_instructional: Podokręg nie może zawierać
+            blank_informative: Brak podokręgu
+            too_long_instructional: Nazwa podokręgu jest za długa (maksymalnie %{limit}
+              znaków)
+            too_long_informative: Nazwa podokręgu jest za długa
+            contains_emojis_instructional: Nazwa podokręgu nie może zawierać emoji
+            contains_emojis_informative: Nazwa podokręgu nie może zawierać emoji
+            contains_mathematical_symbols_instructional: Nazwa podokręgu nie może
+              zawierać symboli matematycznych
+            contains_mathematical_symbols_informative: Nazwa podokręgu nie może zawierać
               symboli matematycznych
-            contains_mathematical_symbols_informative: Podokręg nie może zawierać
-              symboli matematycznych
-            contains_restricted_characters_instructional: Podokręg może zawierać tylko
-              litery, cyfry, znaki lokalne i znaki specjalne
-            contains_restricted_characters_informative: Podokręg nie może zawierać
+            contains_restricted_characters_instructional: Nazwa podokręgu może zawierać
+              tylko litery, cyfry, znaki lokalne i znaki specjalne
+            contains_restricted_characters_informative: Nazwa podokręgu nie może zawierać
               niedozwolonych znaków
-            contains_too_many_words_instructional: Podokręg musi zawierać mniej niż
-              %{word_count} słów
-            contains_too_many_words_informative: Podokręg musi zawierać mniej niż
-              %{word_count} słów
-            contains_html_tags_instructional: Podokręg nie może zawierać tagów HTML
-            contains_html_tags_informative: Podokręg nie może zawierać tagów HTML
-            contains_url_instructional: Podokręg nie może zawierać adresów URL
-            contains_url_informative: Podokręg nie może zawierać adresów URL
-            unknown_for_city_instructional: Wprowadź prawidłową nazwę podokręgu dla
-              miasta %{city}
-            unknown_for_city_informative: Wprowadź prawidłową nazwę podokręgu dla
-              miasta %{city}
-            unknown_for_zip_instructional: Wprowadź prawidłową nazwę podokręgu dla
-              kodu pocztowego %{zip}
-            unknown_for_zip_informative: Wprowadź prawidłową nazwę podokręgu dla kodu
-              pocztowego %{zip}
-            unknown_for_address_instructional: Podokręg może być nieprawidłowy
-            unknown_for_address_informative: Podokręg może być nieprawidłowy
+            contains_too_many_words_instructional: Liczba słów w nazwie podokręgu
+              musi być mniejsza niż %{word_count}
+            contains_too_many_words_informative: Liczba słów w nazwie podokręgu musi
+              być mniejsza niż %{word_count}
+            contains_html_tags_instructional: Nazwa podokręgu nie może zawierać tagów
+              HTML
+            contains_html_tags_informative: Nazwa podokręgu nie może zawierać tagów
+              HTML
+            contains_url_instructional: Nazwa podokręgu nie może zawierać adresów
+              URL
+            contains_url_informative: Nazwa podokręgu nie może zawierać adresów URL
+            unknown_for_city_instructional: 'Wprowadź prawidłową nazwę podokręgu dla:
+              %{city}'
+            unknown_for_city_informative: 'Wprowadź prawidłową nazwę podokręgu dla:
+              %{city}'
+            unknown_for_zip_instructional: 'Wprowadź prawidłową nazwę podokręgu dla:
+              %{zip}'
+            unknown_for_zip_informative: 'Wprowadź prawidłową nazwę podokręgu dla:
+              %{zip}'
+            unknown_for_address_instructional: Nazwa podokręgu może być nieprawidłowa
+            unknown_for_address_informative: Nazwa podokręgu może być nieprawidłowa
           warnings:
-            contains_too_many_words: Zaleca się, aby podokręg zawierał mniej niż %{word_count}
-              słów
+            contains_too_many_words: Zaleca się, aby liczba słów w nazwie podokręgu
+              była mniejsza niż %{word_count}

--- a/data/regions/_default/pl.yml
+++ b/data/regions/_default/pl.yml
@@ -452,3 +452,83 @@ pl:
           errors:
             may_not_exist_instructional: Nie znaleziono adresu lub adres nie istnieje
             may_not_exist_informative: Nie znaleziono adresu
+        district:
+          label:
+            default: Okręg
+            optional: Okręg (opcjonalnie)
+          errors:
+            blank_instructional: Wprowadź okręg
+            blank_informative: Brakuje okręgu
+            too_long_instructional: Okręg jest za długi (maksymalnie %{limit} znaków)
+            too_long_informative: Okręg jest za długi
+            contains_emojis_instructional: Okręg nie może zawierać emoji
+            contains_emojis_informative: Okręg nie może zawierać emoji
+            contains_mathematical_symbols_instructional: Okręg nie może zawierać symboli
+              matematycznych
+            contains_mathematical_symbols_informative: Okręg nie może zawierać symboli
+              matematycznych
+            contains_restricted_characters_instructional: Okręg może zawierać tylko
+              litery, cyfry, znaki lokalne i znaki specjalne
+            contains_restricted_characters_informative: Okręg nie może zawierać niedozwolonych
+              znaków
+            contains_too_many_words_instructional: Okręg musi zawierać mniej niż %{word_count}
+              słów
+            contains_too_many_words_informative: Okręg musi zawierać mniej niż %{word_count}
+              słów
+            contains_html_tags_instructional: Okręg nie może zawierać tagów HTML
+            contains_html_tags_informative: Okręg nie może zawierać tagów HTML
+            contains_url_instructional: Okręg nie może zawierać adresów URL
+            contains_url_informative: Okręg nie może zawierać adresów URL
+            unknown_for_city_instructional: Wprowadź prawidłową nazwę okręgu dla miasta
+              %{city}
+            unknown_for_city_informative: Wprowadź prawidłową nazwę okręgu dla miasta
+              %{city}
+            unknown_for_zip_instructional: Wprowadź prawidłową nazwę okręgu dla kodu
+              pocztowego %{zip}
+            unknown_for_zip_informative: Wprowadź prawidłową nazwę okręgu dla kodu
+              pocztowego %{zip}
+            unknown_for_address_instructional: Okręg może być nieprawidłowy
+            unknown_for_address_informative: Okręg może być nieprawidłowy
+          warnings:
+            contains_too_many_words: Zaleca się, aby okręg zawierał mniej niż %{word_count}
+              słów
+        subdistrict:
+          label:
+            default: Podokręg
+            optional: Podokręg (opcjonalnie)
+          errors:
+            blank_instructional: Wprowadź podokręg
+            blank_informative: Brakuje podokręgu
+            too_long_instructional: Podokręg jest za długi (maksymalnie %{limit} znaków)
+            too_long_informative: Podokręg jest za długi
+            contains_emojis_instructional: Podokręg nie może zawierać emoji
+            contains_emojis_informative: Podokręg nie może zawierać emoji
+            contains_mathematical_symbols_instructional: Podokręg nie może zawierać
+              symboli matematycznych
+            contains_mathematical_symbols_informative: Podokręg nie może zawierać
+              symboli matematycznych
+            contains_restricted_characters_instructional: Podokręg może zawierać tylko
+              litery, cyfry, znaki lokalne i znaki specjalne
+            contains_restricted_characters_informative: Podokręg nie może zawierać
+              niedozwolonych znaków
+            contains_too_many_words_instructional: Podokręg musi zawierać mniej niż
+              %{word_count} słów
+            contains_too_many_words_informative: Podokręg musi zawierać mniej niż
+              %{word_count} słów
+            contains_html_tags_instructional: Podokręg nie może zawierać tagów HTML
+            contains_html_tags_informative: Podokręg nie może zawierać tagów HTML
+            contains_url_instructional: Podokręg nie może zawierać adresów URL
+            contains_url_informative: Podokręg nie może zawierać adresów URL
+            unknown_for_city_instructional: Wprowadź prawidłową nazwę podokręgu dla
+              miasta %{city}
+            unknown_for_city_informative: Wprowadź prawidłową nazwę podokręgu dla
+              miasta %{city}
+            unknown_for_zip_instructional: Wprowadź prawidłową nazwę podokręgu dla
+              kodu pocztowego %{zip}
+            unknown_for_zip_informative: Wprowadź prawidłową nazwę podokręgu dla kodu
+              pocztowego %{zip}
+            unknown_for_address_instructional: Podokręg może być nieprawidłowy
+            unknown_for_address_informative: Podokręg może być nieprawidłowy
+          warnings:
+            contains_too_many_words: Zaleca się, aby podokręg zawierał mniej niż %{word_count}
+              słów

--- a/data/regions/_default/pt-BR.yml
+++ b/data/regions/_default/pt-BR.yml
@@ -453,3 +453,83 @@ pt-BR:
           errors:
             may_not_exist_instructional: O endereço não foi encontrado ou não existe
             may_not_exist_informative: Endereço não encontrado
+        district:
+          label:
+            default: Distrito
+            optional: Distrito (opcional)
+          errors:
+            blank_instructional: Insira um distrito
+            blank_informative: Falta o distrito
+            too_long_instructional: O distrito é muito longo (o máximo é de %{limit}
+              caracteres)
+            too_long_informative: O distrito é muito longo
+            contains_emojis_instructional: O distrito não pode conter emojis
+            contains_emojis_informative: O distrito não pode conter emojis
+            contains_mathematical_symbols_instructional: O distrito não pode conter
+              símbolos matemáticos
+            contains_mathematical_symbols_informative: O distrito não pode conter
+              símbolos matemáticos
+            contains_restricted_characters_instructional: O distrito só pode conter
+              letras, números, caracteres locais e caracteres especiais
+            contains_restricted_characters_informative: O distrito não pode conter
+              caracteres restritos
+            contains_too_many_words_instructional: O distrito deve ter menos de %{word_count}
+              palavras
+            contains_too_many_words_informative: O distrito deve ter menos de %{word_count}
+              palavras
+            contains_html_tags_instructional: O distrito não pode conter tags HTML
+            contains_html_tags_informative: O distrito não pode conter tags HTML
+            contains_url_instructional: O distrito não pode conter URLs
+            contains_url_informative: O distrito não pode conter URLs
+            unknown_for_city_instructional: Insira um nome de distrito válido para
+              %{city}
+            unknown_for_city_informative: Insira um nome de distrito válido para %{city}
+            unknown_for_zip_instructional: Insira um nome de distrito válido para
+              %{zip}
+            unknown_for_zip_informative: Insira um nome de distrito válido para %{zip}
+            unknown_for_address_instructional: O distrito pode estar incorreto
+            unknown_for_address_informative: O distrito pode estar incorreto
+          warnings:
+            contains_too_many_words: Recomenda-se que o distrito tenha menos de %{word_count}
+              palavras
+        subdistrict:
+          label:
+            default: Subdistrito
+            optional: Subdistrito (opcional)
+          errors:
+            blank_instructional: Insira um subdistrito
+            blank_informative: Falta o subdistrito
+            too_long_instructional: O subdistrito é muito longo (o máximo é de %{limit}
+              caracteres)
+            too_long_informative: O subdistrito é muito longo
+            contains_emojis_instructional: O subdistrito não pode conter emojis
+            contains_emojis_informative: O subdistrito não pode conter emojis
+            contains_mathematical_symbols_instructional: O subdistrito não pode conter
+              símbolos matemáticos
+            contains_mathematical_symbols_informative: O subdistrito não pode conter
+              símbolos matemáticos
+            contains_restricted_characters_instructional: O subdistrito só pode conter
+              letras, números, caracteres locais e caracteres especiais
+            contains_restricted_characters_informative: O subdistrito não pode conter
+              caracteres restritos
+            contains_too_many_words_instructional: O subdistrito deve ter menos de
+              %{word_count} palavras
+            contains_too_many_words_informative: O subdistrito deve ter menos de %{word_count}
+              palavras
+            contains_html_tags_instructional: O subdistrito não pode conter tags HTML
+            contains_html_tags_informative: O subdistrito não pode conter tags HTML
+            contains_url_instructional: O subdistrito não pode conter URLs
+            contains_url_informative: O subdistrito não pode conter URLs
+            unknown_for_city_instructional: Insira um nome de subdistrito válido para
+              %{city}
+            unknown_for_city_informative: Insira um nome de subdistrito válido para
+              %{city}
+            unknown_for_zip_instructional: Insira um nome de subdistrito válido para
+              %{zip}
+            unknown_for_zip_informative: Insira um nome de subdistrito válido para
+              %{zip}
+            unknown_for_address_instructional: O subdistrito pode estar incorreto
+            unknown_for_address_informative: O subdistrito pode estar incorreto
+          warnings:
+            contains_too_many_words: Recomenda-se que o subdistrito tenha menos de
+              %{word_count} palavras

--- a/data/regions/_default/pt-PT.yml
+++ b/data/regions/_default/pt-PT.yml
@@ -475,9 +475,9 @@ pt-PT:
             default: Distrito
             optional: Distrito (opcional)
           errors:
-            blank_instructional: Insira um distrito
-            blank_informative: Falta o distrito
-            too_long_instructional: O distrito é demasiado longo (o máximo é de %{limit}
+            blank_instructional: Introduza um distrito
+            blank_informative: O distrito está em falta
+            too_long_instructional: O distrito é demasiado longo (o máximo é %{limit}
               carateres)
             too_long_informative: O distrito é demasiado longo
             contains_emojis_instructional: O distrito não pode conter emojis
@@ -486,7 +486,7 @@ pt-PT:
               símbolos matemáticos
             contains_mathematical_symbols_informative: O distrito não pode conter
               símbolos matemáticos
-            contains_restricted_characters_instructional: O distrito apenas pode conter
+            contains_restricted_characters_instructional: O distrito só pode conter
               letras, números, carateres locais e carateres especiais
             contains_restricted_characters_informative: O distrito não pode conter
               carateres restritos
@@ -499,12 +499,14 @@ pt-PT:
             contains_html_tags_informative: O distrito não pode conter etiquetas HTML
             contains_url_instructional: O distrito não pode conter URL
             contains_url_informative: O distrito não pode conter URL
-            unknown_for_city_instructional: Insira um nome de distrito válido para
+            unknown_for_city_instructional: Introduza um nome de distrito válido para
               %{city}
-            unknown_for_city_informative: Insira um nome de distrito válido para %{city}
-            unknown_for_zip_instructional: Insira um nome de distrito válido para
+            unknown_for_city_informative: Introduza um nome de distrito válido para
+              %{city}
+            unknown_for_zip_instructional: Introduza um nome de distrito válido para
               %{zip}
-            unknown_for_zip_informative: Insira um nome de distrito válido para %{zip}
+            unknown_for_zip_informative: Introduza um nome de distrito válido para
+              %{zip}
             unknown_for_address_instructional: O distrito pode estar incorreto
             unknown_for_address_informative: O distrito pode estar incorreto
           warnings:
@@ -515,10 +517,10 @@ pt-PT:
             default: Subdistrito
             optional: Subdistrito (opcional)
           errors:
-            blank_instructional: Insira um subdistrito
-            blank_informative: Falta o subdistrito
-            too_long_instructional: O subdistrito é demasiado longo (o máximo é de
-              %{limit} carateres)
+            blank_instructional: Introduza um subdistrito
+            blank_informative: O subdistrito está em falta
+            too_long_instructional: O subdistrito é demasiado longo (o máximo é %{limit}
+              carateres)
             too_long_informative: O subdistrito é demasiado longo
             contains_emojis_instructional: O subdistrito não pode conter emojis
             contains_emojis_informative: O subdistrito não pode conter emojis
@@ -526,8 +528,8 @@ pt-PT:
               símbolos matemáticos
             contains_mathematical_symbols_informative: O subdistrito não pode conter
               símbolos matemáticos
-            contains_restricted_characters_instructional: O subdistrito apenas pode
-              conter letras, números, carateres locais e carateres especiais
+            contains_restricted_characters_instructional: O subdistrito só pode conter
+              letras, números, carateres locais e carateres especiais
             contains_restricted_characters_informative: O subdistrito não pode conter
               carateres restritos
             contains_too_many_words_instructional: O subdistrito tem de ter menos
@@ -540,13 +542,13 @@ pt-PT:
               HTML
             contains_url_instructional: O subdistrito não pode conter URL
             contains_url_informative: O subdistrito não pode conter URL
-            unknown_for_city_instructional: Insira um nome de subdistrito válido para
-              %{city}
-            unknown_for_city_informative: Insira um nome de subdistrito válido para
-              %{city}
-            unknown_for_zip_instructional: Insira um nome de subdistrito válido para
-              %{zip}
-            unknown_for_zip_informative: Insira um nome de subdistrito válido para
+            unknown_for_city_instructional: Introduza um nome de subdistrito válido
+              para %{city}
+            unknown_for_city_informative: Introduza um nome de subdistrito válido
+              para %{city}
+            unknown_for_zip_instructional: Introduza um nome de subdistrito válido
+              para %{zip}
+            unknown_for_zip_informative: Introduza um nome de subdistrito válido para
               %{zip}
             unknown_for_address_instructional: O subdistrito pode estar incorreto
             unknown_for_address_informative: O subdistrito pode estar incorreto

--- a/data/regions/_default/pt-PT.yml
+++ b/data/regions/_default/pt-PT.yml
@@ -470,3 +470,86 @@ pt-PT:
           errors:
             may_not_exist_instructional: O endereço não foi encontrado ou não existe
             may_not_exist_informative: Endereço não encontrado
+        district:
+          label:
+            default: Distrito
+            optional: Distrito (opcional)
+          errors:
+            blank_instructional: Insira um distrito
+            blank_informative: Falta o distrito
+            too_long_instructional: O distrito é demasiado longo (o máximo é de %{limit}
+              carateres)
+            too_long_informative: O distrito é demasiado longo
+            contains_emojis_instructional: O distrito não pode conter emojis
+            contains_emojis_informative: O distrito não pode conter emojis
+            contains_mathematical_symbols_instructional: O distrito não pode conter
+              símbolos matemáticos
+            contains_mathematical_symbols_informative: O distrito não pode conter
+              símbolos matemáticos
+            contains_restricted_characters_instructional: O distrito apenas pode conter
+              letras, números, carateres locais e carateres especiais
+            contains_restricted_characters_informative: O distrito não pode conter
+              carateres restritos
+            contains_too_many_words_instructional: O distrito tem de ter menos de
+              %{word_count} palavras
+            contains_too_many_words_informative: O distrito tem de ter menos de %{word_count}
+              palavras
+            contains_html_tags_instructional: O distrito não pode conter etiquetas
+              HTML
+            contains_html_tags_informative: O distrito não pode conter etiquetas HTML
+            contains_url_instructional: O distrito não pode conter URL
+            contains_url_informative: O distrito não pode conter URL
+            unknown_for_city_instructional: Insira um nome de distrito válido para
+              %{city}
+            unknown_for_city_informative: Insira um nome de distrito válido para %{city}
+            unknown_for_zip_instructional: Insira um nome de distrito válido para
+              %{zip}
+            unknown_for_zip_informative: Insira um nome de distrito válido para %{zip}
+            unknown_for_address_instructional: O distrito pode estar incorreto
+            unknown_for_address_informative: O distrito pode estar incorreto
+          warnings:
+            contains_too_many_words: Recomenda-se que o distrito tenha menos de %{word_count}
+              palavras
+        subdistrict:
+          label:
+            default: Subdistrito
+            optional: Subdistrito (opcional)
+          errors:
+            blank_instructional: Insira um subdistrito
+            blank_informative: Falta o subdistrito
+            too_long_instructional: O subdistrito é demasiado longo (o máximo é de
+              %{limit} carateres)
+            too_long_informative: O subdistrito é demasiado longo
+            contains_emojis_instructional: O subdistrito não pode conter emojis
+            contains_emojis_informative: O subdistrito não pode conter emojis
+            contains_mathematical_symbols_instructional: O subdistrito não pode conter
+              símbolos matemáticos
+            contains_mathematical_symbols_informative: O subdistrito não pode conter
+              símbolos matemáticos
+            contains_restricted_characters_instructional: O subdistrito apenas pode
+              conter letras, números, carateres locais e carateres especiais
+            contains_restricted_characters_informative: O subdistrito não pode conter
+              carateres restritos
+            contains_too_many_words_instructional: O subdistrito tem de ter menos
+              de %{word_count} palavras
+            contains_too_many_words_informative: O subdistrito tem de ter menos de
+              %{word_count} palavras
+            contains_html_tags_instructional: O subdistrito não pode conter etiquetas
+              HTML
+            contains_html_tags_informative: O subdistrito não pode conter etiquetas
+              HTML
+            contains_url_instructional: O subdistrito não pode conter URL
+            contains_url_informative: O subdistrito não pode conter URL
+            unknown_for_city_instructional: Insira um nome de subdistrito válido para
+              %{city}
+            unknown_for_city_informative: Insira um nome de subdistrito válido para
+              %{city}
+            unknown_for_zip_instructional: Insira um nome de subdistrito válido para
+              %{zip}
+            unknown_for_zip_informative: Insira um nome de subdistrito válido para
+              %{zip}
+            unknown_for_address_instructional: O subdistrito pode estar incorreto
+            unknown_for_address_informative: O subdistrito pode estar incorreto
+          warnings:
+            contains_too_many_words: Recomenda-se que o subdistrito tenha menos de
+              %{word_count} palavras

--- a/data/regions/_default/ro.yml
+++ b/data/regions/_default/ro.yml
@@ -518,9 +518,9 @@ ro:
             default: District
             optional: District (opțional)
           errors:
-            blank_instructional: Introduceți un district
-            blank_informative: Districtul lipsește
-            too_long_instructional: Districtul este prea lung (maximul este de %{limit}
+            blank_instructional: Introdu un district
+            blank_informative: Lipsește districtul
+            too_long_instructional: Districtul este prea lung (maximum este de %{limit}
               caractere)
             too_long_informative: Districtul este prea lung
             contains_emojis_instructional: Districtul nu poate conține emoji-uri
@@ -530,7 +530,7 @@ ro:
             contains_mathematical_symbols_informative: Districtul nu poate conține
               simboluri matematice
             contains_restricted_characters_instructional: Districtul poate conține
-              doar litere, numere, caractere locale și caractere speciale
+              doar litere, cifre, caractere locale și caractere speciale
             contains_restricted_characters_informative: Districtul nu poate conține
               caractere restricționate
             contains_too_many_words_instructional: Districtul trebuie să aibă mai
@@ -542,16 +542,16 @@ ro:
             contains_html_tags_informative: Districtul nu poate conține etichete HTML
             contains_url_instructional: Districtul nu poate conține URL-uri
             contains_url_informative: Districtul nu poate conține URL-uri
-            unknown_for_city_instructional: Introduceți un nume valid de district
-              pentru %{city}
-            unknown_for_city_informative: Introduceți un nume valid de district pentru
+            unknown_for_city_instructional: Introdu un nume de district valid pentru
               %{city}
-            unknown_for_zip_instructional: Introduceți un nume valid de district pentru
+            unknown_for_city_informative: Introdu un nume de district valid pentru
+              %{city}
+            unknown_for_zip_instructional: Introdu un nume de district valid pentru
               %{zip}
-            unknown_for_zip_informative: Introduceți un nume valid de district pentru
+            unknown_for_zip_informative: Introdu un nume de district valid pentru
               %{zip}
-            unknown_for_address_instructional: Districtul poate fi incorect
-            unknown_for_address_informative: Districtul poate fi incorect
+            unknown_for_address_instructional: Este posibil ca districtul să fie incorect
+            unknown_for_address_informative: Este posibil ca districtul să fie incorect
           warnings:
             contains_too_many_words: Se recomandă ca districtul să aibă mai puțin
               de %{word_count} cuvinte
@@ -560,9 +560,9 @@ ro:
             default: Subdistrict
             optional: Subdistrict (opțional)
           errors:
-            blank_instructional: Introduceți un subdistrict
-            blank_informative: Subdistrictul lipsește
-            too_long_instructional: Subdistrictul este prea lung (maximul este de
+            blank_instructional: Introdu un subdistrict
+            blank_informative: Lipsește subdistrictul
+            too_long_instructional: Subdistrictul este prea lung (maximum este de
               %{limit} caractere)
             too_long_informative: Subdistrictul este prea lung
             contains_emojis_instructional: Subdistrictul nu poate conține emoji-uri
@@ -572,7 +572,7 @@ ro:
             contains_mathematical_symbols_informative: Subdistrictul nu poate conține
               simboluri matematice
             contains_restricted_characters_instructional: Subdistrictul poate conține
-              doar litere, numere, caractere locale și caractere speciale
+              doar litere, cifre, caractere locale și caractere speciale
             contains_restricted_characters_informative: Subdistrictul nu poate conține
               caractere restricționate
             contains_too_many_words_instructional: Subdistrictul trebuie să aibă mai
@@ -585,16 +585,18 @@ ro:
               HTML
             contains_url_instructional: Subdistrictul nu poate conține URL-uri
             contains_url_informative: Subdistrictul nu poate conține URL-uri
-            unknown_for_city_instructional: Introduceți un nume valid de subdistrict
-              pentru %{city}
-            unknown_for_city_informative: Introduceți un nume valid de subdistrict
-              pentru %{city}
-            unknown_for_zip_instructional: Introduceți un nume valid de subdistrict
-              pentru %{zip}
-            unknown_for_zip_informative: Introduceți un nume valid de subdistrict
-              pentru %{zip}
-            unknown_for_address_instructional: Subdistrictul poate fi incorect
-            unknown_for_address_informative: Subdistrictul poate fi incorect
+            unknown_for_city_instructional: Introdu un nume de subdistrict valid pentru
+              %{city}
+            unknown_for_city_informative: Introdu un nume de subdistrict valid pentru
+              %{city}
+            unknown_for_zip_instructional: Introdu un nume de subdistrict valid pentru
+              %{zip}
+            unknown_for_zip_informative: Introdu un nume de subdistrict valid pentru
+              %{zip}
+            unknown_for_address_instructional: Este posibil ca subdistrictul să fie
+              incorect
+            unknown_for_address_informative: Este posibil ca subdistrictul să fie
+              incorect
           warnings:
             contains_too_many_words: Se recomandă ca subdistrictul să aibă mai puțin
               de %{word_count} cuvinte

--- a/data/regions/_default/ro.yml
+++ b/data/regions/_default/ro.yml
@@ -513,3 +513,88 @@ ro:
           errors:
             may_not_exist_instructional: Adresa nu a fost găsită sau nu există
             may_not_exist_informative: Adresa nu a fost găsită
+        district:
+          label:
+            default: District
+            optional: District (opțional)
+          errors:
+            blank_instructional: Introduceți un district
+            blank_informative: Districtul lipsește
+            too_long_instructional: Districtul este prea lung (maximul este de %{limit}
+              caractere)
+            too_long_informative: Districtul este prea lung
+            contains_emojis_instructional: Districtul nu poate conține emoji-uri
+            contains_emojis_informative: Districtul nu poate conține emoji-uri
+            contains_mathematical_symbols_instructional: Districtul nu poate conține
+              simboluri matematice
+            contains_mathematical_symbols_informative: Districtul nu poate conține
+              simboluri matematice
+            contains_restricted_characters_instructional: Districtul poate conține
+              doar litere, numere, caractere locale și caractere speciale
+            contains_restricted_characters_informative: Districtul nu poate conține
+              caractere restricționate
+            contains_too_many_words_instructional: Districtul trebuie să aibă mai
+              puțin de %{word_count} cuvinte
+            contains_too_many_words_informative: Districtul trebuie să aibă mai puțin
+              de %{word_count} cuvinte
+            contains_html_tags_instructional: Districtul nu poate conține etichete
+              HTML
+            contains_html_tags_informative: Districtul nu poate conține etichete HTML
+            contains_url_instructional: Districtul nu poate conține URL-uri
+            contains_url_informative: Districtul nu poate conține URL-uri
+            unknown_for_city_instructional: Introduceți un nume valid de district
+              pentru %{city}
+            unknown_for_city_informative: Introduceți un nume valid de district pentru
+              %{city}
+            unknown_for_zip_instructional: Introduceți un nume valid de district pentru
+              %{zip}
+            unknown_for_zip_informative: Introduceți un nume valid de district pentru
+              %{zip}
+            unknown_for_address_instructional: Districtul poate fi incorect
+            unknown_for_address_informative: Districtul poate fi incorect
+          warnings:
+            contains_too_many_words: Se recomandă ca districtul să aibă mai puțin
+              de %{word_count} cuvinte
+        subdistrict:
+          label:
+            default: Subdistrict
+            optional: Subdistrict (opțional)
+          errors:
+            blank_instructional: Introduceți un subdistrict
+            blank_informative: Subdistrictul lipsește
+            too_long_instructional: Subdistrictul este prea lung (maximul este de
+              %{limit} caractere)
+            too_long_informative: Subdistrictul este prea lung
+            contains_emojis_instructional: Subdistrictul nu poate conține emoji-uri
+            contains_emojis_informative: Subdistrictul nu poate conține emoji-uri
+            contains_mathematical_symbols_instructional: Subdistrictul nu poate conține
+              simboluri matematice
+            contains_mathematical_symbols_informative: Subdistrictul nu poate conține
+              simboluri matematice
+            contains_restricted_characters_instructional: Subdistrictul poate conține
+              doar litere, numere, caractere locale și caractere speciale
+            contains_restricted_characters_informative: Subdistrictul nu poate conține
+              caractere restricționate
+            contains_too_many_words_instructional: Subdistrictul trebuie să aibă mai
+              puțin de %{word_count} cuvinte
+            contains_too_many_words_informative: Subdistrictul trebuie să aibă mai
+              puțin de %{word_count} cuvinte
+            contains_html_tags_instructional: Subdistrictul nu poate conține etichete
+              HTML
+            contains_html_tags_informative: Subdistrictul nu poate conține etichete
+              HTML
+            contains_url_instructional: Subdistrictul nu poate conține URL-uri
+            contains_url_informative: Subdistrictul nu poate conține URL-uri
+            unknown_for_city_instructional: Introduceți un nume valid de subdistrict
+              pentru %{city}
+            unknown_for_city_informative: Introduceți un nume valid de subdistrict
+              pentru %{city}
+            unknown_for_zip_instructional: Introduceți un nume valid de subdistrict
+              pentru %{zip}
+            unknown_for_zip_informative: Introduceți un nume valid de subdistrict
+              pentru %{zip}
+            unknown_for_address_instructional: Subdistrictul poate fi incorect
+            unknown_for_address_informative: Subdistrictul poate fi incorect
+          warnings:
+            contains_too_many_words: Se recomandă ca subdistrictul să aibă mai puțin
+              de %{word_count} cuvinte

--- a/data/regions/_default/ru.yml
+++ b/data/regions/_default/ru.yml
@@ -479,3 +479,88 @@ ru:
           errors:
             may_not_exist_instructional: Адрес не найден или его не существует
             may_not_exist_informative: Адрес не найден
+        district:
+          label:
+            default: Район
+            optional: Район (необязательно)
+          errors:
+            blank_instructional: Введите район
+            blank_informative: Район не указан
+            too_long_instructional: Название района слишком длинное (максимум %{limit}
+              символов)
+            too_long_informative: Название района слишком длинное
+            contains_emojis_instructional: Название района не может содержать эмодзи
+            contains_emojis_informative: Название района не может содержать эмодзи
+            contains_mathematical_symbols_instructional: Название района не может
+              содержать математические символы
+            contains_mathematical_symbols_informative: Название района не может содержать
+              математические символы
+            contains_restricted_characters_instructional: Название района может содержать
+              только буквы, цифры, символы местного алфавита и специальные символы
+            contains_restricted_characters_informative: Название района не может содержать
+              недопустимые символы
+            contains_too_many_words_instructional: Название района должно содержать
+              менее %{word_count} слов
+            contains_too_many_words_informative: Название района должно содержать
+              менее %{word_count} слов
+            contains_html_tags_instructional: Название района не может содержать HTML-теги
+            contains_html_tags_informative: Название района не может содержать HTML-теги
+            contains_url_instructional: Название района не может содержать URL
+            contains_url_informative: Название района не может содержать URL
+            unknown_for_city_instructional: Введите правильное название района для
+              %{city}
+            unknown_for_city_informative: Введите правильное название района для %{city}
+            unknown_for_zip_instructional: Введите правильное название района для
+              почтового индекса %{zip}
+            unknown_for_zip_informative: Введите правильное название района для почтового
+              индекса %{zip}
+            unknown_for_address_instructional: Возможно, район указан неверно
+            unknown_for_address_informative: Возможно, район указан неверно
+          warnings:
+            contains_too_many_words: Рекомендуется, чтобы название района содержало
+              менее %{word_count} слов
+        subdistrict:
+          label:
+            default: Микрорайон
+            optional: Микрорайон (необязательно)
+          errors:
+            blank_instructional: Введите микрорайон
+            blank_informative: Микрорайон не указан
+            too_long_instructional: Название микрорайона слишком длинное (максимум
+              %{limit} символов)
+            too_long_informative: Название микрорайона слишком длинное
+            contains_emojis_instructional: Название микрорайона не может содержать
+              эмодзи
+            contains_emojis_informative: Название микрорайона не может содержать эмодзи
+            contains_mathematical_symbols_instructional: Название микрорайона не может
+              содержать математические символы
+            contains_mathematical_symbols_informative: Название микрорайона не может
+              содержать математические символы
+            contains_restricted_characters_instructional: Название микрорайона может
+              содержать только буквы, цифры, символы местного алфавита и специальные
+              символы
+            contains_restricted_characters_informative: Название микрорайона не может
+              содержать недопустимые символы
+            contains_too_many_words_instructional: Название микрорайона должно содержать
+              менее %{word_count} слов
+            contains_too_many_words_informative: Название микрорайона должно содержать
+              менее %{word_count} слов
+            contains_html_tags_instructional: Название микрорайона не может содержать
+              HTML-теги
+            contains_html_tags_informative: Название микрорайона не может содержать
+              HTML-теги
+            contains_url_instructional: Название микрорайона не может содержать URL
+            contains_url_informative: Название микрорайона не может содержать URL
+            unknown_for_city_instructional: Введите правильное название микрорайона
+              для %{city}
+            unknown_for_city_informative: Введите правильное название микрорайона
+              для %{city}
+            unknown_for_zip_instructional: Введите правильное название микрорайона
+              для почтового индекса %{zip}
+            unknown_for_zip_informative: Введите правильное название микрорайона для
+              почтового индекса %{zip}
+            unknown_for_address_instructional: Возможно, микрорайон указан неверно
+            unknown_for_address_informative: Возможно, микрорайон указан неверно
+          warnings:
+            contains_too_many_words: Рекомендуется, чтобы название микрорайона содержало
+              менее %{word_count} слов

--- a/data/regions/_default/ru.yml
+++ b/data/regions/_default/ru.yml
@@ -485,7 +485,7 @@ ru:
             optional: Район (необязательно)
           errors:
             blank_instructional: Введите район
-            blank_informative: Район не указан
+            blank_informative: Не указан район
             too_long_instructional: Название района слишком длинное (максимум %{limit}
               символов)
             too_long_informative: Название района слишком длинное
@@ -496,9 +496,9 @@ ru:
             contains_mathematical_symbols_informative: Название района не может содержать
               математические символы
             contains_restricted_characters_instructional: Название района может содержать
-              только буквы, цифры, символы местного алфавита и специальные символы
+              только буквы, цифры, местные и специальные символы
             contains_restricted_characters_informative: Название района не может содержать
-              недопустимые символы
+              запрещенные символы
             contains_too_many_words_instructional: Название района должно содержать
               менее %{word_count} слов
             contains_too_many_words_informative: Название района должно содержать
@@ -508,12 +508,13 @@ ru:
             contains_url_instructional: Название района не может содержать URL
             contains_url_informative: Название района не может содержать URL
             unknown_for_city_instructional: Введите правильное название района для
+              города %{city}
+            unknown_for_city_informative: Введите правильное название района для города
               %{city}
-            unknown_for_city_informative: Введите правильное название района для %{city}
             unknown_for_zip_instructional: Введите правильное название района для
-              почтового индекса %{zip}
-            unknown_for_zip_informative: Введите правильное название района для почтового
               индекса %{zip}
+            unknown_for_zip_informative: Введите правильное название района для индекса
+              %{zip}
             unknown_for_address_instructional: Возможно, район указан неверно
             unknown_for_address_informative: Возможно, район указан неверно
           warnings:
@@ -525,7 +526,7 @@ ru:
             optional: Микрорайон (необязательно)
           errors:
             blank_instructional: Введите микрорайон
-            blank_informative: Микрорайон не указан
+            blank_informative: Не указан микрорайон
             too_long_instructional: Название микрорайона слишком длинное (максимум
               %{limit} символов)
             too_long_informative: Название микрорайона слишком длинное
@@ -537,10 +538,9 @@ ru:
             contains_mathematical_symbols_informative: Название микрорайона не может
               содержать математические символы
             contains_restricted_characters_instructional: Название микрорайона может
-              содержать только буквы, цифры, символы местного алфавита и специальные
-              символы
+              содержать только буквы, цифры, местные и специальные символы
             contains_restricted_characters_informative: Название микрорайона не может
-              содержать недопустимые символы
+              содержать запрещенные символы
             contains_too_many_words_instructional: Название микрорайона должно содержать
               менее %{word_count} слов
             contains_too_many_words_informative: Название микрорайона должно содержать
@@ -552,13 +552,13 @@ ru:
             contains_url_instructional: Название микрорайона не может содержать URL
             contains_url_informative: Название микрорайона не может содержать URL
             unknown_for_city_instructional: Введите правильное название микрорайона
-              для %{city}
+              для города %{city}
             unknown_for_city_informative: Введите правильное название микрорайона
-              для %{city}
+              для города %{city}
             unknown_for_zip_instructional: Введите правильное название микрорайона
-              для почтового индекса %{zip}
+              для индекса %{zip}
             unknown_for_zip_informative: Введите правильное название микрорайона для
-              почтового индекса %{zip}
+              индекса %{zip}
             unknown_for_address_instructional: Возможно, микрорайон указан неверно
             unknown_for_address_informative: Возможно, микрорайон указан неверно
           warnings:

--- a/data/regions/_default/sk.yml
+++ b/data/regions/_default/sk.yml
@@ -463,7 +463,7 @@ sk:
         district:
           label:
             default: Okres
-            optional: Okres (nepovinné)
+            optional: Okres (voliteľné)
           errors:
             blank_instructional: Zadajte okres
             blank_informative: Chýba okres
@@ -475,18 +475,18 @@ sk:
               symboly
             contains_mathematical_symbols_informative: Okres nemôže obsahovať matematické
               symboly
-            contains_restricted_characters_instructional: Okres môže obsahovať iba
-              písmená, číslice, lokálne znaky a špeciálne znaky
+            contains_restricted_characters_instructional: Okres môže obsahovať len
+              písmená, číslice, lokálne a špeciálne znaky
             contains_restricted_characters_informative: Okres nemôže obsahovať nepovolené
               znaky
-            contains_too_many_words_instructional: Okres musí obsahovať menej ako
-              %{word_count} slov
-            contains_too_many_words_informative: Okres musí obsahovať menej ako %{word_count}
+            contains_too_many_words_instructional: Okres musí mať menej ako %{word_count}
+              slov
+            contains_too_many_words_informative: Okres musí mať menej ako %{word_count}
               slov
             contains_html_tags_instructional: Okres nemôže obsahovať značky HTML
             contains_html_tags_informative: Okres nemôže obsahovať značky HTML
-            contains_url_instructional: Okres nemôže obsahovať URL adresy
-            contains_url_informative: Okres nemôže obsahovať URL adresy
+            contains_url_instructional: Okres nemôže obsahovať adresy URL
+            contains_url_informative: Okres nemôže obsahovať adresy URL
             unknown_for_city_instructional: Zadajte platný názov okresu pre %{city}
             unknown_for_city_informative: Zadajte platný názov okresu pre %{city}
             unknown_for_zip_instructional: Zadajte platný názov okresu pre %{zip}
@@ -494,46 +494,46 @@ sk:
             unknown_for_address_instructional: Okres môže byť nesprávny
             unknown_for_address_informative: Okres môže byť nesprávny
           warnings:
-            contains_too_many_words: Odporúča sa, aby okres obsahoval menej ako %{word_count}
+            contains_too_many_words: Odporúča sa, aby okres mal menej ako %{word_count}
               slov
         subdistrict:
           label:
-            default: Mestská časť
-            optional: Mestská časť (nepovinné)
+            default: Miestna časť
+            optional: Miestna časť (voliteľné)
           errors:
-            blank_instructional: Zadajte mestskú časť
-            blank_informative: Chýba mestská časť
-            too_long_instructional: Mestská časť je príliš dlhá (maximum je %{limit}
+            blank_instructional: Zadajte miestnu časť
+            blank_informative: Chýba miestna časť
+            too_long_instructional: Miestna časť je príliš dlhá (maximum je %{limit}
               znakov)
-            too_long_informative: Mestská časť je príliš dlhá
-            contains_emojis_instructional: Mestská časť nemôže obsahovať emoji
-            contains_emojis_informative: Mestská časť nemôže obsahovať emoji
-            contains_mathematical_symbols_instructional: Mestská časť nemôže obsahovať
+            too_long_informative: Miestna časť je príliš dlhá
+            contains_emojis_instructional: Miestna časť nemôže obsahovať emoji
+            contains_emojis_informative: Miestna časť nemôže obsahovať emoji
+            contains_mathematical_symbols_instructional: Miestna časť nemôže obsahovať
               matematické symboly
-            contains_mathematical_symbols_informative: Mestská časť nemôže obsahovať
+            contains_mathematical_symbols_informative: Miestna časť nemôže obsahovať
               matematické symboly
-            contains_restricted_characters_instructional: Mestská časť môže obsahovať
-              iba písmená, číslice, lokálne znaky a špeciálne znaky
-            contains_restricted_characters_informative: Mestská časť nemôže obsahovať
+            contains_restricted_characters_instructional: Miestna časť môže obsahovať
+              len písmená, číslice, lokálne a špeciálne znaky
+            contains_restricted_characters_informative: Miestna časť nemôže obsahovať
               nepovolené znaky
-            contains_too_many_words_instructional: Mestská časť musí obsahovať menej
-              ako %{word_count} slov
-            contains_too_many_words_informative: Mestská časť musí obsahovať menej
-              ako %{word_count} slov
-            contains_html_tags_instructional: Mestská časť nemôže obsahovať značky
+            contains_too_many_words_instructional: Miestna časť musí mať menej ako
+              %{word_count} slov
+            contains_too_many_words_informative: Miestna časť musí mať menej ako %{word_count}
+              slov
+            contains_html_tags_instructional: Miestna časť nemôže obsahovať značky
               HTML
-            contains_html_tags_informative: Mestská časť nemôže obsahovať značky HTML
-            contains_url_instructional: Mestská časť nemôže obsahovať URL adresy
-            contains_url_informative: Mestská časť nemôže obsahovať URL adresy
-            unknown_for_city_instructional: Zadajte platný názov mestskej časti pre
+            contains_html_tags_informative: Miestna časť nemôže obsahovať značky HTML
+            contains_url_instructional: Miestna časť nemôže obsahovať adresy URL
+            contains_url_informative: Miestna časť nemôže obsahovať adresy URL
+            unknown_for_city_instructional: Zadajte platný názov miestnej časti pre
               %{city}
-            unknown_for_city_informative: Zadajte platný názov mestskej časti pre
+            unknown_for_city_informative: Zadajte platný názov miestnej časti pre
               %{city}
-            unknown_for_zip_instructional: Zadajte platný názov mestskej časti pre
+            unknown_for_zip_instructional: Zadajte platný názov miestnej časti pre
               %{zip}
-            unknown_for_zip_informative: Zadajte platný názov mestskej časti pre %{zip}
-            unknown_for_address_instructional: Mestská časť môže byť nesprávna
-            unknown_for_address_informative: Mestská časť môže byť nesprávna
+            unknown_for_zip_informative: Zadajte platný názov miestnej časti pre %{zip}
+            unknown_for_address_instructional: Miestna časť môže byť nesprávna
+            unknown_for_address_informative: Miestna časť môže byť nesprávna
           warnings:
-            contains_too_many_words: Odporúča sa, aby mestská časť obsahovala menej
-              ako %{word_count} slov
+            contains_too_many_words: Odporúča sa, aby miestna časť mala menej ako
+              %{word_count} slov

--- a/data/regions/_default/sk.yml
+++ b/data/regions/_default/sk.yml
@@ -460,3 +460,80 @@ sk:
           errors:
             may_not_exist_instructional: Adresa nebola nájdená alebo neexistuje
             may_not_exist_informative: Adresa nebola nájdená
+        district:
+          label:
+            default: Okres
+            optional: Okres (nepovinné)
+          errors:
+            blank_instructional: Zadajte okres
+            blank_informative: Chýba okres
+            too_long_instructional: Okres je príliš dlhý (maximum je %{limit} znakov)
+            too_long_informative: Okres je príliš dlhý
+            contains_emojis_instructional: Okres nemôže obsahovať emoji
+            contains_emojis_informative: Okres nemôže obsahovať emoji
+            contains_mathematical_symbols_instructional: Okres nemôže obsahovať matematické
+              symboly
+            contains_mathematical_symbols_informative: Okres nemôže obsahovať matematické
+              symboly
+            contains_restricted_characters_instructional: Okres môže obsahovať iba
+              písmená, číslice, lokálne znaky a špeciálne znaky
+            contains_restricted_characters_informative: Okres nemôže obsahovať nepovolené
+              znaky
+            contains_too_many_words_instructional: Okres musí obsahovať menej ako
+              %{word_count} slov
+            contains_too_many_words_informative: Okres musí obsahovať menej ako %{word_count}
+              slov
+            contains_html_tags_instructional: Okres nemôže obsahovať značky HTML
+            contains_html_tags_informative: Okres nemôže obsahovať značky HTML
+            contains_url_instructional: Okres nemôže obsahovať URL adresy
+            contains_url_informative: Okres nemôže obsahovať URL adresy
+            unknown_for_city_instructional: Zadajte platný názov okresu pre %{city}
+            unknown_for_city_informative: Zadajte platný názov okresu pre %{city}
+            unknown_for_zip_instructional: Zadajte platný názov okresu pre %{zip}
+            unknown_for_zip_informative: Zadajte platný názov okresu pre %{zip}
+            unknown_for_address_instructional: Okres môže byť nesprávny
+            unknown_for_address_informative: Okres môže byť nesprávny
+          warnings:
+            contains_too_many_words: Odporúča sa, aby okres obsahoval menej ako %{word_count}
+              slov
+        subdistrict:
+          label:
+            default: Mestská časť
+            optional: Mestská časť (nepovinné)
+          errors:
+            blank_instructional: Zadajte mestskú časť
+            blank_informative: Chýba mestská časť
+            too_long_instructional: Mestská časť je príliš dlhá (maximum je %{limit}
+              znakov)
+            too_long_informative: Mestská časť je príliš dlhá
+            contains_emojis_instructional: Mestská časť nemôže obsahovať emoji
+            contains_emojis_informative: Mestská časť nemôže obsahovať emoji
+            contains_mathematical_symbols_instructional: Mestská časť nemôže obsahovať
+              matematické symboly
+            contains_mathematical_symbols_informative: Mestská časť nemôže obsahovať
+              matematické symboly
+            contains_restricted_characters_instructional: Mestská časť môže obsahovať
+              iba písmená, číslice, lokálne znaky a špeciálne znaky
+            contains_restricted_characters_informative: Mestská časť nemôže obsahovať
+              nepovolené znaky
+            contains_too_many_words_instructional: Mestská časť musí obsahovať menej
+              ako %{word_count} slov
+            contains_too_many_words_informative: Mestská časť musí obsahovať menej
+              ako %{word_count} slov
+            contains_html_tags_instructional: Mestská časť nemôže obsahovať značky
+              HTML
+            contains_html_tags_informative: Mestská časť nemôže obsahovať značky HTML
+            contains_url_instructional: Mestská časť nemôže obsahovať URL adresy
+            contains_url_informative: Mestská časť nemôže obsahovať URL adresy
+            unknown_for_city_instructional: Zadajte platný názov mestskej časti pre
+              %{city}
+            unknown_for_city_informative: Zadajte platný názov mestskej časti pre
+              %{city}
+            unknown_for_zip_instructional: Zadajte platný názov mestskej časti pre
+              %{zip}
+            unknown_for_zip_informative: Zadajte platný názov mestskej časti pre %{zip}
+            unknown_for_address_instructional: Mestská časť môže byť nesprávna
+            unknown_for_address_informative: Mestská časť môže byť nesprávna
+          warnings:
+            contains_too_many_words: Odporúča sa, aby mestská časť obsahovala menej
+              ako %{word_count} slov

--- a/data/regions/_default/sl.yml
+++ b/data/regions/_default/sl.yml
@@ -479,3 +479,75 @@ sl:
           errors:
             may_not_exist_instructional: Naslova ni mogoče najti ali ne obstaja
             may_not_exist_informative: Naslova ni mogoče najti
+        district:
+          label:
+            default: Okrožje
+            optional: Okrožje (izbirno)
+          errors:
+            blank_instructional: Vnesite okrožje
+            blank_informative: Manjka okrožje
+            too_long_instructional: Okrožje je predolgo (največ %{limit} znakov)
+            too_long_informative: Okrožje je predolgo
+            contains_emojis_instructional: Okrožje ne sme vsebovati emodžijev
+            contains_emojis_informative: Okrožje ne sme vsebovati emodžijev
+            contains_mathematical_symbols_instructional: Okrožje ne sme vsebovati
+              matematičnih simbolov
+            contains_mathematical_symbols_informative: Okrožje ne sme vsebovati matematičnih
+              simbolov
+            contains_restricted_characters_instructional: Okrožje lahko vsebuje samo
+              črke, številke, lokalne znake in posebne znake
+            contains_restricted_characters_informative: Okrožje ne sme vsebovati nedovoljenih
+              znakov
+            contains_too_many_words_instructional: Število besed za okrožje mora biti
+              manjše od %{word_count}
+            contains_too_many_words_informative: Število besed za okrožje mora biti
+              manjše od %{word_count}
+            contains_html_tags_instructional: Okrožje ne sme vsebovati oznak HTML
+            contains_html_tags_informative: Okrožje ne sme vsebovati oznak HTML
+            contains_url_instructional: Okrožje ne sme vsebovati URL-naslovov
+            contains_url_informative: Okrožje ne sme vsebovati URL-naslovov
+            unknown_for_city_instructional: Vnesite veljavno ime okrožja za %{city}
+            unknown_for_city_informative: Vnesite veljavno ime okrožja za %{city}
+            unknown_for_zip_instructional: Vnesite veljavno ime okrožja za %{zip}
+            unknown_for_zip_informative: Vnesite veljavno ime okrožja za %{zip}
+            unknown_for_address_instructional: Okrožje je morda napačno
+            unknown_for_address_informative: Okrožje je morda napačno
+          warnings:
+            contains_too_many_words: Priporočljivo je, da je število besed za okrožje
+              manjše od %{word_count}
+        subdistrict:
+          label:
+            default: Podokrožje
+            optional: Podokrožje (izbirno)
+          errors:
+            blank_instructional: Vnesite podokrožje
+            blank_informative: Manjka podokrožje
+            too_long_instructional: Podokrožje je predolgo (največ %{limit} znakov)
+            too_long_informative: Podokrožje je predolgo
+            contains_emojis_instructional: Podokrožje ne sme vsebovati emodžijev
+            contains_emojis_informative: Podokrožje ne sme vsebovati emodžijev
+            contains_mathematical_symbols_instructional: Podokrožje ne sme vsebovati
+              matematičnih simbolov
+            contains_mathematical_symbols_informative: Podokrožje ne sme vsebovati
+              matematičnih simbolov
+            contains_restricted_characters_instructional: Podokrožje lahko vsebuje
+              samo črke, številke, lokalne znake in posebne znake
+            contains_restricted_characters_informative: Podokrožje ne sme vsebovati
+              nedovoljenih znakov
+            contains_too_many_words_instructional: Število besed za podokrožje mora
+              biti manjše od %{word_count}
+            contains_too_many_words_informative: Število besed za podokrožje mora
+              biti manjše od %{word_count}
+            contains_html_tags_instructional: Podokrožje ne sme vsebovati oznak HTML
+            contains_html_tags_informative: Podokrožje ne sme vsebovati oznak HTML
+            contains_url_instructional: Podokrožje ne sme vsebovati URL-naslovov
+            contains_url_informative: Podokrožje ne sme vsebovati URL-naslovov
+            unknown_for_city_instructional: Vnesite veljavno ime podokrožja za %{city}
+            unknown_for_city_informative: Vnesite veljavno ime podokrožja za %{city}
+            unknown_for_zip_instructional: Vnesite veljavno ime podokrožja za %{zip}
+            unknown_for_zip_informative: Vnesite veljavno ime podokrožja za %{zip}
+            unknown_for_address_instructional: Podokrožje je morda napačno
+            unknown_for_address_informative: Podokrožje je morda napačno
+          warnings:
+            contains_too_many_words: Priporočljivo je, da je število besed za podokrožje
+              manjše od %{word_count}

--- a/data/regions/_default/sl.yml
+++ b/data/regions/_default/sl.yml
@@ -486,7 +486,8 @@ sl:
           errors:
             blank_instructional: Vnesite okrožje
             blank_informative: Manjka okrožje
-            too_long_instructional: Okrožje je predolgo (največ %{limit} znakov)
+            too_long_instructional: Okrožje je predolgo (dovoljenih je največ %{limit}
+              znakov)
             too_long_informative: Okrožje je predolgo
             contains_emojis_instructional: Okrožje ne sme vsebovati emodžijev
             contains_emojis_informative: Okrožje ne sme vsebovati emodžijev
@@ -494,27 +495,30 @@ sl:
               matematičnih simbolov
             contains_mathematical_symbols_informative: Okrožje ne sme vsebovati matematičnih
               simbolov
-            contains_restricted_characters_instructional: Okrožje lahko vsebuje samo
+            contains_restricted_characters_instructional: Okrožje lahko vsebuje le
               črke, številke, lokalne znake in posebne znake
             contains_restricted_characters_informative: Okrožje ne sme vsebovati nedovoljenih
               znakov
-            contains_too_many_words_instructional: Število besed za okrožje mora biti
-              manjše od %{word_count}
-            contains_too_many_words_informative: Število besed za okrožje mora biti
-              manjše od %{word_count}
+            contains_too_many_words_instructional: Okrožje mora vsebovati manj kot
+              %{word_count} besed
+            contains_too_many_words_informative: Okrožje mora vsebovati manj kot %{word_count}
+              besed
             contains_html_tags_instructional: Okrožje ne sme vsebovati oznak HTML
             contains_html_tags_informative: Okrožje ne sme vsebovati oznak HTML
             contains_url_instructional: Okrožje ne sme vsebovati URL-naslovov
             contains_url_informative: Okrožje ne sme vsebovati URL-naslovov
-            unknown_for_city_instructional: Vnesite veljavno ime okrožja za %{city}
-            unknown_for_city_informative: Vnesite veljavno ime okrožja za %{city}
-            unknown_for_zip_instructional: Vnesite veljavno ime okrožja za %{zip}
-            unknown_for_zip_informative: Vnesite veljavno ime okrožja za %{zip}
+            unknown_for_city_instructional: Vnesite veljavno ime okrožja za mesto
+              %{city}
+            unknown_for_city_informative: Vnesite veljavno ime okrožja za mesto %{city}
+            unknown_for_zip_instructional: Vnesite veljavno ime okrožja za poštno
+              številko %{zip}
+            unknown_for_zip_informative: Vnesite veljavno ime okrožja za poštno številko
+              %{zip}
             unknown_for_address_instructional: Okrožje je morda napačno
             unknown_for_address_informative: Okrožje je morda napačno
           warnings:
-            contains_too_many_words: Priporočljivo je, da je število besed za okrožje
-              manjše od %{word_count}
+            contains_too_many_words: Priporočamo, da okrožje vsebuje manj kot %{word_count}
+              besed
         subdistrict:
           label:
             default: Podokrožje
@@ -522,7 +526,8 @@ sl:
           errors:
             blank_instructional: Vnesite podokrožje
             blank_informative: Manjka podokrožje
-            too_long_instructional: Podokrožje je predolgo (največ %{limit} znakov)
+            too_long_instructional: Podokrožje je predolgo (dovoljenih je največ %{limit}
+              znakov)
             too_long_informative: Podokrožje je predolgo
             contains_emojis_instructional: Podokrožje ne sme vsebovati emodžijev
             contains_emojis_informative: Podokrožje ne sme vsebovati emodžijev
@@ -531,23 +536,27 @@ sl:
             contains_mathematical_symbols_informative: Podokrožje ne sme vsebovati
               matematičnih simbolov
             contains_restricted_characters_instructional: Podokrožje lahko vsebuje
-              samo črke, številke, lokalne znake in posebne znake
+              le črke, številke, lokalne znake in posebne znake
             contains_restricted_characters_informative: Podokrožje ne sme vsebovati
               nedovoljenih znakov
-            contains_too_many_words_instructional: Število besed za podokrožje mora
-              biti manjše od %{word_count}
-            contains_too_many_words_informative: Število besed za podokrožje mora
-              biti manjše od %{word_count}
+            contains_too_many_words_instructional: Podokrožje mora vsebovati manj
+              kot %{word_count} besed
+            contains_too_many_words_informative: Podokrožje mora vsebovati manj kot
+              %{word_count} besed
             contains_html_tags_instructional: Podokrožje ne sme vsebovati oznak HTML
             contains_html_tags_informative: Podokrožje ne sme vsebovati oznak HTML
             contains_url_instructional: Podokrožje ne sme vsebovati URL-naslovov
             contains_url_informative: Podokrožje ne sme vsebovati URL-naslovov
-            unknown_for_city_instructional: Vnesite veljavno ime podokrožja za %{city}
-            unknown_for_city_informative: Vnesite veljavno ime podokrožja za %{city}
-            unknown_for_zip_instructional: Vnesite veljavno ime podokrožja za %{zip}
-            unknown_for_zip_informative: Vnesite veljavno ime podokrožja za %{zip}
+            unknown_for_city_instructional: Vnesite veljavno ime podokrožja za mesto
+              %{city}
+            unknown_for_city_informative: Vnesite veljavno ime podokrožja za mesto
+              %{city}
+            unknown_for_zip_instructional: Vnesite veljavno ime podokrožja za poštno
+              številko %{zip}
+            unknown_for_zip_informative: Vnesite veljavno ime podokrožja za poštno
+              številko %{zip}
             unknown_for_address_instructional: Podokrožje je morda napačno
             unknown_for_address_informative: Podokrožje je morda napačno
           warnings:
-            contains_too_many_words: Priporočljivo je, da je število besed za podokrožje
-              manjše od %{word_count}
+            contains_too_many_words: Priporočamo, da podokrožje vsebuje manj kot %{word_count}
+              besed

--- a/data/regions/_default/sv.yml
+++ b/data/regions/_default/sv.yml
@@ -441,3 +441,76 @@ sv:
           warnings:
             contains_too_many_words: Vi rekommenderar att den andra adressraden består
               av färre än %{word_count} ord
+        district:
+          label:
+            default: Distrikt
+            optional: Distrikt (valfritt)
+          errors:
+            blank_instructional: Ange ett distrikt
+            blank_informative: Distrikt saknas
+            too_long_instructional: Distrikt är för långt (högst %{limit} tecken)
+            too_long_informative: Distrikt är för långt
+            contains_emojis_instructional: Distrikt får inte innehålla emojis
+            contains_emojis_informative: Distrikt får inte innehålla emojis
+            contains_mathematical_symbols_instructional: Distrikt får inte innehålla
+              matematiska symboler
+            contains_mathematical_symbols_informative: Distrikt får inte innehålla
+              matematiska symboler
+            contains_restricted_characters_instructional: Distrikt får endast innehålla
+              bokstäver, siffror, lokala tecken och specialtecken
+            contains_restricted_characters_informative: Distrikt får inte innehålla
+              otillåtna tecken
+            contains_too_many_words_instructional: Distrikt måste ha färre än %{word_count}
+              ord
+            contains_too_many_words_informative: Distrikt måste ha färre än %{word_count}
+              ord
+            contains_html_tags_instructional: Distrikt får inte innehålla HTML-taggar
+            contains_html_tags_informative: Distrikt får inte innehålla HTML-taggar
+            contains_url_instructional: Distrikt får inte innehålla URL:er
+            contains_url_informative: Distrikt får inte innehålla URL:er
+            unknown_for_city_instructional: Ange ett giltigt distriktsnamn för %{city}
+            unknown_for_city_informative: Ange ett giltigt distriktsnamn för %{city}
+            unknown_for_zip_instructional: Ange ett giltigt distriktsnamn för %{zip}
+            unknown_for_zip_informative: Ange ett giltigt distriktsnamn för %{zip}
+            unknown_for_address_instructional: Distrikt kan vara felaktigt
+            unknown_for_address_informative: Distrikt kan vara felaktigt
+          warnings:
+            contains_too_many_words: Distrikt bör ha färre än %{word_count} ord
+        subdistrict:
+          label:
+            default: Underdistrikt
+            optional: Underdistrikt (valfritt)
+          errors:
+            blank_instructional: Ange ett underdistrikt
+            blank_informative: Underdistrikt saknas
+            too_long_instructional: Underdistrikt är för långt (högst %{limit} tecken)
+            too_long_informative: Underdistrikt är för långt
+            contains_emojis_instructional: Underdistrikt får inte innehålla emojis
+            contains_emojis_informative: Underdistrikt får inte innehålla emojis
+            contains_mathematical_symbols_instructional: Underdistrikt får inte innehålla
+              matematiska symboler
+            contains_mathematical_symbols_informative: Underdistrikt får inte innehålla
+              matematiska symboler
+            contains_restricted_characters_instructional: Underdistrikt får endast
+              innehålla bokstäver, siffror, lokala tecken och specialtecken
+            contains_restricted_characters_informative: Underdistrikt får inte innehålla
+              otillåtna tecken
+            contains_too_many_words_instructional: Underdistrikt måste ha färre än
+              %{word_count} ord
+            contains_too_many_words_informative: Underdistrikt måste ha färre än %{word_count}
+              ord
+            contains_html_tags_instructional: Underdistrikt får inte innehålla HTML-taggar
+            contains_html_tags_informative: Underdistrikt får inte innehålla HTML-taggar
+            contains_url_instructional: Underdistrikt får inte innehålla URL:er
+            contains_url_informative: Underdistrikt får inte innehålla URL:er
+            unknown_for_city_instructional: Ange ett giltigt underdistriktsnamn för
+              %{city}
+            unknown_for_city_informative: Ange ett giltigt underdistriktsnamn för
+              %{city}
+            unknown_for_zip_instructional: Ange ett giltigt underdistriktsnamn för
+              %{zip}
+            unknown_for_zip_informative: Ange ett giltigt underdistriktsnamn för %{zip}
+            unknown_for_address_instructional: Underdistrikt kan vara felaktigt
+            unknown_for_address_informative: Underdistrikt kan vara felaktigt
+          warnings:
+            contains_too_many_words: Underdistrikt bör ha färre än %{word_count} ord

--- a/data/regions/_default/sv.yml
+++ b/data/regions/_default/sv.yml
@@ -448,34 +448,35 @@ sv:
           errors:
             blank_instructional: Ange ett distrikt
             blank_informative: Distrikt saknas
-            too_long_instructional: Distrikt är för långt (högst %{limit} tecken)
-            too_long_informative: Distrikt är för långt
-            contains_emojis_instructional: Distrikt får inte innehålla emojis
-            contains_emojis_informative: Distrikt får inte innehålla emojis
-            contains_mathematical_symbols_instructional: Distrikt får inte innehålla
+            too_long_instructional: Distriktet är för långt (max %{limit} tecken)
+            too_long_informative: Distriktet är för långt
+            contains_emojis_instructional: Distriktet kan inte innehålla emojis
+            contains_emojis_informative: Distriktet kan inte innehålla emojis
+            contains_mathematical_symbols_instructional: Distriktet kan inte innehålla
               matematiska symboler
-            contains_mathematical_symbols_informative: Distrikt får inte innehålla
+            contains_mathematical_symbols_informative: Distriktet kan inte innehålla
               matematiska symboler
-            contains_restricted_characters_instructional: Distrikt får endast innehålla
+            contains_restricted_characters_instructional: Distriktet kan endast innehålla
               bokstäver, siffror, lokala tecken och specialtecken
-            contains_restricted_characters_informative: Distrikt får inte innehålla
+            contains_restricted_characters_informative: Distriktet kan inte innehålla
               otillåtna tecken
-            contains_too_many_words_instructional: Distrikt måste ha färre än %{word_count}
+            contains_too_many_words_instructional: Distriktet måste ha färre än %{word_count}
               ord
-            contains_too_many_words_informative: Distrikt måste ha färre än %{word_count}
+            contains_too_many_words_informative: Distriktet måste ha färre än %{word_count}
               ord
-            contains_html_tags_instructional: Distrikt får inte innehålla HTML-taggar
-            contains_html_tags_informative: Distrikt får inte innehålla HTML-taggar
-            contains_url_instructional: Distrikt får inte innehålla URL:er
-            contains_url_informative: Distrikt får inte innehålla URL:er
-            unknown_for_city_instructional: Ange ett giltigt distriktsnamn för %{city}
-            unknown_for_city_informative: Ange ett giltigt distriktsnamn för %{city}
-            unknown_for_zip_instructional: Ange ett giltigt distriktsnamn för %{zip}
-            unknown_for_zip_informative: Ange ett giltigt distriktsnamn för %{zip}
-            unknown_for_address_instructional: Distrikt kan vara felaktigt
-            unknown_for_address_informative: Distrikt kan vara felaktigt
+            contains_html_tags_instructional: Distriktet kan inte innehålla HTML-taggar
+            contains_html_tags_informative: Distriktet kan inte innehålla HTML-taggar
+            contains_url_instructional: Distriktet kan inte innehålla URL:er
+            contains_url_informative: Distriktet kan inte innehålla URL:er
+            unknown_for_city_instructional: Ange ett giltigt distrikt för %{city}
+            unknown_for_city_informative: Ange ett giltigt distrikt för %{city}
+            unknown_for_zip_instructional: Ange ett giltigt distrikt för %{zip}
+            unknown_for_zip_informative: Ange ett giltigt distrikt för %{zip}
+            unknown_for_address_instructional: Distriktet kan vara felaktigt
+            unknown_for_address_informative: Distriktet kan vara felaktigt
           warnings:
-            contains_too_many_words: Distrikt bör ha färre än %{word_count} ord
+            contains_too_many_words: Distriktet rekommenderas ha färre än %{word_count}
+              ord
         subdistrict:
           label:
             default: Underdistrikt
@@ -483,34 +484,32 @@ sv:
           errors:
             blank_instructional: Ange ett underdistrikt
             blank_informative: Underdistrikt saknas
-            too_long_instructional: Underdistrikt är för långt (högst %{limit} tecken)
-            too_long_informative: Underdistrikt är för långt
-            contains_emojis_instructional: Underdistrikt får inte innehålla emojis
-            contains_emojis_informative: Underdistrikt får inte innehålla emojis
-            contains_mathematical_symbols_instructional: Underdistrikt får inte innehålla
+            too_long_instructional: Underdistriktet är för långt (max %{limit} tecken)
+            too_long_informative: Underdistriktet är för långt
+            contains_emojis_instructional: Underdistriktet kan inte innehålla emojis
+            contains_emojis_informative: Underdistriktet kan inte innehålla emojis
+            contains_mathematical_symbols_instructional: Underdistriktet kan inte
+              innehålla matematiska symboler
+            contains_mathematical_symbols_informative: Underdistriktet kan inte innehålla
               matematiska symboler
-            contains_mathematical_symbols_informative: Underdistrikt får inte innehålla
-              matematiska symboler
-            contains_restricted_characters_instructional: Underdistrikt får endast
+            contains_restricted_characters_instructional: Underdistriktet kan endast
               innehålla bokstäver, siffror, lokala tecken och specialtecken
-            contains_restricted_characters_informative: Underdistrikt får inte innehålla
+            contains_restricted_characters_informative: Underdistriktet kan inte innehålla
               otillåtna tecken
-            contains_too_many_words_instructional: Underdistrikt måste ha färre än
+            contains_too_many_words_instructional: Underdistriktet måste ha färre
+              än %{word_count} ord
+            contains_too_many_words_informative: Underdistriktet måste ha färre än
               %{word_count} ord
-            contains_too_many_words_informative: Underdistrikt måste ha färre än %{word_count}
-              ord
-            contains_html_tags_instructional: Underdistrikt får inte innehålla HTML-taggar
-            contains_html_tags_informative: Underdistrikt får inte innehålla HTML-taggar
-            contains_url_instructional: Underdistrikt får inte innehålla URL:er
-            contains_url_informative: Underdistrikt får inte innehålla URL:er
-            unknown_for_city_instructional: Ange ett giltigt underdistriktsnamn för
-              %{city}
-            unknown_for_city_informative: Ange ett giltigt underdistriktsnamn för
-              %{city}
-            unknown_for_zip_instructional: Ange ett giltigt underdistriktsnamn för
-              %{zip}
-            unknown_for_zip_informative: Ange ett giltigt underdistriktsnamn för %{zip}
-            unknown_for_address_instructional: Underdistrikt kan vara felaktigt
-            unknown_for_address_informative: Underdistrikt kan vara felaktigt
+            contains_html_tags_instructional: Underdistriktet kan inte innehålla HTML-taggar
+            contains_html_tags_informative: Underdistriktet kan inte innehålla HTML-taggar
+            contains_url_instructional: Underdistriktet kan inte innehålla URL:er
+            contains_url_informative: Underdistriktet kan inte innehålla URL:er
+            unknown_for_city_instructional: Ange ett giltigt underdistrikt för %{city}
+            unknown_for_city_informative: Ange ett giltigt underdistrikt för %{city}
+            unknown_for_zip_instructional: Ange ett giltigt underdistrikt för %{zip}
+            unknown_for_zip_informative: Ange ett giltigt underdistrikt för %{zip}
+            unknown_for_address_instructional: Underdistriktet kan vara felaktigt
+            unknown_for_address_informative: Underdistriktet kan vara felaktigt
           warnings:
-            contains_too_many_words: Underdistrikt bör ha färre än %{word_count} ord
+            contains_too_many_words: Underdistriktet rekommenderas ha färre än %{word_count}
+              ord

--- a/data/regions/_default/th.yml
+++ b/data/regions/_default/th.yml
@@ -397,3 +397,69 @@ th:
           errors:
             may_not_exist_instructional: ไม่พบหรือไม่มีที่อยู่
             may_not_exist_informative: ไม่พบที่อยู่
+        district:
+          label:
+            default: เขต/อำเภอ
+            optional: เขต/อำเภอ (ไม่บังคับ)
+          errors:
+            blank_instructional: โปรดระบุเขต/อำเภอ
+            blank_informative: ไม่มีเขต/อำเภอ
+            too_long_instructional: เขต/อำเภอยาวเกินไป (สูงสุด %{limit} อักขระ)
+            too_long_informative: เขต/อำเภอยาวเกินไป
+            contains_emojis_instructional: เขต/อำเภอต้องไม่มีอีโมจิ
+            contains_emojis_informative: เขต/อำเภอต้องไม่มีอีโมจิ
+            contains_mathematical_symbols_instructional: เขต/อำเภอต้องไม่มีสัญลักษณ์ทางคณิตศาสตร์
+            contains_mathematical_symbols_informative: เขต/อำเภอต้องไม่มีสัญลักษณ์ทางคณิตศาสตร์
+            contains_restricted_characters_instructional: เขต/อำเภอต้องมีเฉพาะตัวอักษร
+              ตัวเลข ตัวอักษรท้องถิ่น และอักขระพิเศษเท่านั้น
+            contains_restricted_characters_informative: เขต/อำเภอต้องไม่มีอักขระที่ถูกจำกัด
+            contains_too_many_words_instructional: เขต/อำเภอต้องมีน้อยกว่า %{word_count}
+              คำ
+            contains_too_many_words_informative: เขต/อำเภอต้องมีน้อยกว่า %{word_count}
+              คำ
+            contains_html_tags_instructional: เขต/อำเภอต้องไม่มีแท็ก HTML
+            contains_html_tags_informative: เขต/อำเภอต้องไม่มีแท็ก HTML
+            contains_url_instructional: เขต/อำเภอต้องไม่มี URL
+            contains_url_informative: เขต/อำเภอต้องไม่มี URL
+            unknown_for_city_instructional: โปรดระบุชื่อเขต/อำเภอที่ถูกต้องสำหรับ
+              %{city}
+            unknown_for_city_informative: โปรดระบุชื่อเขต/อำเภอที่ถูกต้องสำหรับ %{city}
+            unknown_for_zip_instructional: โปรดระบุชื่อเขต/อำเภอที่ถูกต้องสำหรับ %{zip}
+            unknown_for_zip_informative: โปรดระบุชื่อเขต/อำเภอที่ถูกต้องสำหรับ %{zip}
+            unknown_for_address_instructional: เขต/อำเภออาจไม่ถูกต้อง
+            unknown_for_address_informative: เขต/อำเภออาจไม่ถูกต้อง
+          warnings:
+            contains_too_many_words: ขอแนะนำให้เขต/อำเภอมีน้อยกว่า %{word_count} คำ
+        subdistrict:
+          label:
+            default: แขวง/ตำบล
+            optional: แขวง/ตำบล (ไม่บังคับ)
+          errors:
+            blank_instructional: โปรดระบุแขวง/ตำบล
+            blank_informative: ไม่มีแขวง/ตำบล
+            too_long_instructional: แขวง/ตำบลยาวเกินไป (สูงสุด %{limit} อักขระ)
+            too_long_informative: แขวง/ตำบลยาวเกินไป
+            contains_emojis_instructional: แขวง/ตำบลต้องไม่มีอีโมจิ
+            contains_emojis_informative: แขวง/ตำบลต้องไม่มีอีโมจิ
+            contains_mathematical_symbols_instructional: แขวง/ตำบลต้องไม่มีสัญลักษณ์ทางคณิตศาสตร์
+            contains_mathematical_symbols_informative: แขวง/ตำบลต้องไม่มีสัญลักษณ์ทางคณิตศาสตร์
+            contains_restricted_characters_instructional: แขวง/ตำบลต้องมีเฉพาะตัวอักษร
+              ตัวเลข ตัวอักษรท้องถิ่น และอักขระพิเศษเท่านั้น
+            contains_restricted_characters_informative: แขวง/ตำบลต้องไม่มีอักขระที่ถูกจำกัด
+            contains_too_many_words_instructional: แขวง/ตำบลต้องมีน้อยกว่า %{word_count}
+              คำ
+            contains_too_many_words_informative: แขวง/ตำบลต้องมีน้อยกว่า %{word_count}
+              คำ
+            contains_html_tags_instructional: แขวง/ตำบลต้องไม่มีแท็ก HTML
+            contains_html_tags_informative: แขวง/ตำบลต้องไม่มีแท็ก HTML
+            contains_url_instructional: แขวง/ตำบลต้องไม่มี URL
+            contains_url_informative: แขวง/ตำบลต้องไม่มี URL
+            unknown_for_city_instructional: โปรดระบุชื่อแขวง/ตำบลที่ถูกต้องสำหรับ
+              %{city}
+            unknown_for_city_informative: โปรดระบุชื่อแขวง/ตำบลที่ถูกต้องสำหรับ %{city}
+            unknown_for_zip_instructional: โปรดระบุชื่อแขวง/ตำบลที่ถูกต้องสำหรับ %{zip}
+            unknown_for_zip_informative: โปรดระบุชื่อแขวง/ตำบลที่ถูกต้องสำหรับ %{zip}
+            unknown_for_address_instructional: แขวง/ตำบลอาจไม่ถูกต้อง
+            unknown_for_address_informative: แขวง/ตำบลอาจไม่ถูกต้อง
+          warnings:
+            contains_too_many_words: ขอแนะนำให้แขวง/ตำบลมีน้อยกว่า %{word_count} คำ

--- a/data/regions/_default/th.yml
+++ b/data/regions/_default/th.yml
@@ -402,9 +402,9 @@ th:
             default: เขต/อำเภอ
             optional: เขต/อำเภอ (ไม่บังคับ)
           errors:
-            blank_instructional: โปรดระบุเขต/อำเภอ
-            blank_informative: ไม่มีเขต/อำเภอ
-            too_long_instructional: เขต/อำเภอยาวเกินไป (สูงสุด %{limit} อักขระ)
+            blank_instructional: โปรดป้อนเขต/อำเภอ
+            blank_informative: ไม่ได้ระบุเขต/อำเภอ
+            too_long_instructional: เขต/อำเภอยาวเกินไป (สูงสุด %{limit} ตัวอักษร)
             too_long_informative: เขต/อำเภอยาวเกินไป
             contains_emojis_instructional: เขต/อำเภอต้องไม่มีอีโมจิ
             contains_emojis_informative: เขต/อำเภอต้องไม่มีอีโมจิ
@@ -421,11 +421,11 @@ th:
             contains_html_tags_informative: เขต/อำเภอต้องไม่มีแท็ก HTML
             contains_url_instructional: เขต/อำเภอต้องไม่มี URL
             contains_url_informative: เขต/อำเภอต้องไม่มี URL
-            unknown_for_city_instructional: โปรดระบุชื่อเขต/อำเภอที่ถูกต้องสำหรับ
+            unknown_for_city_instructional: โปรดป้อนชื่อเขต/อำเภอที่ถูกต้องสำหรับ
               %{city}
-            unknown_for_city_informative: โปรดระบุชื่อเขต/อำเภอที่ถูกต้องสำหรับ %{city}
-            unknown_for_zip_instructional: โปรดระบุชื่อเขต/อำเภอที่ถูกต้องสำหรับ %{zip}
-            unknown_for_zip_informative: โปรดระบุชื่อเขต/อำเภอที่ถูกต้องสำหรับ %{zip}
+            unknown_for_city_informative: โปรดป้อนชื่อเขต/อำเภอที่ถูกต้องสำหรับ %{city}
+            unknown_for_zip_instructional: โปรดป้อนชื่อเขต/อำเภอที่ถูกต้องสำหรับ %{zip}
+            unknown_for_zip_informative: โปรดป้อนชื่อเขต/อำเภอที่ถูกต้องสำหรับ %{zip}
             unknown_for_address_instructional: เขต/อำเภออาจไม่ถูกต้อง
             unknown_for_address_informative: เขต/อำเภออาจไม่ถูกต้อง
           warnings:
@@ -435,9 +435,9 @@ th:
             default: แขวง/ตำบล
             optional: แขวง/ตำบล (ไม่บังคับ)
           errors:
-            blank_instructional: โปรดระบุแขวง/ตำบล
-            blank_informative: ไม่มีแขวง/ตำบล
-            too_long_instructional: แขวง/ตำบลยาวเกินไป (สูงสุด %{limit} อักขระ)
+            blank_instructional: โปรดป้อนแขวง/ตำบล
+            blank_informative: ไม่ได้ระบุแขวง/ตำบล
+            too_long_instructional: แขวง/ตำบลยาวเกินไป (สูงสุด %{limit} ตัวอักษร)
             too_long_informative: แขวง/ตำบลยาวเกินไป
             contains_emojis_instructional: แขวง/ตำบลต้องไม่มีอีโมจิ
             contains_emojis_informative: แขวง/ตำบลต้องไม่มีอีโมจิ
@@ -454,11 +454,11 @@ th:
             contains_html_tags_informative: แขวง/ตำบลต้องไม่มีแท็ก HTML
             contains_url_instructional: แขวง/ตำบลต้องไม่มี URL
             contains_url_informative: แขวง/ตำบลต้องไม่มี URL
-            unknown_for_city_instructional: โปรดระบุชื่อแขวง/ตำบลที่ถูกต้องสำหรับ
+            unknown_for_city_instructional: โปรดป้อนชื่อแขวง/ตำบลที่ถูกต้องสำหรับ
               %{city}
-            unknown_for_city_informative: โปรดระบุชื่อแขวง/ตำบลที่ถูกต้องสำหรับ %{city}
-            unknown_for_zip_instructional: โปรดระบุชื่อแขวง/ตำบลที่ถูกต้องสำหรับ %{zip}
-            unknown_for_zip_informative: โปรดระบุชื่อแขวง/ตำบลที่ถูกต้องสำหรับ %{zip}
+            unknown_for_city_informative: โปรดป้อนชื่อแขวง/ตำบลที่ถูกต้องสำหรับ %{city}
+            unknown_for_zip_instructional: โปรดป้อนชื่อแขวง/ตำบลที่ถูกต้องสำหรับ %{zip}
+            unknown_for_zip_informative: โปรดป้อนชื่อแขวง/ตำบลที่ถูกต้องสำหรับ %{zip}
             unknown_for_address_instructional: แขวง/ตำบลอาจไม่ถูกต้อง
             unknown_for_address_informative: แขวง/ตำบลอาจไม่ถูกต้อง
           warnings:

--- a/data/regions/_default/tr.yml
+++ b/data/regions/_default/tr.yml
@@ -454,7 +454,7 @@ tr:
           errors:
             blank_instructional: Bir ilçe girin
             blank_informative: İlçe eksik
-            too_long_instructional: İlçe çok uzun (en fazla %{limit} karakter)
+            too_long_instructional: İlçe çok uzun (maksimum %{limit} karakter)
             too_long_informative: İlçe çok uzun
             contains_emojis_instructional: İlçe emoji içeremez
             contains_emojis_informative: İlçe emoji içeremez
@@ -488,7 +488,7 @@ tr:
           errors:
             blank_instructional: Bir semt girin
             blank_informative: Semt eksik
-            too_long_instructional: Semt çok uzun (en fazla %{limit} karakter)
+            too_long_instructional: Semt çok uzun (maksimum %{limit} karakter)
             too_long_informative: Semt çok uzun
             contains_emojis_instructional: Semt emoji içeremez
             contains_emojis_informative: Semt emoji içeremez

--- a/data/regions/_default/tr.yml
+++ b/data/regions/_default/tr.yml
@@ -447,3 +447,71 @@ tr:
           errors:
             may_not_exist_instructional: Adres bulunamadı veya mevcut değil
             may_not_exist_informative: Adres bulunamadı
+        district:
+          label:
+            default: İlçe
+            optional: İlçe (isteğe bağlı)
+          errors:
+            blank_instructional: Bir ilçe girin
+            blank_informative: İlçe eksik
+            too_long_instructional: İlçe çok uzun (en fazla %{limit} karakter)
+            too_long_informative: İlçe çok uzun
+            contains_emojis_instructional: İlçe emoji içeremez
+            contains_emojis_informative: İlçe emoji içeremez
+            contains_mathematical_symbols_instructional: İlçe matematiksel semboller
+              içeremez
+            contains_mathematical_symbols_informative: İlçe matematiksel semboller
+              içeremez
+            contains_restricted_characters_instructional: İlçe yalnızca harf, sayı,
+              yerel karakter ve özel karakter içerebilir
+            contains_restricted_characters_informative: İlçe kısıtlanmış karakterler
+              içeremez
+            contains_too_many_words_instructional: İlçe %{word_count} kelimeden az
+              olmalıdır
+            contains_too_many_words_informative: İlçe %{word_count} kelimeden az olmalıdır
+            contains_html_tags_instructional: İlçe HTML etiketleri içeremez
+            contains_html_tags_informative: İlçe HTML etiketleri içeremez
+            contains_url_instructional: İlçe URL içeremez
+            contains_url_informative: İlçe URL içeremez
+            unknown_for_city_instructional: "%{city} için geçerli bir ilçe adı girin"
+            unknown_for_city_informative: "%{city} için geçerli bir ilçe adı girin"
+            unknown_for_zip_instructional: "%{zip} için geçerli bir ilçe adı girin"
+            unknown_for_zip_informative: "%{zip} için geçerli bir ilçe adı girin"
+            unknown_for_address_instructional: İlçe yanlış olabilir
+            unknown_for_address_informative: İlçe yanlış olabilir
+          warnings:
+            contains_too_many_words: İlçenin %{word_count} kelimeden az olması önerilir
+        subdistrict:
+          label:
+            default: Semt
+            optional: Semt (isteğe bağlı)
+          errors:
+            blank_instructional: Bir semt girin
+            blank_informative: Semt eksik
+            too_long_instructional: Semt çok uzun (en fazla %{limit} karakter)
+            too_long_informative: Semt çok uzun
+            contains_emojis_instructional: Semt emoji içeremez
+            contains_emojis_informative: Semt emoji içeremez
+            contains_mathematical_symbols_instructional: Semt matematiksel semboller
+              içeremez
+            contains_mathematical_symbols_informative: Semt matematiksel semboller
+              içeremez
+            contains_restricted_characters_instructional: Semt yalnızca harf, sayı,
+              yerel karakter ve özel karakter içerebilir
+            contains_restricted_characters_informative: Semt kısıtlanmış karakterler
+              içeremez
+            contains_too_many_words_instructional: Semt %{word_count} kelimeden az
+              olmalıdır
+            contains_too_many_words_informative: Semt %{word_count} kelimeden az olmalıdır
+            contains_html_tags_instructional: Semt HTML etiketleri içeremez
+            contains_html_tags_informative: Semt HTML etiketleri içeremez
+            contains_url_instructional: Semt URL içeremez
+            contains_url_informative: Semt URL içeremez
+            unknown_for_city_instructional: "%{city} için geçerli bir semt adı girin"
+            unknown_for_city_informative: "%{city} için geçerli bir semt adı girin"
+            unknown_for_zip_instructional: "%{zip} için geçerli bir semt adı girin"
+            unknown_for_zip_informative: "%{zip} için geçerli bir semt adı girin"
+            unknown_for_address_instructional: Semt yanlış olabilir
+            unknown_for_address_informative: Semt yanlış olabilir
+          warnings:
+            contains_too_many_words: Semtin %{word_count} kelimeden az olması önerilir

--- a/data/regions/_default/vi.yml
+++ b/data/regions/_default/vi.yml
@@ -457,14 +457,16 @@ vi:
             blank_informative: Thiếu quận/huyện
             too_long_instructional: Quận/huyện quá dài (tối đa %{limit} ký tự)
             too_long_informative: Quận/huyện quá dài
-            contains_emojis_instructional: Quận/huyện không được chứa emoji
-            contains_emojis_informative: Quận/huyện không được chứa emoji
+            contains_emojis_instructional: Quận/huyện không được chứa biểu tượng cảm
+              xúc
+            contains_emojis_informative: Quận/huyện không được chứa biểu tượng cảm
+              xúc
             contains_mathematical_symbols_instructional: Quận/huyện không được chứa
               ký hiệu toán học
             contains_mathematical_symbols_informative: Quận/huyện không được chứa
               ký hiệu toán học
-            contains_restricted_characters_instructional: Quận/huyện chỉ được chứa
-              chữ cái, chữ số, ký tự địa phương và ký tự đặc biệt
+            contains_restricted_characters_instructional: Quận/huyện chỉ có thể chứa
+              chữ cái, số, ký tự địa phương và ký tự đặc biệt
             contains_restricted_characters_informative: Quận/huyện không được chứa
               ký tự bị hạn chế
             contains_too_many_words_instructional: Quận/huyện phải có ít hơn %{word_count}
@@ -492,14 +494,16 @@ vi:
             blank_informative: Thiếu phường/xã
             too_long_instructional: Phường/xã quá dài (tối đa %{limit} ký tự)
             too_long_informative: Phường/xã quá dài
-            contains_emojis_instructional: Phường/xã không được chứa emoji
-            contains_emojis_informative: Phường/xã không được chứa emoji
+            contains_emojis_instructional: Phường/xã không được chứa biểu tượng cảm
+              xúc
+            contains_emojis_informative: Phường/xã không được chứa biểu tượng cảm
+              xúc
             contains_mathematical_symbols_instructional: Phường/xã không được chứa
               ký hiệu toán học
             contains_mathematical_symbols_informative: Phường/xã không được chứa ký
               hiệu toán học
-            contains_restricted_characters_instructional: Phường/xã chỉ được chứa
-              chữ cái, chữ số, ký tự địa phương và ký tự đặc biệt
+            contains_restricted_characters_instructional: Phường/xã chỉ có thể chứa
+              chữ cái, số, ký tự địa phương và ký tự đặc biệt
             contains_restricted_characters_informative: Phường/xã không được chứa
               ký tự bị hạn chế
             contains_too_many_words_instructional: Phường/xã phải có ít hơn %{word_count}

--- a/data/regions/_default/vi.yml
+++ b/data/regions/_default/vi.yml
@@ -448,3 +448,73 @@ vi:
             may_not_exist_instructional: Không tìm thấy địa chỉ hoặc địa chỉ không
               tồn tại
             may_not_exist_informative: Không tìm thấy địa chỉ
+        district:
+          label:
+            default: Quận/huyện
+            optional: Quận/huyện (tùy chọn)
+          errors:
+            blank_instructional: Nhập quận/huyện
+            blank_informative: Thiếu quận/huyện
+            too_long_instructional: Quận/huyện quá dài (tối đa %{limit} ký tự)
+            too_long_informative: Quận/huyện quá dài
+            contains_emojis_instructional: Quận/huyện không được chứa emoji
+            contains_emojis_informative: Quận/huyện không được chứa emoji
+            contains_mathematical_symbols_instructional: Quận/huyện không được chứa
+              ký hiệu toán học
+            contains_mathematical_symbols_informative: Quận/huyện không được chứa
+              ký hiệu toán học
+            contains_restricted_characters_instructional: Quận/huyện chỉ được chứa
+              chữ cái, chữ số, ký tự địa phương và ký tự đặc biệt
+            contains_restricted_characters_informative: Quận/huyện không được chứa
+              ký tự bị hạn chế
+            contains_too_many_words_instructional: Quận/huyện phải có ít hơn %{word_count}
+              từ
+            contains_too_many_words_informative: Quận/huyện phải có ít hơn %{word_count}
+              từ
+            contains_html_tags_instructional: Quận/huyện không được chứa thẻ HTML
+            contains_html_tags_informative: Quận/huyện không được chứa thẻ HTML
+            contains_url_instructional: Quận/huyện không được chứa URL
+            contains_url_informative: Quận/huyện không được chứa URL
+            unknown_for_city_instructional: Nhập tên quận/huyện hợp lệ cho %{city}
+            unknown_for_city_informative: Nhập tên quận/huyện hợp lệ cho %{city}
+            unknown_for_zip_instructional: Nhập tên quận/huyện hợp lệ cho %{zip}
+            unknown_for_zip_informative: Nhập tên quận/huyện hợp lệ cho %{zip}
+            unknown_for_address_instructional: Quận/huyện có thể không chính xác
+            unknown_for_address_informative: Quận/huyện có thể không chính xác
+          warnings:
+            contains_too_many_words: Quận/huyện nên có ít hơn %{word_count} từ
+        subdistrict:
+          label:
+            default: Phường/xã
+            optional: Phường/xã (tùy chọn)
+          errors:
+            blank_instructional: Nhập phường/xã
+            blank_informative: Thiếu phường/xã
+            too_long_instructional: Phường/xã quá dài (tối đa %{limit} ký tự)
+            too_long_informative: Phường/xã quá dài
+            contains_emojis_instructional: Phường/xã không được chứa emoji
+            contains_emojis_informative: Phường/xã không được chứa emoji
+            contains_mathematical_symbols_instructional: Phường/xã không được chứa
+              ký hiệu toán học
+            contains_mathematical_symbols_informative: Phường/xã không được chứa ký
+              hiệu toán học
+            contains_restricted_characters_instructional: Phường/xã chỉ được chứa
+              chữ cái, chữ số, ký tự địa phương và ký tự đặc biệt
+            contains_restricted_characters_informative: Phường/xã không được chứa
+              ký tự bị hạn chế
+            contains_too_many_words_instructional: Phường/xã phải có ít hơn %{word_count}
+              từ
+            contains_too_many_words_informative: Phường/xã phải có ít hơn %{word_count}
+              từ
+            contains_html_tags_instructional: Phường/xã không được chứa thẻ HTML
+            contains_html_tags_informative: Phường/xã không được chứa thẻ HTML
+            contains_url_instructional: Phường/xã không được chứa URL
+            contains_url_informative: Phường/xã không được chứa URL
+            unknown_for_city_instructional: Nhập tên phường/xã hợp lệ cho %{city}
+            unknown_for_city_informative: Nhập tên phường/xã hợp lệ cho %{city}
+            unknown_for_zip_instructional: Nhập tên phường/xã hợp lệ cho %{zip}
+            unknown_for_zip_informative: Nhập tên phường/xã hợp lệ cho %{zip}
+            unknown_for_address_instructional: Phường/xã có thể không chính xác
+            unknown_for_address_informative: Phường/xã có thể không chính xác
+          warnings:
+            contains_too_many_words: Phường/xã nên có ít hơn %{word_count} từ

--- a/data/regions/_default/zh-CN.yml
+++ b/data/regions/_default/zh-CN.yml
@@ -358,28 +358,28 @@ zh-CN:
           errors:
             blank_instructional: 输入区
             blank_informative: 缺少区
-            too_long_instructional: 区名称过长（最多 %{limit} 个字符）
-            too_long_informative: 区名称过长
+            too_long_instructional: 区太长（最多 %{limit} 个字符）
+            too_long_informative: 区太长
             contains_emojis_instructional: 区不能包含表情符号
             contains_emojis_informative: 区不能包含表情符号
             contains_mathematical_symbols_instructional: 区不能包含数学符号
             contains_mathematical_symbols_informative: 区不能包含数学符号
             contains_restricted_characters_instructional: 区只能包含字母、数字、本地字符和特殊字符
             contains_restricted_characters_informative: 区不能包含受限字符
-            contains_too_many_words_instructional: 区名称必须少于 %{word_count} 个字词
-            contains_too_many_words_informative: 区名称必须少于 %{word_count} 个字词
+            contains_too_many_words_instructional: 区必须少于 %{word_count} 个词
+            contains_too_many_words_informative: 区必须少于 %{word_count} 个词
             contains_html_tags_instructional: 区不能包含 HTML 标签
             contains_html_tags_informative: 区不能包含 HTML 标签
             contains_url_instructional: 区不能包含 URL
             contains_url_informative: 区不能包含 URL
-            unknown_for_city_instructional: 输入 %{city} 的有效区名称
-            unknown_for_city_informative: 输入 %{city} 的有效区名称
-            unknown_for_zip_instructional: 输入 %{zip} 的有效区名称
-            unknown_for_zip_informative: 输入 %{zip} 的有效区名称
+            unknown_for_city_instructional: 为 %{city} 输入有效的区名称
+            unknown_for_city_informative: 为 %{city} 输入有效的区名称
+            unknown_for_zip_instructional: 为 %{zip} 输入有效的区名称
+            unknown_for_zip_informative: 为 %{zip} 输入有效的区名称
             unknown_for_address_instructional: 区可能不正确
             unknown_for_address_informative: 区可能不正确
           warnings:
-            contains_too_many_words: 建议区名称少于 %{word_count} 个字词
+            contains_too_many_words: 建议区少于 %{word_count} 个词
         subdistrict:
           label:
             default: 分区
@@ -387,25 +387,25 @@ zh-CN:
           errors:
             blank_instructional: 输入分区
             blank_informative: 缺少分区
-            too_long_instructional: 分区名称过长（最多 %{limit} 个字符）
-            too_long_informative: 分区名称过长
+            too_long_instructional: 分区太长（最多 %{limit} 个字符）
+            too_long_informative: 分区太长
             contains_emojis_instructional: 分区不能包含表情符号
             contains_emojis_informative: 分区不能包含表情符号
             contains_mathematical_symbols_instructional: 分区不能包含数学符号
             contains_mathematical_symbols_informative: 分区不能包含数学符号
             contains_restricted_characters_instructional: 分区只能包含字母、数字、本地字符和特殊字符
             contains_restricted_characters_informative: 分区不能包含受限字符
-            contains_too_many_words_instructional: 分区名称必须少于 %{word_count} 个字词
-            contains_too_many_words_informative: 分区名称必须少于 %{word_count} 个字词
+            contains_too_many_words_instructional: 分区必须少于 %{word_count} 个词
+            contains_too_many_words_informative: 分区必须少于 %{word_count} 个词
             contains_html_tags_instructional: 分区不能包含 HTML 标签
             contains_html_tags_informative: 分区不能包含 HTML 标签
             contains_url_instructional: 分区不能包含 URL
             contains_url_informative: 分区不能包含 URL
-            unknown_for_city_instructional: 输入 %{city} 的有效分区名称
-            unknown_for_city_informative: 输入 %{city} 的有效分区名称
-            unknown_for_zip_instructional: 输入 %{zip} 的有效分区名称
-            unknown_for_zip_informative: 输入 %{zip} 的有效分区名称
+            unknown_for_city_instructional: 为 %{city} 输入有效的分区名称
+            unknown_for_city_informative: 为 %{city} 输入有效的分区名称
+            unknown_for_zip_instructional: 为 %{zip} 输入有效的分区名称
+            unknown_for_zip_informative: 为 %{zip} 输入有效的分区名称
             unknown_for_address_instructional: 分区可能不正确
             unknown_for_address_informative: 分区可能不正确
           warnings:
-            contains_too_many_words: 建议分区名称少于 %{word_count} 个字词
+            contains_too_many_words: 建议分区少于 %{word_count} 个词

--- a/data/regions/_default/zh-CN.yml
+++ b/data/regions/_default/zh-CN.yml
@@ -351,3 +351,61 @@ zh-CN:
           errors:
             may_not_exist_instructional: 找不到地址或地址不存在
             may_not_exist_informative: 找不到地址
+        district:
+          label:
+            default: 区
+            optional: 区（可选）
+          errors:
+            blank_instructional: 输入区
+            blank_informative: 缺少区
+            too_long_instructional: 区名称过长（最多 %{limit} 个字符）
+            too_long_informative: 区名称过长
+            contains_emojis_instructional: 区不能包含表情符号
+            contains_emojis_informative: 区不能包含表情符号
+            contains_mathematical_symbols_instructional: 区不能包含数学符号
+            contains_mathematical_symbols_informative: 区不能包含数学符号
+            contains_restricted_characters_instructional: 区只能包含字母、数字、本地字符和特殊字符
+            contains_restricted_characters_informative: 区不能包含受限字符
+            contains_too_many_words_instructional: 区名称必须少于 %{word_count} 个字词
+            contains_too_many_words_informative: 区名称必须少于 %{word_count} 个字词
+            contains_html_tags_instructional: 区不能包含 HTML 标签
+            contains_html_tags_informative: 区不能包含 HTML 标签
+            contains_url_instructional: 区不能包含 URL
+            contains_url_informative: 区不能包含 URL
+            unknown_for_city_instructional: 输入 %{city} 的有效区名称
+            unknown_for_city_informative: 输入 %{city} 的有效区名称
+            unknown_for_zip_instructional: 输入 %{zip} 的有效区名称
+            unknown_for_zip_informative: 输入 %{zip} 的有效区名称
+            unknown_for_address_instructional: 区可能不正确
+            unknown_for_address_informative: 区可能不正确
+          warnings:
+            contains_too_many_words: 建议区名称少于 %{word_count} 个字词
+        subdistrict:
+          label:
+            default: 分区
+            optional: 分区（可选）
+          errors:
+            blank_instructional: 输入分区
+            blank_informative: 缺少分区
+            too_long_instructional: 分区名称过长（最多 %{limit} 个字符）
+            too_long_informative: 分区名称过长
+            contains_emojis_instructional: 分区不能包含表情符号
+            contains_emojis_informative: 分区不能包含表情符号
+            contains_mathematical_symbols_instructional: 分区不能包含数学符号
+            contains_mathematical_symbols_informative: 分区不能包含数学符号
+            contains_restricted_characters_instructional: 分区只能包含字母、数字、本地字符和特殊字符
+            contains_restricted_characters_informative: 分区不能包含受限字符
+            contains_too_many_words_instructional: 分区名称必须少于 %{word_count} 个字词
+            contains_too_many_words_informative: 分区名称必须少于 %{word_count} 个字词
+            contains_html_tags_instructional: 分区不能包含 HTML 标签
+            contains_html_tags_informative: 分区不能包含 HTML 标签
+            contains_url_instructional: 分区不能包含 URL
+            contains_url_informative: 分区不能包含 URL
+            unknown_for_city_instructional: 输入 %{city} 的有效分区名称
+            unknown_for_city_informative: 输入 %{city} 的有效分区名称
+            unknown_for_zip_instructional: 输入 %{zip} 的有效分区名称
+            unknown_for_zip_informative: 输入 %{zip} 的有效分区名称
+            unknown_for_address_instructional: 分区可能不正确
+            unknown_for_address_informative: 分区可能不正确
+          warnings:
+            contains_too_many_words: 建议分区名称少于 %{word_count} 个字词

--- a/data/regions/_default/zh-TW.yml
+++ b/data/regions/_default/zh-TW.yml
@@ -353,59 +353,59 @@ zh-TW:
             may_not_exist_informative: 找不到地址
         district:
           label:
-            default: 行政區
-            optional: 行政區 (選填)
+            default: 地區
+            optional: 地區 (選填)
           errors:
-            blank_instructional: 輸入行政區
-            blank_informative: 缺少行政區
-            too_long_instructional: 行政區太長 (最多 %{limit} 個字元)
-            too_long_informative: 行政區太長
-            contains_emojis_instructional: 行政區不可包含表情符號
-            contains_emojis_informative: 行政區不可包含表情符號
-            contains_mathematical_symbols_instructional: 行政區不可包含數學符號
-            contains_mathematical_symbols_informative: 行政區不可包含數學符號
-            contains_restricted_characters_instructional: 行政區僅可包含字母、數字、本地字元及特殊字元
-            contains_restricted_characters_informative: 行政區不可包含受限字元
-            contains_too_many_words_instructional: 行政區的字數必須少於 %{word_count} 個字
-            contains_too_many_words_informative: 行政區的字數必須少於 %{word_count} 個字
-            contains_html_tags_instructional: 行政區不可包含 HTML 標籤
-            contains_html_tags_informative: 行政區不可包含 HTML 標籤
-            contains_url_instructional: 行政區不可包含網址
-            contains_url_informative: 行政區不可包含網址
-            unknown_for_city_instructional: 輸入 %{city} 的有效行政區名稱
-            unknown_for_city_informative: 輸入 %{city} 的有效行政區名稱
-            unknown_for_zip_instructional: 輸入 %{zip} 的有效行政區名稱
-            unknown_for_zip_informative: 輸入 %{zip} 的有效行政區名稱
-            unknown_for_address_instructional: 行政區可能不正確
-            unknown_for_address_informative: 行政區可能不正確
+            blank_instructional: 輸入地區
+            blank_informative: 遺漏地區
+            too_long_instructional: 地區名稱過長 (最多 %{limit} 個字元)
+            too_long_informative: 地區名稱過長
+            contains_emojis_instructional: 地區不能包含表情符號
+            contains_emojis_informative: 地區不能包含表情符號
+            contains_mathematical_symbols_instructional: 地區不能包含數學符號
+            contains_mathematical_symbols_informative: 地區不能包含數學符號
+            contains_restricted_characters_instructional: 地區僅能包含字母、數字、當地字元和特殊字元
+            contains_restricted_characters_informative: 地區不能包含受限字元
+            contains_too_many_words_instructional: 地區名稱必須少於 %{word_count} 個字
+            contains_too_many_words_informative: 地區名稱必須少於 %{word_count} 個字
+            contains_html_tags_instructional: 地區不能包含 HTML 標籤
+            contains_html_tags_informative: 地區不能包含 HTML 標籤
+            contains_url_instructional: 地區不能包含網址
+            contains_url_informative: 地區不能包含網址
+            unknown_for_city_instructional: 輸入 %{city} 的有效地區名稱
+            unknown_for_city_informative: 輸入 %{city} 的有效地區名稱
+            unknown_for_zip_instructional: 輸入 %{zip} 的有效地區名稱
+            unknown_for_zip_informative: 輸入 %{zip} 的有效地區名稱
+            unknown_for_address_instructional: 地區可能不正確
+            unknown_for_address_informative: 地區可能不正確
           warnings:
-            contains_too_many_words: 建議行政區的字數少於 %{word_count} 個字
+            contains_too_many_words: 地區名稱建議少於 %{word_count} 個字
         subdistrict:
           label:
-            default: 分區
-            optional: 分區 (選填)
+            default: 次分區
+            optional: 次分區 (選填)
           errors:
-            blank_instructional: 輸入分區
-            blank_informative: 缺少分區
-            too_long_instructional: 分區太長 (最多 %{limit} 個字元)
-            too_long_informative: 分區太長
-            contains_emojis_instructional: 分區不可包含表情符號
-            contains_emojis_informative: 分區不可包含表情符號
-            contains_mathematical_symbols_instructional: 分區不可包含數學符號
-            contains_mathematical_symbols_informative: 分區不可包含數學符號
-            contains_restricted_characters_instructional: 分區僅可包含字母、數字、本地字元及特殊字元
-            contains_restricted_characters_informative: 分區不可包含受限字元
-            contains_too_many_words_instructional: 分區的字數必須少於 %{word_count} 個字
-            contains_too_many_words_informative: 分區的字數必須少於 %{word_count} 個字
-            contains_html_tags_instructional: 分區不可包含 HTML 標籤
-            contains_html_tags_informative: 分區不可包含 HTML 標籤
-            contains_url_instructional: 分區不可包含網址
-            contains_url_informative: 分區不可包含網址
-            unknown_for_city_instructional: 輸入 %{city} 的有效分區名稱
-            unknown_for_city_informative: 輸入 %{city} 的有效分區名稱
-            unknown_for_zip_instructional: 輸入 %{zip} 的有效分區名稱
-            unknown_for_zip_informative: 輸入 %{zip} 的有效分區名稱
-            unknown_for_address_instructional: 分區可能不正確
-            unknown_for_address_informative: 分區可能不正確
+            blank_instructional: 輸入次分區
+            blank_informative: 遺漏次分區
+            too_long_instructional: 次分區名稱過長 (最多 %{limit} 個字元)
+            too_long_informative: 次分區名稱過長
+            contains_emojis_instructional: 次分區不能包含表情符號
+            contains_emojis_informative: 次分區不能包含表情符號
+            contains_mathematical_symbols_instructional: 次分區不能包含數學符號
+            contains_mathematical_symbols_informative: 次分區不能包含數學符號
+            contains_restricted_characters_instructional: 次分區僅能包含字母、數字、當地字元和特殊字元
+            contains_restricted_characters_informative: 次分區不能包含受限字元
+            contains_too_many_words_instructional: 次分區名稱必須少於 %{word_count} 個字
+            contains_too_many_words_informative: 次分區名稱必須少於 %{word_count} 個字
+            contains_html_tags_instructional: 次分區不能包含 HTML 標籤
+            contains_html_tags_informative: 次分區不能包含 HTML 標籤
+            contains_url_instructional: 次分區不能包含網址
+            contains_url_informative: 次分區不能包含網址
+            unknown_for_city_instructional: 輸入 %{city} 的有效次分區名稱
+            unknown_for_city_informative: 輸入 %{city} 的有效次分區名稱
+            unknown_for_zip_instructional: 輸入 %{zip} 的有效次分區名稱
+            unknown_for_zip_informative: 輸入 %{zip} 的有效次分區名稱
+            unknown_for_address_instructional: 次分區可能不正確
+            unknown_for_address_informative: 次分區可能不正確
           warnings:
-            contains_too_many_words: 建議分區的字數少於 %{word_count} 個字
+            contains_too_many_words: 次分區名稱建議少於 %{word_count} 個字

--- a/data/regions/_default/zh-TW.yml
+++ b/data/regions/_default/zh-TW.yml
@@ -351,3 +351,61 @@ zh-TW:
           errors:
             may_not_exist_instructional: 找不到地址或地址不存在
             may_not_exist_informative: 找不到地址
+        district:
+          label:
+            default: 行政區
+            optional: 行政區 (選填)
+          errors:
+            blank_instructional: 輸入行政區
+            blank_informative: 缺少行政區
+            too_long_instructional: 行政區太長 (最多 %{limit} 個字元)
+            too_long_informative: 行政區太長
+            contains_emojis_instructional: 行政區不可包含表情符號
+            contains_emojis_informative: 行政區不可包含表情符號
+            contains_mathematical_symbols_instructional: 行政區不可包含數學符號
+            contains_mathematical_symbols_informative: 行政區不可包含數學符號
+            contains_restricted_characters_instructional: 行政區僅可包含字母、數字、本地字元及特殊字元
+            contains_restricted_characters_informative: 行政區不可包含受限字元
+            contains_too_many_words_instructional: 行政區的字數必須少於 %{word_count} 個字
+            contains_too_many_words_informative: 行政區的字數必須少於 %{word_count} 個字
+            contains_html_tags_instructional: 行政區不可包含 HTML 標籤
+            contains_html_tags_informative: 行政區不可包含 HTML 標籤
+            contains_url_instructional: 行政區不可包含網址
+            contains_url_informative: 行政區不可包含網址
+            unknown_for_city_instructional: 輸入 %{city} 的有效行政區名稱
+            unknown_for_city_informative: 輸入 %{city} 的有效行政區名稱
+            unknown_for_zip_instructional: 輸入 %{zip} 的有效行政區名稱
+            unknown_for_zip_informative: 輸入 %{zip} 的有效行政區名稱
+            unknown_for_address_instructional: 行政區可能不正確
+            unknown_for_address_informative: 行政區可能不正確
+          warnings:
+            contains_too_many_words: 建議行政區的字數少於 %{word_count} 個字
+        subdistrict:
+          label:
+            default: 分區
+            optional: 分區 (選填)
+          errors:
+            blank_instructional: 輸入分區
+            blank_informative: 缺少分區
+            too_long_instructional: 分區太長 (最多 %{limit} 個字元)
+            too_long_informative: 分區太長
+            contains_emojis_instructional: 分區不可包含表情符號
+            contains_emojis_informative: 分區不可包含表情符號
+            contains_mathematical_symbols_instructional: 分區不可包含數學符號
+            contains_mathematical_symbols_informative: 分區不可包含數學符號
+            contains_restricted_characters_instructional: 分區僅可包含字母、數字、本地字元及特殊字元
+            contains_restricted_characters_informative: 分區不可包含受限字元
+            contains_too_many_words_instructional: 分區的字數必須少於 %{word_count} 個字
+            contains_too_many_words_informative: 分區的字數必須少於 %{word_count} 個字
+            contains_html_tags_instructional: 分區不可包含 HTML 標籤
+            contains_html_tags_informative: 分區不可包含 HTML 標籤
+            contains_url_instructional: 分區不可包含網址
+            contains_url_informative: 分區不可包含網址
+            unknown_for_city_instructional: 輸入 %{city} 的有效分區名稱
+            unknown_for_city_informative: 輸入 %{city} 的有效分區名稱
+            unknown_for_zip_instructional: 輸入 %{zip} 的有效分區名稱
+            unknown_for_zip_informative: 輸入 %{zip} 的有效分區名稱
+            unknown_for_address_instructional: 分區可能不正確
+            unknown_for_address_informative: 分區可能不正確
+          warnings:
+            contains_too_many_words: 建議分區的字數少於 %{word_count} 個字

--- a/lib/worldwide/address.rb
+++ b/lib/worldwide/address.rb
@@ -311,8 +311,6 @@ module Worldwide
         last_name: last_name,
         phone: phone,
         province: province_name,
-        district: district,
-        subdistrict: subdistrict,
         zip: zip,
       }
     end

--- a/lib/worldwide/address.rb
+++ b/lib/worldwide/address.rb
@@ -17,7 +17,9 @@ module Worldwide
       :street_name,
       :street_number,
       :line2,
-      :neighborhood
+      :neighborhood,
+      :district,
+      :subdistrict
 
     def initialize(
       first_name: nil,
@@ -33,7 +35,9 @@ module Worldwide
       street_name: nil,
       street_number: nil,
       line2: nil,
-      neighborhood: nil
+      neighborhood: nil,
+      district: nil,
+      subdistrict: nil
     )
       @first_name = first_name
       @last_name = last_name
@@ -49,6 +53,8 @@ module Worldwide
       @street_number = street_number
       @line2 = line2
       @neighborhood = neighborhood
+      @district = district
+      @subdistrict = subdistrict
     end
 
     def errors
@@ -305,6 +311,8 @@ module Worldwide
         last_name: last_name,
         phone: phone,
         province: province_name,
+        district: district,
+        subdistrict: subdistrict,
         zip: zip,
       }
     end

--- a/lib/worldwide/field.rb
+++ b/lib/worldwide/field.rb
@@ -16,6 +16,8 @@ module Worldwide
       :address2,
       :line2,
       :neighborhood,
+      :district,
+      :subdistrict,
       :city,
       :province,
       :zip,

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "1.24.2"
+  VERSION = "1.25.0"
 end

--- a/test/worldwide/address_test.rb
+++ b/test/worldwide/address_test.rb
@@ -49,19 +49,6 @@ module Worldwide
       assert_equal "Vila Madalena", address.subdistrict
     end
 
-    test "format fills district and subdistrict additional lines" do
-      address = Address.new(
-        district: "Centro",
-        subdistrict: "Vila Madalena",
-        country_code: "BR",
-      )
-
-      lines = address.format(additional_lines: ["{district}", "{subdistrict}"])
-
-      assert_includes lines, "Centro"
-      assert_includes lines, "Vila Madalena"
-    end
-
     test "omitted parameters default to `nil`, except for country_code" do
       address = Address.new
 

--- a/test/worldwide/address_test.rb
+++ b/test/worldwide/address_test.rb
@@ -38,6 +38,30 @@ module Worldwide
       assert_equal zip, address.zip
     end
 
+    test "can initialize an Address with district and subdistrict and read their values" do
+      address = Address.new(
+        district: "Centro",
+        subdistrict: "Vila Madalena",
+        country_code: "BR",
+      )
+
+      assert_equal "Centro", address.district
+      assert_equal "Vila Madalena", address.subdistrict
+    end
+
+    test "format fills district and subdistrict additional lines" do
+      address = Address.new(
+        district: "Centro",
+        subdistrict: "Vila Madalena",
+        country_code: "BR",
+      )
+
+      lines = address.format(additional_lines: ["{district}", "{subdistrict}"])
+
+      assert_includes lines, "Centro"
+      assert_includes lines, "Vila Madalena"
+    end
+
     test "omitted parameters default to `nil`, except for country_code" do
       address = Address.new
 
@@ -48,6 +72,8 @@ module Worldwide
       assert_nil address.address2
       assert_nil address.city
       assert_nil address.province_code
+      assert_nil address.district
+      assert_nil address.subdistrict
       assert_nil address.zip
       assert_equal "ZZ", address.country_code
     end

--- a/test/worldwide/field_test.rb
+++ b/test/worldwide/field_test.rb
@@ -10,7 +10,13 @@ module Worldwide
         [:last_name, true],
         [:company, true],
         [:address1, true],
+        [:street_name, true],
+        [:street_number, true],
         [:address2, true],
+        [:line2, true],
+        [:neighborhood, true],
+        [:district, true],
+        [:subdistrict, true],
         [:city, true],
         [:province, true],
         [:zip, true],
@@ -99,6 +105,21 @@ module Worldwide
       assert_nil Worldwide.region(code: "CA").field(key: :first_name).error(code: :bogus_code_does_not_exist)
     end
 
+    test "district and subdistrict errors return expected values" do
+      [
+        [:br, :district, :blank, "Enter a district"],
+        [:kw, :district, :blank, "Enter a block"],
+        [:pe, :district, :blank, "Enter a district"],
+        [:pe, :subdistrict, :blank, "Enter a subdistrict"],
+      ].each do |country_code, field_key, error_code, expected|
+        assert_equal(
+          expected,
+          Worldwide.region(code: country_code).field(key: field_key).error(code: error_code),
+          "Expected #{field_key} error for country #{country_code} to be #{expected}",
+        )
+      end
+    end
+
     test "warning accepts parameters" do
       [
         [:en, :ca, "Address line 1 is recommended to have less than 15 words"],
@@ -132,6 +153,11 @@ module Worldwide
         [:de, :ae, :province, "Emirat"],
         [:ja, :jp, :province, "都道府県"],
         [:en, :jp, :province, "Prefecture"],
+        [:en, :br, :district, "District"],
+        [:en, :ph, :district, "Barangay"],
+        [:en, :kw, :district, "Block"],
+        [:en, :pe, :district, "District"],
+        [:en, :br, :subdistrict, "Subdistrict"],
       ].each do |locale, country_code, field_key, expected|
         assert_equal(
           expected,

--- a/test/worldwide/field_test.rb
+++ b/test/worldwide/field_test.rb
@@ -107,7 +107,7 @@ module Worldwide
 
     test "district and subdistrict errors return expected values" do
       [
-        [:br, :district, :blank, "Enter a district"],
+        [:br, :district, :blank, "Enter a neighborhood"],
         [:kw, :district, :blank, "Enter a block"],
         [:pe, :district, :blank, "Enter a district"],
         [:pe, :subdistrict, :blank, "Enter a subdistrict"],
@@ -153,7 +153,7 @@ module Worldwide
         [:de, :ae, :province, "Emirat"],
         [:ja, :jp, :province, "都道府県"],
         [:en, :jp, :province, "Prefecture"],
-        [:en, :br, :district, "District"],
+        [:en, :br, :district, "Neighborhood"],
         [:en, :ph, :district, "Barangay"],
         [:en, :kw, :district, "Block"],
         [:en, :pe, :district, "District"],

--- a/test/worldwide/region_yml_consistency_test.rb
+++ b/test/worldwide/region_yml_consistency_test.rb
@@ -126,7 +126,7 @@ module Worldwide
 
     test "format_extended keys must belong to a limited set of required and allowed keys" do
       required_format_keys = ["{firstName}", "{lastName}", "{company}", "{country}", "{phone}"]
-      allowed_format_keys = ["{address1}", "{address2}", "{streetName}", "{streetNumber}", "{line2}", "{neighborhood}", "{city}", "{zip}", "{province}"]
+      allowed_format_keys = ["{address1}", "{address2}", "{streetName}", "{streetNumber}", "{line2}", "{neighborhood}", "{district}", "{subdistrict}", "{city}", "{zip}", "{province}"]
 
       Regions.all.select(&:country?).each do |country|
         next if country.format_extended.blank?
@@ -144,7 +144,7 @@ module Worldwide
     end
 
     test "additional_address_fields names must belong to a limited set of allowed names" do
-      allowed_names = ["streetName", "streetNumber", "line2", "neighborhood"]
+      allowed_names = ["streetName", "streetNumber", "line2", "neighborhood", "district", "subdistrict"]
 
       Regions.all.select(&:country?).each do |country|
         next if country.additional_address_fields.blank?

--- a/test/worldwide/region_yml_consistency_test.rb
+++ b/test/worldwide/region_yml_consistency_test.rb
@@ -126,7 +126,7 @@ module Worldwide
 
     test "format_extended keys must belong to a limited set of required and allowed keys" do
       required_format_keys = ["{firstName}", "{lastName}", "{company}", "{country}", "{phone}"]
-      allowed_format_keys = ["{address1}", "{address2}", "{streetName}", "{streetNumber}", "{line2}", "{neighborhood}", "{district}", "{subdistrict}", "{city}", "{zip}", "{province}"]
+      allowed_format_keys = ["{address1}", "{address2}", "{streetName}", "{streetNumber}", "{line2}", "{neighborhood}", "{city}", "{zip}", "{province}"]
 
       Regions.all.select(&:country?).each do |country|
         next if country.format_extended.blank?
@@ -144,7 +144,7 @@ module Worldwide
     end
 
     test "additional_address_fields names must belong to a limited set of allowed names" do
-      allowed_names = ["streetName", "streetNumber", "line2", "neighborhood", "district", "subdistrict"]
+      allowed_names = ["streetName", "streetNumber", "line2", "neighborhood"]
 
       Regions.all.select(&:country?).each do |country|
         next if country.additional_address_fields.blank?


### PR DESCRIPTION
### What are you trying to accomplish?
<!--
Link to an issue or provide enough context so that someone new can understand the 'why' behind this change.
-->

Add support for `district` and `subdistrict` as address fields, enabling regions to collect and validate these address components. This is needed to support address formats in countries where district and subdistrict are meaningful parts of a postal address (e.g., Brazil, Philippines, Kuwait, Peru).

Also cut a new minor version.

### What approach did you choose and why?
<!--
There are many ways to solve a problem. How did you approach this problem and why?
-->

`district` and `subdistrict` were added following the same pattern already established by neighborhood, street_name, etc -
- Both fields are added as attributes on the `Address` class with reader accessors and constructor parameters.
- Both are registered in `Field` as recognized field keys.
- Translations for validation error/warning messages are added


### What should reviewers focus on?
<!--
Outline anything you'd like reviewers to pay extra attention to. List open questions for discussion.
-->

Are the changes sufficient to introduce new error translations and labels to clients?

### The impact of these changes
<!--
Are there any specific impacts from this change that you'd like to call out?
-->

Consumers of this gem can now use district and subdistrict address fields with full label and validation message support. Existing addresses without these fields are unaffected, as both default to nil.

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

New tests cover:

- Initializing an Address with district and subdistrict and reading their values back.
- Verifying that format correctly fills {district} and {subdistrict} placeholders in additional lines.
- Confirming that nil is the default for both fields when omitted.
- Asserting correct error messages for district and subdistrict across BR, KW, PE, and PH.
- Asserting correct labels for district and subdistrict across multiple locales and countries.


<img width="642" height="252" alt="Screenshot 2026-05-22 at 5 44 45 PM" src="https://github.com/user-attachments/assets/c1921e78-a1a5-4318-a131-d0a7f8498e5c" />

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
