### PR TITLE
Handle backslash in address formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Security in case of vulnerabilities.
 
 ## [Unreleased]
+- Fixed: `Address#format` no longer drops backslash sequences (e.g. `\2`) in field values [#533](https://github.com/Shopify/worldwide/pull/533)
 
 ---
 

--- a/lib/worldwide/address.rb
+++ b/lib/worldwide/address.rb
@@ -343,7 +343,7 @@ module Worldwide
 
           replacement ||= ""
 
-          mapped = mapped.gsub("{#{snake_to_camel_case(key)}}", replacement)
+          mapped = mapped.gsub("{#{snake_to_camel_case(key)}}") { replacement }
         end
         mapped
       end

--- a/test/worldwide/address_formatting_test.rb
+++ b/test/worldwide/address_formatting_test.rb
@@ -741,6 +741,27 @@ module Worldwide
       end
     end
 
+    test "format_address preserves backslash sequences in field values" do
+      address = {
+        first_name: "Test",
+        last_name: "Customer",
+        address1: "10 1\\2 California Ave",
+        city: "Los Angeles",
+        province_code: "CA",
+        country_code: "US",
+        zip: "90001",
+      }
+
+      expected = [
+        "Test Customer",
+        "10 1\\2 California Ave",
+        "Los Angeles CA 90001",
+        "United States",
+      ]
+
+      assert_equal expected, Worldwide.address(**address).format
+    end
+
     private
 
     def try_formatting_single_line(locale, country_code, city_name, expected)


### PR DESCRIPTION
### WHAT are you trying to accomplish with this PR?

Address#format sometimes misinterprets backslashes in addresses.  If an address field contains `\2`, it is interpreted as a replacement backreference, not as literal address text:

```
Worldwide.address(
     first_name:    "Test",
     last_name:     "Customer",
     phone:         nil,
     address1:      "10 1\\2 California Ave",
     address2:      nil,
     city:          "Los Angeles",
     province_code: "CA",
     country_code:  "US",
     zip:           "90001",
     company:       nil,
 ).format

=>  ["10 1 California Ave", "Los Angeles CA 90001", "United States"]

```


### What approach did you choose and why?

Updated the `sub` call to use the block form instead.  When you use the block form, Ruby inserts the block’s return value literally.

```
Worldwide.address(
     first_name:    "Test",
     last_name:     "Customer",
     phone:         nil,
     address1:      "10 1\\2 California Ave",
     address2:      nil,
     city:          "Los Angeles",
     province_code: "CA",
     country_code:  "US",
     zip:           "90001",
     company:       nil,
 )

=> ["10 1\\2 California Ave", "Los Angeles CA 90001", "United States"]
```
