### PR TITLE
Cut new patch version 1.25.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Security in case of vulnerabilities.
 
 ## [Unreleased]
-- Fix Nova Scotia HST rate from 15% to 14% [#529](https://github.com/Shopify/worldwide/pull/529)
 
 ---
+
+## [1.25.5] - 2026-07-14
+- Fix Nova Scotia HST rate from 15% to 14% [#529](https://github.com/Shopify/worldwide/pull/529)
 
 ## [1.25.4] - 2026-07-08
 - Update translations: buyer [#523](https://github.com/Shopify/worldwide/pull/523)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (1.25.4)
+    worldwide (1.25.5)
       activesupport (>= 7.0)
       i18n
       phonelib (~> 0.8)

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "1.25.4"
+  VERSION = "1.25.5"
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Release new patch version 1.25.5. Includes:

- Fix Nova Scotia HST rate from 15% to 14% [#529](https://github.com/Shopify/worldwide/pull/529)

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
