### PR TITLE
Tighten BR address1 regex fallback

### DIFF
--- a/data/regions/BR.yml
+++ b/data/regions/BR.yml
@@ -29,6 +29,10 @@ format:
 format_extended:
   edit: "{country}_{firstName}{lastName}_{company}_{zip}_{streetName}{streetNumber}_{line2}{neighborhood}_{city}{province}_{phone}"
 address1_regex:
+  - "^(?<streetName>.+?),\\s*(?<streetNumber>(?:\\d+[a-zà-öø-ÿ]?|\\d+(?:[-/]\\d+[a-zà-öø-ÿ]?)+|\\d+(?:\\s+\\d+)+|s\\/?n|sem n[úu]mero))$"
+  - "^(?<streetName>.+?),\\s*(?<streetNumber>(?:\\d+[a-zà-öø-ÿ]?|\\d+(?:[-/]\\d+[a-zà-öø-ÿ]?)+|\\d+(?:\\s+\\d+)+|s\\/?n|sem n[úu]mero))\\s*,\\s*(?<line2>.+)$"
+  - "^(?<streetName>(?:[^\\d,\\s]+\\s)*[^\\d,\\s]+)\\s+(?<streetNumber>\\d+(?: ?[a-z])?)\\s+(?<line2>(?:apt(?:o|\\.)?|apartamento|bloco|casa|sala|fundos|loja)\\b.+)$"
+  - "^(?<streetName>(?:[^\\d,\\s]+\\s)*[^\\d,\\s]+)(?:,? ?)(?<streetNumber>\\d+(?: ?[a-z])?)\\s*,\\s*(?<line2>.+)$"
   - "^(?<streetName>(?:[^\\d,\\s]+\\s)*[^\\d,\\s]+)(?:,? ?)(?<streetNumber>\\d+(?: ?[a-z])?)$"
 additional_address_fields:
   - name: streetName

--- a/lang/typescript/src/extended-address/splitAddress1.test.ts
+++ b/lang/typescript/src/extended-address/splitAddress1.test.ts
@@ -44,11 +44,6 @@ describe('splitAddress1', () => {
       address: '40 Baandersstraat',
       expected: {streetName: '40 Baandersstraat'},
     },
-    {
-      country: 'BR',
-      address: 'Main, 123, Apt 2',
-      expected: {streetName: 'Main, 123, Apt 2'},
-    },
   ])(
     'returns address1 as street name when no delimiter is present, tryRegexFallback is true, and address does not match regex',
     ({country, address, expected}) => {
@@ -384,10 +379,98 @@ describe('splitAddress1', () => {
         streetNumber: '449',
       },
     },
+    {
+      address: 'Rua 25 de Março, 100',
+      expected: {streetName: 'Rua 25 de Março', streetNumber: '100'},
+    },
+    {
+      address: 'Rua Coronel José Mário Vilela, 201 201',
+      expected: {
+        streetName: 'Rua Coronel José Mário Vilela',
+        streetNumber: '201 201',
+      },
+    },
+    {
+      address: 'Fórum De Linhares, Sem número',
+      expected: {streetName: 'Fórum De Linhares', streetNumber: 'Sem número'},
+    },
   ])(
     'returns full address object when not separated by delimiter, tryRegexFallback is true and address matches regex for BR',
     ({address, expected}) => {
       expect(splitAddress1('BR', address, true)).toEqual(expected);
+    },
+  );
+
+  test.each([
+    {
+      address: 'Praça Ramos de Azevedo, 123, Apto 45',
+      expected: {
+        streetName: 'Praça Ramos de Azevedo',
+        streetNumber: '123',
+        line2: 'Apto 45',
+      },
+    },
+    {
+      address: 'Rua Santo Antônio, 722, Apto 4',
+      expected: {
+        streetName: 'Rua Santo Antônio',
+        streetNumber: '722',
+        line2: 'Apto 4',
+      },
+    },
+    {
+      address: 'Rua 25 de Março, 100, Apto 4',
+      expected: {
+        streetName: 'Rua 25 de Março',
+        streetNumber: '100',
+        line2: 'Apto 4',
+      },
+    },
+    {
+      address: 'Rua Corumbá 47A, Bloco 2',
+      expected: {
+        streetName: 'Rua Corumbá',
+        streetNumber: '47A',
+        line2: 'Bloco 2',
+      },
+    },
+    {
+      address: 'Praça Ramos de Azevedo 123 Apto 45',
+      expected: {
+        streetName: 'Praça Ramos de Azevedo',
+        streetNumber: '123',
+        line2: 'Apto 45',
+      },
+    },
+    {
+      address: 'Rua Corumbá 47 A, Apto 12',
+      expected: {
+        streetName: 'Rua Corumbá',
+        streetNumber: '47 A',
+        line2: 'Apto 12',
+      },
+    },
+    {
+      address: 'Av. de São João, 123, Apto 4 - Bloco B',
+      expected: {
+        streetName: 'Av. de São João',
+        streetNumber: '123',
+        line2: 'Apto 4 - Bloco B',
+      },
+    },
+  ])(
+    'extracts the optional line2 component from 3-component BR addresses',
+    ({address, expected}) => {
+      expect(splitAddress1('BR', address, true)).toEqual(expected);
+    },
+  );
+
+  test.each(['Avenida Normando Tedesco, 1400 - Centro', 'Rua 25 de Março 100'])(
+    'returns address1 as street name when BR address is ambiguous for regex fallback',
+    (address) => {
+      expect(splitAddress1('BR', address, true)).toEqual({
+        streetName: address,
+      });
     },
   );
 });


### PR DESCRIPTION
## Summary

This consolidates the BR address1 parser changes so Worldwide can handle both:

- comma-delimited raw prefill values whose street names can contain digits, like `Rua 25 de Marco, 100`
- flat 3-component values that include complement text, like `Praca Ramos de Azevedo, 123, Apto 45`

The BR regex list is intentionally ordered from higher-confidence comma-delimited patterns to the existing digit-free street-name fallbacks. Ambiguous values such as `Avenida Normando Tedesco, 1400 - Centro` continue to fall back to the full `streetName` instead of being split heuristically.

## Follow-up

Checkout-web still needs to bump `@shopify/worldwide` and decide how to seed a returned `line2` into checkout state at the trusted prefill/autofill boundary.

## Validation

- `pnpm test src/extended-address/splitAddress1.test.ts`
