### PR TITLE
Add ar, he, ur to translation targets (RTL address labels)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Security in case of vulnerabilities.
 
 ## [Unreleased]
-- nil
+- Add `ar`, `he`, and `ur` to `translation.yml` target languages so the Translation Platform generates RTL localizations of the region address data [#519](https://github.com/Shopify/worldwide/pull/519)
 
 ---
 

--- a/translation.yml
+++ b/translation.yml
@@ -1,5 +1,42 @@
 source_language: en
-target_languages: [bg, cs, da, de, el, es, fi, fr, hi, hr, hu, id, it, ja, ko, lt, ms, nb, nl, pl, pt-BR, pt-PT, ro, ru, sk, sl, sv, th, tr, vi, zh-CN, zh-TW]
+target_languages:
+  [
+    ar,
+    bg,
+    cs,
+    da,
+    de,
+    el,
+    es,
+    fi,
+    fr,
+    he,
+    hi,
+    hr,
+    hu,
+    id,
+    it,
+    ja,
+    ko,
+    lt,
+    ms,
+    nb,
+    nl,
+    pl,
+    pt-BR,
+    pt-PT,
+    ro,
+    ru,
+    sk,
+    sl,
+    sv,
+    th,
+    tr,
+    ur,
+    vi,
+    zh-CN,
+    zh-TW,
+  ]
 async_pr_mode: per_pr
 components:
   - name: 'buyer'


### PR DESCRIPTION
Relates to https://github.com/shop/issues-international/issues/3073

Adds Arabic (`ar`), Hebrew (`he`) and Urdu (`ur`) to `target_languages` in `translation.yml` so the Translation Platform generates the RTL localizations of the region address data (`data/regions/*/{{language}}.yml`).

Those files back the address-form field labels (First name, Address, Postcode, etc.). Because these locales were never in `target_languages`, no translated files exist and the labels currently fall back to English for RTL locales in Shopify Admin.

Notes:
- This only enables the languages; the translated `data/regions/*/{ar,he,ur}.yml` files are generated asynchronously by the Translation Platform.
- A companion PR against `Shopify/country_db` adds the same three locales there — both are required for the end-to-end fix. https://github.com/Shopify/country_db/pull/2033
