### PR TITLE
Fix Nova Scotia HST default rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Security in case of vulnerabilities.
 
 ## [Unreleased]
-- Fix Nova Scotia HST rate from 15% to 14%
+- Fix Nova Scotia HST rate from 15% to 14% [#529](https://github.com/Shopify/worldwide/pull/529)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Security in case of vulnerabilities.
 
 ## [Unreleased]
-- nil
+- Fix Nova Scotia HST rate from 15% to 14%
 
 ---
 

--- a/data/regions/CA.yml
+++ b/data/regions/CA.yml
@@ -97,7 +97,7 @@ zones:
   - X0E
   - X0G
   - X1A
-- tax: 0.15
+- tax: 0.14
   tax_name: HST
   tax_type: harmonized
   name: Nova Scotia

--- a/test/worldwide/region_test.rb
+++ b/test/worldwide/region_test.rb
@@ -567,6 +567,7 @@ module Worldwide
 
     test "#tax_rate returns values as expected" do
       assert_in_delta(0.13, Worldwide.region(code: "CA").zone(code: "ON").tax_rate)
+      assert_in_delta(0.14, Worldwide.region(code: "CA").zone(code: "NS").tax_rate)
     end
 
     test "#ignore_provinces returns values as expected" do


### PR DESCRIPTION
### What are you trying to accomplish?

Nova Scotia reduced its HST rate from 15% to 14% effective April 1, 2025. Worldwide still exposes Nova Scotia's `tax_rate` as `0.15`, which causes consumers of Worldwide region data to keep using the old default.

Related issue: https://github.com/shop/issues-taxes/issues/3443

### What approach did you choose and why?

Following the same pattern as https://github.com/Shopify/worldwide/pull/425: update the static region data and add a changelog entry under Unreleased. I also added a regression assertion for `Worldwide.region(code: "CA").zone(code: "NS").tax_rate` so this doesn't drift back to 15%.

### What should reviewers focus on?

Is `data/regions/CA.yml` the right data source for the province-level default tax rate, and should any downstream consumers be explicitly notified to bump Worldwide after this lands/releases?

### The impact of these changes

Consumers reading `Worldwide.region(code: "CA").zone(code: "NS").tax_rate` will get `0.14` instead of `0.15` once they consume a Worldwide release containing this change.

### Testing

- `ruby -Ilib -e 'require "worldwide"; puts Worldwide::VERSION; puts Worldwide.region(code: "CA").zone(code: "NS").tax_rate'` → prints `1.25.4` and `0.14`
- Attempted `bundle exec ruby -Itest test/worldwide/region_test.rb`, but local bundle setup is blocked by native extension build failures in this environment (`bigdecimal`/`byebug` missing compiler/jemalloc headers). CI should run the full test suite.

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
