### PR TITLE
Use OIDC for npm publishing

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          node-version: 20
+          node-version: 24
       - name: Setup PNPM
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
         with:
@@ -35,13 +35,13 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Create release Pull Request or publish to NPM
         id: changesets
-        uses: changesets/action@001cd79f0a536e733315164543a727bdf2d70aff # v1.5.1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           publish: pnpm release
           cwd: lang/typescript
           title: Version NPM Package
           commit: Version NPM Package
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
+          NPM_TOKEN: ""
           NPM_CONFIG_PROVENANCE: true

--- a/lang/typescript/package.json
+++ b/lang/typescript/package.json
@@ -38,7 +38,7 @@
     "format": "prettier src rollup-plugin-regions-yaml *.config.ts --write",
     "test": "vitest run --config vitest.config.ts",
     "test:watch": "vitest",
-    "release": "pnpm build && changeset publish --no-git-tag",
+    "release": "pnpm build && node scripts/publish-if-unpublished.mjs",
     "package:publint": "npx publint",
     "package:attw": "attw $(npm pack) && rimraf shopify-worldwide-*.tgz"
   },

--- a/lang/typescript/scripts/publish-if-unpublished.mjs
+++ b/lang/typescript/scripts/publish-if-unpublished.mjs
@@ -1,0 +1,61 @@
+import {spawnSync} from 'node:child_process';
+import {readFileSync} from 'node:fs';
+import {dirname, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const packageJson = JSON.parse(
+  readFileSync(resolve(packageRoot, 'package.json'), 'utf8'),
+);
+const packageSpec = `${packageJson.name}@${packageJson.version}`;
+const registry = 'https://registry.npmjs.org';
+const env = {
+  ...process.env,
+  npm_config_registry: registry,
+};
+
+const npmView = spawnSync(
+  'npm',
+  ['view', packageSpec, 'version', '--registry', registry, '--json'],
+  {
+    cwd: packageRoot,
+    encoding: 'utf8',
+    env,
+  },
+);
+
+if (npmView.status === 0) {
+  console.log(`${packageSpec} is already published on npm`);
+  process.exit(0);
+}
+
+const npmViewOutput = `${npmView.stdout ?? ''}\n${npmView.stderr ?? ''}`;
+if (!npmViewOutput.includes('E404')) {
+  console.error(npmViewOutput.trim());
+  process.exit(npmView.status ?? 1);
+}
+
+console.log(`${packageSpec} is not published on npm; publishing with npm CLI`);
+const publish = spawnSync(
+  'pnpm',
+  [
+    'dlx',
+    'npm@11.5.1',
+    'publish',
+    '--no-git-checks',
+    '--access',
+    packageJson.publishConfig?.access ?? 'public',
+    '--tag',
+    'latest',
+    '--provenance',
+    '--registry',
+    registry,
+  ],
+  {
+    cwd: packageRoot,
+    env,
+    stdio: 'inherit',
+  },
+);
+
+process.exit(publish.status ?? 1);


### PR DESCRIPTION
## Summary

Updates the TypeScript package release workflow to publish through npm trusted publishing/OIDC instead of the legacy secret-backed npm token.

This follows the standard OIDC path by:

- running the release on Node 24
- using changesets/action v1.9.0, which avoids writing a token auth line when NPM_TOKEN is empty
- keeping NPM_TOKEN as the required literal empty string
- keeping provenance enabled
- routing the actual package upload through npm CLI 11.5.1 while preserving the already-published no-op guard

Once the trusted publisher migration is active, this should allow @shopify/worldwide to publish through OIDC.
