### PR TITLE
Add changeset for BR address parser

### DIFF
--- a/lang/typescript/.changeset/quiet-brazil-addresses.md
+++ b/lang/typescript/.changeset/quiet-brazil-addresses.md
@@ -1,0 +1,5 @@
+---
+'@shopify/worldwide': patch
+---
+
+Tighten Brazilian address1 parsing for apartment complements.


### PR DESCRIPTION
## Summary

Adds the missing patch changeset for the BR `address1_regex` update merged in Shopify/worldwide#520.

Once this lands on `main`, Changesets should include it in the next `Version Packages` PR for `@shopify/worldwide`.