### PR TITLE
Strip blank Japanese address components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- Fix trailing whitespace in formatted Japanese addresses when the postal code is blank or excluded. [#548](https://github.com/Shopify/worldwide/pull/548)
+
 ---
 
 ## [1.25.6] - 2026-07-21

--- a/lib/worldwide/address.rb
+++ b/lib/worldwide/address.rb
@@ -446,13 +446,11 @@ module Worldwide
     def strip_extra_chars(lines:, excluded_fields:)
       result = []
       lines.each do |components|
-        line = components.filter_map do |component|
-          component unless component.empty?
-        end
+        line = strip_extra_japanese_chars(line: components, excluded_fields: excluded_fields)
+        line.map!(&:strip)
+        line.reject!(&:empty?)
 
-        line = strip_extra_japanese_chars(line: line, excluded_fields: excluded_fields)
-
-        result << line.map(&:strip) unless blank?(line.join(""))
+        result << line unless blank?(line.join(""))
       end
       result
     end

--- a/test/worldwide/address_formatting_test.rb
+++ b/test/worldwide/address_formatting_test.rb
@@ -155,6 +155,45 @@ module Worldwide
       assert_equal expected, Worldwide.address(**japan_address).format
     end
 
+    test "format_address removes Japanese postal mark spacing when zip is blank" do
+      japan_address = {
+        first_name: "Chocolate",
+        last_name: "Brownie",
+        address1: "東京 1",
+        province_code: "JP-01",
+        country_code: "JP",
+      }
+
+      expected = [
+        "Japan",
+        "Hokkaido",
+        "東京 1",
+        "Brownie Chocolate様",
+      ]
+
+      assert_equal expected, Worldwide.address(**japan_address).format
+    end
+
+    test "format_address removes Japanese postal mark spacing when zip is excluded" do
+      japan_address = {
+        first_name: "Chocolate",
+        last_name: "Brownie",
+        address1: "東京 1",
+        province_code: "JP-01",
+        country_code: "JP",
+        zip: "097-0005",
+      }
+
+      expected = [
+        "Japan",
+        "Hokkaido",
+        "東京 1",
+        "Brownie Chocolate様",
+      ]
+
+      assert_equal expected, Worldwide.address(**japan_address).format(excluded_fields: [:zip])
+    end
+
     test "format_address has specified excluded fields excluded" do
       bobs_home = {
         first_name: "Bob",
@@ -474,6 +513,21 @@ module Worldwide
           assert_equal expected, actual
         end
       end
+    end
+
+    test "single_line removes the Japanese postal mark when zip is excluded" do
+      address = {
+        city: "Yokohama",
+        address1: "Hodogaya Bukkocho",
+        province_code: "JP-14",
+        zip: "240-0044",
+        country_code: "JP",
+      }
+
+      expected = "Hodogaya Bukkocho, Yokohama, Kanagawa, Japan"
+      actual = Worldwide.address(**address).single_line(excluded_fields: [:zip])
+
+      assert_equal expected, actual
     end
 
     test "japan formats single_line differently for japanese" do


### PR DESCRIPTION
## Summary

Japanese addresses without a postal code can format the country line as `"Japan "` because removing the postal marker leaves an empty address component. This removes the resulting whitespace for missing and explicitly excluded postal codes across multiline and single line formatting.

Fixes https://github.com/Shopify/worldwide/issues/546

## Approach

- Apply Japanese special character cleanup before normalizing address components
- Strip and reject empty components in place to avoid redundant filtering and intermediate allocations
- Cover missing and excluded postal codes through the public multiline formatting interface
- Cover excluded postal codes through the public single line formatting interface
- Document the fix in the Unreleased changelog

Co-authored-by: GPT-5.6-sol <noreply@openai.com>
Orchestrated-by: ae <noreply@shopify.com>

<!-- ae-body-hash:a19e95e9ca47d85b9cb94d964e9fcf300bee432c78c5889bb6294051b0fad85e -->
