### PR TITLE
Prepare minor release 1.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,13 +26,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Security in case of vulnerabilities.
 
 ## [Unreleased]
-- Fixed: `Address#format` no longer drops backslash sequences (e.g. `\2`) in field values [#533](https://github.com/Shopify/worldwide/pull/533)
-- Add `Worldwide::Names.abbreviated` to abbreviate personal names by script [#539](https://github.com/Shopify/worldwide/pull/539)
-- Add `Worldwide::BusinessNames.abbreviated` to abbreviate a single business name string based on its script.
-
-- Fix trailing whitespace in formatted Japanese addresses when the postal code is blank or excluded. [#548](https://github.com/Shopify/worldwide/pull/548)
 
 ---
+
+## [1.26.0] - 2026-07-22
+- Add `Worldwide::BusinessNames.abbreviated` for script-aware abbreviation of a single business name string. [#538](https://github.com/Shopify/worldwide/pull/538) [#553](https://github.com/Shopify/worldwide/pull/553)
+- Add `Worldwide::Names.abbreviated` to abbreviate personal names by script. [#539](https://github.com/Shopify/worldwide/pull/539)
+- Fix trailing whitespace in formatted Japanese addresses when the postal code is blank or excluded. [#548](https://github.com/Shopify/worldwide/pull/548)
+- Fix `Address#format` dropping backslash sequences (e.g. `\2`) in field values. [#533](https://github.com/Shopify/worldwide/pull/533)
 
 ## [1.25.6] - 2026-07-21
 - Bump i18n from 1.14.1 to 1.15.2 (now required as `>= 1.15`) and update `Cldr.with_cldr` to mirror i18n's fiber-aware config and fallbacks storage so the CLDR config still applies on Ruby 3.2+. [#540](https://github.com/Shopify/worldwide/pull/540)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (1.25.6)
+    worldwide (1.26.0)
       activesupport (>= 7.0)
       i18n (>= 1.15)
       phonelib (~> 0.8)

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "1.25.6"
+  VERSION = "1.26.0"
 end


### PR DESCRIPTION
## Summary

Prepare Worldwide 1.26.0, the next minor gem release. This release includes the new `Worldwide::Names.abbreviated` and `Worldwide::BusinessNames.abbreviated` APIs plus the address formatting fixes merged since 1.25.6.

## Approach

- Bump `Worldwide::VERSION` and the lockfile package version to 1.26.0
- Move the unreleased changes into a dated 1.26.0 changelog section and link each contributing PR
- Leave publishing and tag creation to ShipIt after this PR merges

## Validation

- `bundle exec rake`
- `bundle exec gem build worldwide.gemspec --output /tmp/worldwide-1.26.0.gem`

Co-authored-by: GPT-5.6-sol <noreply@openai.com>
Orchestrated-by: ae <noreply@shopify.com>

<!-- ae-body-hash:566c0af368cd61c8608b39b2a4dd6a4be93bf8e6fc223c888e23a932e3ac0c1f -->
