### PR TITLE
Add Worldwide::Names.abbreviated for personal-name abbreviation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 - Fixed: `Address#format` no longer drops backslash sequences (e.g. `\2`) in field values [#533](https://github.com/Shopify/worldwide/pull/533)
+- Add `Worldwide::Names.abbreviated` to abbreviate personal names by script [#539](https://github.com/Shopify/worldwide/pull/539)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -625,6 +625,8 @@ Say, for example, your customer has the given name "Ken" and surname "Tanaka".  
 
 `Names.surname_first?` will let you know if the current locale places the surname (family name, last name) before the given name ("first name", forename).
 
+`Names.abbreviated` returns a short form of a personal name based on its writing script. Latin names use the first letters of the given name and surname. Han, Hiragana, and Katakana names use the surname. Hangul names use the given name when it is within `ideal_max_length`, or its first grapheme cluster when it is longer. Thai names use the first grapheme cluster of the given name. The Hangul and Thai rules fall back to the surname when the given name is blank. The method returns `nil` when it cannot abbreviate the name, allowing the caller to fall back to `Names.greeting`.
+
 ```ruby
 I18n.with_locale(:en) { Worldwide.names.full(given: "John", surname: "Smith") }
 => "John Smith"
@@ -636,6 +638,10 @@ I18n.with_locale(:en) { Worldwide.names.greeting(given: "John", surname: "Smith"
 => "John"
 I18n.with_locale(:ja) { Worldwide.names.greeting(given: "John", surname: "Smith") }
 => "Smith様"
+Worldwide.names.abbreviated(given: "John", surname: "Smith")
+=> "JS"
+Worldwide.names.abbreviated(given: "이슬", surname: "재현", ideal_max_length: 1)
+=> "이"
 Worldwide.names.surname_first?("en")
 => false
 Worldwide.names.surname_first?("ja")

--- a/lib/worldwide/names.rb
+++ b/lib/worldwide/names.rb
@@ -30,6 +30,43 @@ module Worldwide
         names.map { |name| name[0] }
       end
 
+      def abbreviated(given:, surname:, ideal_max_length: 3)
+        given_stripped = given&.strip
+        surname_stripped = surname&.strip
+
+        combined_name = given_stripped.to_s + surname_stripped.to_s
+        return if combined_name.blank? || combined_name.match?(/[\p{Punctuation}\s]/)
+
+        scripts = Scripts.identify(text: combined_name)
+        return unless scripts.length == 1
+
+        given_clusters = given_stripped&.grapheme_clusters
+        surname_clusters = surname_stripped&.grapheme_clusters
+
+        # Scripts that Scripts.identify recognizes but that have no abbreviation rule
+        # here (e.g. Arabic) intentionally return nil so callers fall back to a greeting.
+        case scripts.first
+        when :Latin
+          [given_stripped, surname_stripped].reject(&:blank?).map { |name| name[0] }.join
+        when :Han, :Katakana, :Hiragana
+          surname_stripped.presence
+        when :Hangul
+          if given_stripped.blank?
+            surname_stripped
+          elsif given_clusters.length > ideal_max_length
+            given_clusters[0]
+          else
+            given_stripped
+          end
+        when :Thai
+          if given_stripped.present?
+            given_clusters[0]
+          elsif surname_stripped.present?
+            surname_clusters[0]
+          end
+        end
+      end
+
       private
 
       def format_name(format, given, surname)

--- a/test/worldwide/names_test.rb
+++ b/test/worldwide/names_test.rb
@@ -143,5 +143,77 @@ module Worldwide
         assert_equal "Dillon", Worldwide::Names.greeting(given: "", surname: @surname)
       end
     end
+
+    test ".abbreviated ignores leading and trailing whitespace" do
+      assert_equal "MG", Worldwide::Names.abbreviated(given: " Michael ", surname: " Garfinkle ")
+    end
+
+    test ".abbreviated returns nil when given or surname contains punctuation or whitespace" do
+      assert_nil Worldwide::Names.abbreviated(given: "Michael", surname: "Garfinkle-Smith")
+      assert_nil Worldwide::Names.abbreviated(given: "Mr.", surname: "Garfinkle")
+      assert_nil Worldwide::Names.abbreviated(given: "Michael", surname: "van der Garfinkle")
+    end
+
+    test ".abbreviated returns nil for mixed scripts" do
+      assert_nil Worldwide::Names.abbreviated(given: "คEวง", surname: "อภัADSยวงศ์")
+      assert_nil Worldwide::Names.abbreviated(given: "アイ", surname: "Garfinkle")
+    end
+
+    test ".abbreviated returns nil when both given and surname are blank" do
+      assert_nil Worldwide::Names.abbreviated(given: "", surname: "")
+      assert_nil Worldwide::Names.abbreviated(given: nil, surname: nil)
+    end
+
+    test ".abbreviated Latin script returns first letter of surname when given is blank" do
+      assert_equal "G", Worldwide::Names.abbreviated(given: "", surname: "Garfinkle")
+      assert_equal "G", Worldwide::Names.abbreviated(given: nil, surname: "Garfinkle")
+    end
+
+    test ".abbreviated Latin script returns first letter of given when surname is blank" do
+      assert_equal "M", Worldwide::Names.abbreviated(given: "Michael", surname: "")
+      assert_equal "M", Worldwide::Names.abbreviated(given: "Michael", surname: nil)
+    end
+
+    test ".abbreviated Latin script returns first letter of given and surname when both present" do
+      assert_equal "MG", Worldwide::Names.abbreviated(given: "Michael", surname: "Garfinkle")
+    end
+
+    test ".abbreviated Han/Katakana/Hiragana returns surname regardless of given" do
+      assert_equal "愛莉", Worldwide::Names.abbreviated(given: "", surname: "愛莉")
+      assert_equal "アイ", Worldwide::Names.abbreviated(given: nil, surname: "アイ")
+      assert_equal "エリ", Worldwide::Names.abbreviated(given: "エ", surname: "エリ")
+    end
+
+    test ".abbreviated Han/Katakana/Hiragana returns nil when surname is blank" do
+      assert_nil Worldwide::Names.abbreviated(given: "愛莉", surname: "")
+      assert_nil Worldwide::Names.abbreviated(given: "アイ", surname: nil)
+    end
+
+    test ".abbreviated Hangul returns given when within ideal_max_length" do
+      assert_equal "이슬", Worldwide::Names.abbreviated(given: "이슬", surname: "재현")
+      assert_equal "하야나", Worldwide::Names.abbreviated(given: "하야나", surname: "재현")
+    end
+
+    test ".abbreviated Hangul returns first cluster of given when it exceeds default ideal_max_length" do
+      assert_equal "이", Worldwide::Names.abbreviated(given: "이슬슬슬", surname: "재현")
+    end
+
+    test ".abbreviated Hangul returns first cluster of given when it exceeds supplied ideal_max_length" do
+      assert_equal "이", Worldwide::Names.abbreviated(given: "이슬", surname: "재현", ideal_max_length: 1)
+    end
+
+    test ".abbreviated Hangul returns surname when given is blank" do
+      assert_equal "재현", Worldwide::Names.abbreviated(given: nil, surname: "재현")
+      assert_equal "재현", Worldwide::Names.abbreviated(given: "", surname: "재현")
+    end
+
+    test ".abbreviated Thai returns first cluster of given" do
+      assert_equal "ค", Worldwide::Names.abbreviated(given: "ควง", surname: "อภัยวงศ์")
+    end
+
+    test ".abbreviated Thai returns first cluster of surname when given is blank" do
+      assert_equal "อ", Worldwide::Names.abbreviated(given: "", surname: "อภัยวงศ์")
+      assert_equal "อ", Worldwide::Names.abbreviated(given: nil, surname: "อภัยวงศ์")
+    end
   end
 end


### PR DESCRIPTION
## What

Ports the personal-name abbreviation logic from `ShopifyI18n::NameFormatter` into a new public `Worldwide::Names.abbreviated(given:, surname:, ideal_max_length: 3)`, so `shopify-i18n` can delegate its last remaining `NameFormatter` method (`display_abbreviated_name`) upstream and drop its direct dependency on `ShopifyI18n::Scripts`.

## Behavior

The method mirrors `try_abbreviate_name` and returns `nil` when it cannot abbreviate, leaving the caller to fall back to a greeting/display name:

- **Latin**: first letter of given + first letter of surname (e.g. "John Smith" -> "JS").
- **Han / Katakana / Hiragana**: the surname, or `nil` when the surname is blank.
- **Hangul**: the full given name, or its first grapheme cluster when it exceeds `ideal_max_length`; falls back to the surname when the given name is blank.
- **Thai**: the first grapheme cluster of the given name, or of the surname when the given name is blank.
- Combined name containing punctuation or whitespace -> `nil`.
- Ambiguous / mixed scripts -> `nil`.

Script detection reuses `Worldwide::Scripts.identify` and string handling operates on grapheme clusters.

## Faithful port: known limitations

This intentionally reproduces the upstream `try_abbreviate_name` behavior verbatim so `shopify-i18n` can delegate without a behavior change. Notable inherited limitations:

- **Arabic (and other recognized-but-unhandled scripts):** `Worldwide::Scripts.identify` recognizes Arabic, but there is no Arabic abbreviation rule, so single-script Arabic names return `nil` and fall back to a greeting. A code comment documents this. Shopify/worldwide#551 tracks defining Arabic script rules for personal and business name abbreviation.
- **Mixed-script names:** the single-script guard means names combining scripts (e.g. a kanji surname with a kana given name) return `nil`.
- **Rejection guard:** only punctuation and whitespace are rejected; symbols and digits are not.

## Changes

- `lib/worldwide/names.rb`: new public `abbreviated` method.
- `test/worldwide/names_test.rb`: ports the abbreviation cases from `shopify-i18n`'s `name_formatter_test.rb`, plus the Han/Katakana/Hiragana blank-surname `nil` case.
- `README.md`: describes abbreviation behavior across supported scripts and includes Latin and Hangul examples, including `ideal_max_length`.
- `CHANGELOG.md`: Unreleased entry.

## Validation

- `bundle exec ruby -Itest test/worldwide/names_test.rb` -> 34 tests, 57 assertions, 0 failures.
- `bundle exec rubocop lib/worldwide/names.rb test/worldwide/names_test.rb` -> no offenses.

Closes Shopify/shopify-i18n#2275

Co-authored-by: GPT-5.6-sol <noreply@openai.com>
Orchestrated-by: ae <noreply@shopify.com>

<!-- ae-body-hash:a8632446810ae9d50fd8cca1b92860b431c0b5b9b07d1cb55315ac92ccfb1bd3 -->
