### PR TITLE
Bump version to 1.25.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ---
 
+## [1.25.4] - 2026-07-08
+- Update translations: buyer [#523](https://github.com/Shopify/worldwide/pull/523)
+
 ## [1.25.3] - 2026-07-08
 - Add `ar`, `he`, and `ur` to `translation.yml` target languages so the Translation Platform generates RTL localizations of the region address data [#519](https://github.com/Shopify/worldwide/pull/519)
 - Fixed: format Urdu (`ur`) percentages with a trailing % sign in numeric layout order (e.g. `2%` instead of `%2`), matching the existing Hebrew behaviour. [#518](https://github.com/Shopify/worldwide/pull/518)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (1.25.3)
+    worldwide (1.25.4)
       activesupport (>= 7.0)
       i18n
       phonelib (~> 0.8)

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "1.25.3"
+  VERSION = "1.25.4"
 end


### PR DESCRIPTION
Relates to https://github.com/shop/issues-international/issues/3073
Deploy: https://shipit.shopify.io/shopify/worldwide/rubygems

Bumps the gem version to `1.25.4` so the Translation Platform buyer translations from #523 get published.

PR #523 ("Update translations: buyer") merged without bumping the version or `Gemfile.lock`, so the shipit deploy did not publish a new gem (`worldwide version 1.25.3 is already published`).

## Changes
- Patch bump `Worldwide::VERSION` to `1.25.4` in `lib/worldwide/version.rb`
- Update `Gemfile.lock` via `bundle install`
- Add `1.25.4 - 2026-07-08` changelog entry referencing #523

After merge, retry the deploy on shipit.