### PR TITLE
Bump i18n from 1.14.1 to 1.15.2 and fix Cldr fiber-local config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Security in case of vulnerabilities.
 
 ## [Unreleased]
+- Bump i18n from 1.14.1 to 1.15.2 (now required as `>= 1.15`) and update `Cldr.with_cldr` to mirror i18n's fiber-aware config and fallbacks storage so the CLDR config still applies on Ruby 3.2+. [#540](https://github.com/Shopify/worldwide/pull/540)
 
 ---
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ PATH
   specs:
     worldwide (1.25.5)
       activesupport (>= 7.0)
-      i18n
+      i18n (>= 1.15)
       phonelib (~> 0.8)
 
 GEM
@@ -42,7 +42,7 @@ GEM
     connection_pool (2.4.1)
     drb (2.1.1)
       ruby2_keywords
-    i18n (1.14.1)
+    i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.6)

--- a/lib/worldwide/cldr.rb
+++ b/lib/worldwide/cldr.rb
@@ -11,6 +11,54 @@ module Worldwide
       cldr_config.exception_handler = Worldwide::Config.exception_handler
     end
 
+    # i18n 1.15 keeps the active config and fallbacks in Fiber storage on Ruby
+    # 3.2+ and in thread-local storage otherwise. We must write the same slots
+    # i18n reads back, so a Thread.current[:i18n_config] write is not silently
+    # ignored on Ruby 3.2+. These strategies mirror i18n's own storage; the one
+    # matching the runtime is selected once into STORAGE.
+    module FiberStorage
+      class << self
+        def config
+          Fiber[:i18n_config]
+        end
+
+        def config=(value)
+          Fiber[:i18n_config] = value
+          value.owner = Fiber.current if value.respond_to?(:owner=) && !value.frozen?
+        end
+
+        def fallbacks
+          Fiber[:i18n_fallbacks]
+        end
+
+        def fallbacks=(value)
+          Fiber[:i18n_fallbacks] = value
+        end
+      end
+    end
+
+    module ThreadStorage
+      class << self
+        def config
+          Thread.current.thread_variable_get(:i18n_config)
+        end
+
+        def config=(value)
+          Thread.current.thread_variable_set(:i18n_config, value)
+        end
+
+        def fallbacks
+          Thread.current[:i18n_fallbacks]
+        end
+
+        def fallbacks=(value)
+          Thread.current[:i18n_fallbacks] = value
+        end
+      end
+    end
+
+    STORAGE = Fiber.respond_to?(:[]) ? FiberStorage : ThreadStorage
+
     class << self
       def fallbacks
         FALLBACKS
@@ -33,17 +81,20 @@ module Worldwide
       end
 
       def with_cldr(&block)
-        original_fallbacks = Thread.current[:i18n_fallbacks]
-        Thread.current[:i18n_fallbacks] = fallbacks
-
+        # Swap the fallbacks slot directly rather than via I18n.fallbacks= so the
+        # change stays fiber/thread-local and never clobbers the host
+        # application's global fallbacks.
+        original_config = STORAGE.config
+        original_fallbacks = STORAGE.fallbacks
         locale = I18n.locale
-        original_config = Thread.current[:i18n_config]
-        Thread.current[:i18n_config] = config
+
+        STORAGE.config = config
+        STORAGE.fallbacks = fallbacks
 
         I18n.with_locale(locale, &block)
       ensure
-        Thread.current[:i18n_fallbacks] = original_fallbacks
-        Thread.current[:i18n_config] = original_config
+        STORAGE.config = original_config
+        STORAGE.fallbacks = original_fallbacks
       end
     end
   end

--- a/test/worldwide/cldr_test.rb
+++ b/test/worldwide/cldr_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Worldwide
+  class CldrTest < ActiveSupport::TestCase
+    test "applies the CLDR config and fallbacks while translating" do
+      # Regression guard: on i18n 1.15 the config and fallbacks live in fiber
+      # storage, so a Thread.current[:i18n_config] write is silently ignored and
+      # the CLDR symbol lookup falls back to the ISO code ("EUR").
+      assert_equal "€1,234.50 EUR", Worldwide.currency(code: :EUR).format_explicit(1234.5, locale: :"en-IE")
+    end
+
+    test "restores the previous config and fallbacks after translating" do
+      before_config = I18n.config
+      before_fallbacks = I18n.fallbacks
+
+      Worldwide::Cldr.t("currencies.EUR.symbol", locale: :en, default: nil)
+
+      assert_same before_config, I18n.config
+      assert_same before_fallbacks, I18n.fallbacks
+    end
+
+    test "restores the previous config and fallbacks even when the translation raises" do
+      before_config = I18n.config
+      before_fallbacks = I18n.fallbacks
+
+      assert_raises(I18n::MissingTranslationData) do
+        Worldwide::Cldr.translate!(:__worldwide_cldr_missing_key__)
+      end
+
+      assert_same before_config, I18n.config
+      assert_same before_fallbacks, I18n.fallbacks
+    end
+
+    test "preserves the host application's custom fallbacks across a translation" do
+      old_fallbacks = I18n.fallbacks
+      custom_fallbacks = I18n::Locale::Fallbacks.new([:"es-JP-POTATO"])
+      I18n.fallbacks = custom_fallbacks
+
+      Worldwide::Cldr.t("currencies.EUR.symbol", locale: :"en-IE", default: nil)
+
+      assert_same(custom_fallbacks, I18n.fallbacks)
+    ensure
+      I18n.fallbacks = old_fallbacks
+    end
+  end
+end

--- a/worldwide.gemspec
+++ b/worldwide.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.1.0"
 
   spec.add_dependency("activesupport", ">= 7.0")
-  spec.add_dependency("i18n")
+  spec.add_dependency("i18n", ">= 1.15")
   spec.add_dependency("phonelib", "~> 0.8")
 end


### PR DESCRIPTION
## What

Bumps `i18n` from 1.14.1 to 1.15.2 (superseding dependabot #509) and fixes the test regression that bump introduced in `Worldwide::Cldr`, adds a matching gemspec constraint, and adds regression tests.

## Why

i18n 1.15.0 made both the active config **and** the fallbacks fiber-local: on Ruby 3.2+ they are stored in `Fiber[:i18n_config]` / `Fiber[:i18n_fallbacks]` (with thread-local storage as the fallback when fibers do not support `[]`, e.g. Ruby 3.1). See ruby-i18n/i18n#729 and #731.

`Worldwide::Cldr#with_cldr` set the CLDR config and fallbacks by writing `Thread.current[:i18n_config]` and `Thread.current[:i18n_fallbacks]` directly. Under 1.15 those assignments are no longer read on Ruby 3.2+, so the CLDR config (and its custom exception handler) and the CLDR fallbacks were never applied. That regressed currency, number, date, and weekday name formatting: `bundle exec rake test` went from all green to 8 failures + 1 error (e.g. `€1,234.50` rendered as `EUR1,234.50`, `Kč` came back `nil`, `zh-HK` number formatting fell back, stand-alone weekday/month names broke).

## Fix

`with_cldr` now saves, swaps, and restores the config and fallbacks through a storage strategy that mirrors i18n 1.15's own storage. Because i18n keeps config and fallbacks in Fiber storage on Ruby 3.2+ and in thread-local storage on Ruby 3.1 (i18n 1.15 still supports Ruby 3.1), the choice is captured **once** at load time:

- `STORAGE = Fiber.respond_to?(:[]) ? FiberStorage : ThreadStorage` selects the strategy once, so there is no per-call reflection or repeated conditional on the hot path.
- `FiberStorage` reads/writes `Fiber[:i18n_config]` (setting `owner` to the current fiber, matching `I18n.config=`) and `Fiber[:i18n_fallbacks]`.
- `ThreadStorage` reads/writes `Thread.current.thread_variable_*(:i18n_config)` and `Thread.current[:i18n_fallbacks]`, matching i18n's thread-local layout exactly.

The fallbacks slot is set directly rather than through `I18n.fallbacks=` on purpose: `I18n.fallbacks=` also mutates the shared class-level `@@fallbacks`, whereas we keep the swap fiber/thread-local so it never clobbers the host application's global fallbacks. Because Fiber storage is per-root-fiber, this is also thread-local, so concurrent callers never see each other's CLDR config or fallbacks.

`worldwide.gemspec` now pins `i18n >= 1.15` so the storage assumption is enforced for consumers (the gem previously declared `i18n` with no constraint).

This is the same class of fix as Shopify/shopify-i18n#2273, extended to also cover the fiber-aware fallbacks storage that i18n 1.15 introduced (1.14.8, which that PR targeted, only moved the config to a thread variable).

## Testing

- New `test/worldwide/cldr_test.rb` covers: CLDR config/fallbacks actually apply while translating (the regression guard, `€1,234.50 EUR`), config + fallbacks are restored after a normal return and after the translation raises, and the host application's custom `I18n.fallbacks` is preserved across a Cldr translation.
- `bundle exec rake test` passes (1397 tests, 0 failures, 0 errors) and `rubocop` is clean. Before the fix the same suite reported 8 failures + 1 error, and reverting to i18n 1.14.1 is all green, confirming the regression is caused by the bump.
- Thread safety verified out of band: 20 threads × 500 iterations of `Worldwide.currency(...).format_explicit(...)`, each with a distinct host `I18n.fallbacks`, produced correct output in every thread with no fallbacks leakage.

Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>
Orchestrated-by: ae <noreply@shopify.com>

<!-- ae-body-hash:745dbc1d972697724957f5c7bec861e8d7b8c25cb401a83942c95555040e552a -->
