### PR TITLE
Format Urdu percentages with a trailing % sign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Security in case of vulnerabilities.
 
 ## [Unreleased]
-- Add `ar`, `he`, and `ur` to `translation.yml` target languages so the Translation Platform generates RTL localizations of the region address data [#519](https://github.com/Shopify/worldwide/pull/519)
+- nil
 
 ---
+
+## [1.25.3] - 2026-07-08
+- Add `ar`, `he`, and `ur` to `translation.yml` target languages so the Translation Platform generates RTL localizations of the region address data [#519](https://github.com/Shopify/worldwide/pull/519)
+- Fixed: format Urdu (`ur`) percentages with a trailing % sign in numeric layout order (e.g. `2%` instead of `%2`), matching the existing Hebrew behaviour. [#518](https://github.com/Shopify/worldwide/pull/518)
 
 ## [1.25.2] - 2026-07-02
 - Bump phonelib from 0.10.17 to 0.10.22 to pick up updated libphonenumber metadata.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (1.25.2)
+    worldwide (1.25.3)
       activesupport (>= 7.0)
       i18n
       phonelib (~> 0.8)

--- a/lib/worldwide/numbers.rb
+++ b/lib/worldwide/numbers.rb
@@ -8,6 +8,11 @@ module Worldwide
     COMPACT_DECIMAL_BASE_KEY = "numbers.latn.formats.decimal.patterns"
     DEFAULT_COMPACT_PATTERN = "0"
 
+    # Right-to-left locales that CLDR records with a trailing % sign in character order
+    # (implying a leading % sign in numeric layout order) but which actually use a
+    # trailing % sign in numeric layout order (e.g. "75%", "2%").
+    TRAILING_PERCENT_SIGN_LOCALES = ["he", "ur"].freeze
+
     def initialize(locale: I18n.locale)
       @locale = locale.to_sym
     end
@@ -291,10 +296,11 @@ module Worldwide
       second = [digit_pos, percent_pos].max
 
       spacing = format[(first + 1)..(second - 1)]
-      trailing = if locale.to_s.downcase.split("-").first == "he"
-        # CLDR says Hebrew is right-to-left with a trailing % sign in character order,
-        # which would imply a prefix % sign in numeric layout order, but Hebrew uses
-        # a trailing % sign when considered in numeric layout order.  So, we override here.
+      trailing = if TRAILING_PERCENT_SIGN_LOCALES.include?(locale.to_s.downcase.split("-").first)
+        # CLDR records these right-to-left locales with a trailing % sign in character
+        # order, which would imply a prefix % sign in numeric layout order.  In practice
+        # these locales use a trailing % sign when considered in numeric layout order
+        # (e.g. Hebrew "75%", Urdu "2%"), so we override here.
         true
       elsif character_order == "right-to-left"
         digit_pos > percent_pos

--- a/lib/worldwide/numbers.rb
+++ b/lib/worldwide/numbers.rb
@@ -8,9 +8,8 @@ module Worldwide
     COMPACT_DECIMAL_BASE_KEY = "numbers.latn.formats.decimal.patterns"
     DEFAULT_COMPACT_PATTERN = "0"
 
-    # Right-to-left locales that CLDR records with a trailing % sign in character order
-    # (implying a leading % sign in numeric layout order) but which actually use a
-    # trailing % sign in numeric layout order (e.g. "75%", "2%").
+    # RTL locales that CLDR marks as leading % in numeric layout order, but which
+    # actually use a trailing % (e.g. "75%", "2%"). We override the placement for these.
     TRAILING_PERCENT_SIGN_LOCALES = ["he", "ur"].freeze
 
     def initialize(locale: I18n.locale)
@@ -297,10 +296,6 @@ module Worldwide
 
       spacing = format[(first + 1)..(second - 1)]
       trailing = if TRAILING_PERCENT_SIGN_LOCALES.include?(locale.to_s.downcase.split("-").first)
-        # CLDR records these right-to-left locales with a trailing % sign in character
-        # order, which would imply a prefix % sign in numeric layout order.  In practice
-        # these locales use a trailing % sign when considered in numeric layout order
-        # (e.g. Hebrew "75%", Urdu "2%"), so we override here.
         true
       elsif character_order == "right-to-left"
         digit_pos > percent_pos

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "1.25.2"
+  VERSION = "1.25.3"
 end

--- a/test/worldwide/numbers_test.rb
+++ b/test/worldwide/numbers_test.rb
@@ -272,6 +272,8 @@ module Worldwide
         ["he", 0.75, "75%"],
         ["ku", 0.1, "%10"],
         ["tr", 1, "%100"],
+        ["ur", 0.02, "2%"],
+        ["ur-PK", 0.02, "2%"],
         ["zh-CN", 0.22, "22%"],
       ].each do |locale, amount, expected|
         nf = Worldwide::Numbers.new(locale: locale)


### PR DESCRIPTION
Relates to https://github.com/shop/issues-international/issues/2953

Urdu (`ur`) percentages were rendering with a leading `%` (`%2`) on the shopify.com pricing page. They should use a trailing `%` (`2%`), the same as Hebrew.

Hebrew already has an override for this in `Worldwide::Numbers#percentage_specification`. This just adds `ur` to that same path (via a new `TRAILING_PERCENT_SIGN_LOCALES` constant) and adds `ur` / `ur-PK` test cases. `ar` / `ku` / `tr` are intentionally left as leading `%`.

Also cuts release `1.25.3` per the repo's per-PR convention (VERSION + Gemfile.lock + dated CHANGELOG entry).
