### PR TITLE
Release v1.25.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ---
 
+## [1.25.2] - 2026-07-02
+- Bump phonelib from 0.10.17 to 0.10.22 to pick up updated libphonenumber metadata.
+
 ## [1.25.1] - 2026-05-26
 - Update postal code expectations in Portugal to require seven digit postal code (XXXX-XXX) [#493](https://github.com/Shopify/worldwide/pull/493)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (1.25.1)
+    worldwide (1.25.2)
       activesupport (>= 7.0)
       i18n
       phonelib (~> 0.8)
@@ -66,7 +66,7 @@ GEM
     parser (3.3.0.5)
       ast (~> 2.4.1)
       racc
-    phonelib (0.10.17)
+    phonelib (0.10.22)
     prettier_print (1.2.0)
     pry (0.14.2)
       coderay (~> 1.1)

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "1.25.1"
+  VERSION = "1.25.2"
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Bump `phonelib` to the latest 0.10.22 and release a new `worldwide` version so downstream apps can pick up the updated libphonenumber metadata.

### Testing

All tests pass

### Checklist

* [x] I have added a CHANGELOG entry for this change
