### PR TITLE
Rename BusinessNames abbreviation method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,12 +28,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 - Fixed: `Address#format` no longer drops backslash sequences (e.g. `\2`) in field values [#533](https://github.com/Shopify/worldwide/pull/533)
 - Add `Worldwide::Names.abbreviated` to abbreviate personal names by script [#539](https://github.com/Shopify/worldwide/pull/539)
+- Add `Worldwide::BusinessNames.abbreviated` to abbreviate a single business name string based on its script.
 
 - Fix trailing whitespace in formatted Japanese addresses when the postal code is blank or excluded. [#548](https://github.com/Shopify/worldwide/pull/548)
 
 ---
-
-- Add `Worldwide::BusinessNames.abbreviate` for script-aware abbreviation of a single business name string.
 
 ## [1.25.6] - 2026-07-21
 - Bump i18n from 1.14.1 to 1.15.2 (now required as `>= 1.15`) and update `Cldr.with_cldr` to mirror i18n's fiber-aware config and fallbacks storage so the CLDR config still applies on Ruby 3.2+. [#540](https://github.com/Shopify/worldwide/pull/540)

--- a/README.md
+++ b/README.md
@@ -654,17 +654,17 @@ Worldwide.names.surname_first?("ja")
 `Worldwide::BusinessNames` abbreviates a single business name according to its detected script. The default `ideal_max_length` is 3. The method returns `nil` when the input is blank, uses multiple or unsupported scripts, or cannot be abbreviated by the script's rules. It is also available through `Worldwide.business_names`.
 
 ```ruby
-Worldwide::BusinessNames.abbreviate(name: "Shopify")
+Worldwide.business_names.abbreviated(name: "Shopify")
 => "Sho"
-Worldwide::BusinessNames.abbreviate(name: "A Better Shop")
+Worldwide::BusinessNames.abbreviated(name: "A Better Shop")
 => "ABS"
-Worldwide::BusinessNames.abbreviate(name: "A Better Looking Shop")
+Worldwide::BusinessNames.abbreviated(name: "A Better Looking Shop")
 => "AS"
-Worldwide::BusinessNames.abbreviate(name: "삼성 한국어", ideal_max_length: 2)
+Worldwide::BusinessNames.abbreviated(name: "삼성 한국어", ideal_max_length: 2)
 => "삼성"
-Worldwide::BusinessNames.abbreviate(name: "任天堂")
+Worldwide::BusinessNames.abbreviated(name: "任天堂")
 => "任天堂"
-Worldwide::BusinessNames.abbreviate(name: "อภัADSยวงศ์")
+Worldwide::BusinessNames.abbreviated(name: "อภัADSยวงศ์")
 => nil
 ```
 

--- a/lib/worldwide/business_names.rb
+++ b/lib/worldwide/business_names.rb
@@ -4,7 +4,7 @@ module Worldwide
   class BusinessNames
     class << self
       # Returns a script aware abbreviation, or nil when the name cannot be abbreviated.
-      def abbreviate(name:, ideal_max_length: 3)
+      def abbreviated(name:, ideal_max_length: 3)
         name_stripped = name&.strip
 
         return if Util.blank?(name_stripped)

--- a/lib/worldwide/names.rb
+++ b/lib/worldwide/names.rb
@@ -36,6 +36,7 @@ module Worldwide
 
         combined_name = given_stripped.to_s + surname_stripped.to_s
         return if combined_name.blank? || combined_name.match?(/[\p{Punctuation}\s]/)
+        return unless ideal_max_length.is_a?(Integer) && ideal_max_length.positive?
 
         scripts = Scripts.identify(text: combined_name)
         return unless scripts.length == 1

--- a/test/worldwide/business_names_test.rb
+++ b/test/worldwide/business_names_test.rb
@@ -5,106 +5,107 @@ require "test_helper"
 module Worldwide
   class BusinessNamesTest < ActiveSupport::TestCase
     test "leading or trailing whitespace is ignored when creating abbreviation" do
-      assert_equal "AS", Worldwide::BusinessNames.abbreviate(name: " A Better Looking Shop  ")
+      assert_equal "AS", Worldwide::BusinessNames.abbreviated(name: " A Better Looking Shop  ")
     end
 
     test "mixed scripts return nil" do
-      assert_nil Worldwide::BusinessNames.abbreviate(name: "อภัADSยวงศ์")
+      assert_nil Worldwide::BusinessNames.abbreviated(name: "อภัADSยวงศ์")
     end
 
     test "single but unsupported script returns nil" do
-      assert_nil Worldwide::BusinessNames.abbreviate(name: "Мосэнерго")
-      assert_nil Worldwide::BusinessNames.abbreviate(name: "بترول")
+      assert_nil Worldwide::BusinessNames.abbreviated(name: "Мосэнерго")
+      assert_nil Worldwide::BusinessNames.abbreviated(name: "بترول")
     end
 
     test "whitespace-only name returns nil" do
-      assert_nil Worldwide::BusinessNames.abbreviate(name: "   ")
+      assert_nil Worldwide::BusinessNames.abbreviated(name: "   ")
     end
 
-    test "non-positive ideal_max_length returns nil" do
-      assert_nil Worldwide::BusinessNames.abbreviate(name: "Shop", ideal_max_length: 0)
-      assert_nil Worldwide::BusinessNames.abbreviate(name: "Shop", ideal_max_length: -1)
+    test "non-positive or non-integer ideal_max_length returns nil" do
+      assert_nil Worldwide::BusinessNames.abbreviated(name: "Shop", ideal_max_length: 0)
+      assert_nil Worldwide::BusinessNames.abbreviated(name: "Shop", ideal_max_length: -1)
+      assert_nil Worldwide::BusinessNames.abbreviated(name: "Shop", ideal_max_length: "3")
     end
 
     test "empty name returns nil" do
-      assert_nil Worldwide::BusinessNames.abbreviate(name: "")
+      assert_nil Worldwide::BusinessNames.abbreviated(name: "")
     end
 
     test "nil name returns nil" do
-      assert_nil Worldwide::BusinessNames.abbreviate(name: nil)
+      assert_nil Worldwide::BusinessNames.abbreviated(name: nil)
     end
 
     test "single word Latin name returns up to the first 3 letters when ideal_max_length is not set" do
-      assert_equal "Sho", Worldwide::BusinessNames.abbreviate(name: "Shop")
-      assert_equal "Sh", Worldwide::BusinessNames.abbreviate(name: "Sh")
+      assert_equal "Sho", Worldwide::BusinessNames.abbreviated(name: "Shop")
+      assert_equal "Sh", Worldwide::BusinessNames.abbreviated(name: "Sh")
     end
 
     test "single word Latin name returns up to ideal_max_length letters when ideal_max_length is set" do
-      assert_equal "Shop", Worldwide::BusinessNames.abbreviate(name: "Shop1", ideal_max_length: 4)
-      assert_equal "Shop1", Worldwide::BusinessNames.abbreviate(name: "Shop1", ideal_max_length: 7)
+      assert_equal "Shop", Worldwide::BusinessNames.abbreviated(name: "Shop1", ideal_max_length: 4)
+      assert_equal "Shop1", Worldwide::BusinessNames.abbreviated(name: "Shop1", ideal_max_length: 7)
     end
 
     test "Latin name with more than 3 words returns first letter of first and last word when ideal_max_length is not set" do
-      assert_equal "AS", Worldwide::BusinessNames.abbreviate(name: "A Better Looking Shop")
+      assert_equal "AS", Worldwide::BusinessNames.abbreviated(name: "A Better Looking Shop")
     end
 
     test "Latin name with word count up to ideal_max_length returns first letter of each word" do
-      assert_equal "ABLS", Worldwide::BusinessNames.abbreviate(name: "A Better Looking Shop", ideal_max_length: 4)
+      assert_equal "ABLS", Worldwide::BusinessNames.abbreviated(name: "A Better Looking Shop", ideal_max_length: 4)
     end
 
     test "Latin name within the default ideal_max_length word window returns first letter of each word" do
-      assert_equal "ABS", Worldwide::BusinessNames.abbreviate(name: "A Better Shop")
+      assert_equal "ABS", Worldwide::BusinessNames.abbreviated(name: "A Better Shop")
     end
 
     test "Thai name with more than one word returns nil" do
-      assert_nil Worldwide::BusinessNames.abbreviate(name: "ปูนซ ปูนซิ")
+      assert_nil Worldwide::BusinessNames.abbreviated(name: "ปูนซ ปูนซิ")
     end
 
     test "Thai name returns the first grapheme cluster regardless of ideal_max_length" do
-      assert_equal "ปู", Worldwide::BusinessNames.abbreviate(name: "ปูนซิเมนต์ไทย")
-      assert_equal "ปู", Worldwide::BusinessNames.abbreviate(name: "ปูนซิเมนต์ไทย", ideal_max_length: 20)
+      assert_equal "ปู", Worldwide::BusinessNames.abbreviated(name: "ปูนซิเมนต์ไทย")
+      assert_equal "ปู", Worldwide::BusinessNames.abbreviated(name: "ปูนซิเมนต์ไทย", ideal_max_length: 20)
     end
 
     test "single word Chinese name returns the full name" do
-      assert_equal "国家电网", Worldwide::BusinessNames.abbreviate(name: "国家电网")
+      assert_equal "国家电网", Worldwide::BusinessNames.abbreviated(name: "国家电网")
     end
 
     test "multi word Chinese name returns nil" do
-      assert_nil Worldwide::BusinessNames.abbreviate(name: "国家电网 国家电网")
+      assert_nil Worldwide::BusinessNames.abbreviated(name: "国家电网 国家电网")
     end
 
     test "single word Japanese name returns the full name" do
-      assert_equal "任天堂", Worldwide::BusinessNames.abbreviate(name: "任天堂")
+      assert_equal "任天堂", Worldwide::BusinessNames.abbreviated(name: "任天堂")
     end
 
     test "multi word Japanese name returns nil" do
-      assert_nil Worldwide::BusinessNames.abbreviate(name: "任天堂 任天堂")
+      assert_nil Worldwide::BusinessNames.abbreviated(name: "任天堂 任天堂")
     end
 
     test "single word Katakana name returns the full name" do
-      assert_equal "ソニー", Worldwide::BusinessNames.abbreviate(name: "ソニー")
+      assert_equal "ソニー", Worldwide::BusinessNames.abbreviated(name: "ソニー")
     end
 
     test "multi word Katakana name returns nil" do
-      assert_nil Worldwide::BusinessNames.abbreviate(name: "ソニー ソニー")
+      assert_nil Worldwide::BusinessNames.abbreviated(name: "ソニー ソニー")
     end
 
     test "single word Hiragana name returns the full name" do
-      assert_equal "すし", Worldwide::BusinessNames.abbreviate(name: "すし")
+      assert_equal "すし", Worldwide::BusinessNames.abbreviated(name: "すし")
     end
 
     test "multi word Hiragana name returns nil" do
-      assert_nil Worldwide::BusinessNames.abbreviate(name: "すし すし")
+      assert_nil Worldwide::BusinessNames.abbreviated(name: "すし すし")
     end
 
     test "Hangul name returns first letters of first word up to 3 letters regardless of word count when ideal_max_length is not set" do
-      assert_equal "삼성", Worldwide::BusinessNames.abbreviate(name: "삼성 한국어 성삼 한국어")
-      assert_equal "삼성한", Worldwide::BusinessNames.abbreviate(name: "삼성한어 한국어 성삼 한국어")
+      assert_equal "삼성", Worldwide::BusinessNames.abbreviated(name: "삼성 한국어 성삼 한국어")
+      assert_equal "삼성한", Worldwide::BusinessNames.abbreviated(name: "삼성한어 한국어 성삼 한국어")
     end
 
     test "Hangul name returns first letters of first word up to ideal_max_length regardless of word count when ideal_max_length is set" do
-      assert_equal "삼", Worldwide::BusinessNames.abbreviate(name: "삼성 한국어 성삼 한국어", ideal_max_length: 1)
-      assert_equal "삼성", Worldwide::BusinessNames.abbreviate(name: "삼성 한국어 성삼 한국어", ideal_max_length: 2)
+      assert_equal "삼", Worldwide::BusinessNames.abbreviated(name: "삼성 한국어 성삼 한국어", ideal_max_length: 1)
+      assert_equal "삼성", Worldwide::BusinessNames.abbreviated(name: "삼성 한국어 성삼 한국어", ideal_max_length: 2)
     end
   end
 end

--- a/test/worldwide/names_test.rb
+++ b/test/worldwide/names_test.rb
@@ -159,6 +159,12 @@ module Worldwide
       assert_nil Worldwide::Names.abbreviated(given: "アイ", surname: "Garfinkle")
     end
 
+    test ".abbreviated returns nil for a non-positive or non-integer ideal_max_length" do
+      assert_nil Worldwide::Names.abbreviated(given: "Michael", surname: "Garfinkle", ideal_max_length: 0)
+      assert_nil Worldwide::Names.abbreviated(given: "Michael", surname: "Garfinkle", ideal_max_length: -1)
+      assert_nil Worldwide::Names.abbreviated(given: "Michael", surname: "Garfinkle", ideal_max_length: "3")
+    end
+
     test ".abbreviated returns nil when both given and surname are blank" do
       assert_nil Worldwide::Names.abbreviated(given: "", surname: "")
       assert_nil Worldwide::Names.abbreviated(given: nil, surname: nil)


### PR DESCRIPTION
## Summary

Make the two new name abbreviation APIs consistent by renaming `Worldwide::BusinessNames.abbreviate` to `Worldwide::BusinessNames.abbreviated`. This aligns it with `Worldwide::Names.abbreviated` and the existing output oriented methods on `Worldwide::Names`.

## Approach

- Rename the public business name method without retaining an alias because the API was newly introduced
- Align both methods so a nonpositive or noninteger `ideal_max_length` returns `nil`
- Update focused tests and all documentation references
- Demonstrate that the renamed method remains available through `Worldwide.business_names`

## Validation

- `bundle exec ruby -Itest test/worldwide/business_names_test.rb`
- `bundle exec ruby -Itest test/worldwide/names_test.rb`
- `bundle exec rubocop lib/worldwide/business_names.rb lib/worldwide/names.rb test/worldwide/business_names_test.rb test/worldwide/names_test.rb`
- `bundle exec rake`

Co-authored-by: GPT-5.6-sol <noreply@openai.com>
Orchestrated-by: ae <noreply@shopify.com>

<!-- ae-body-hash:5fdce6f122638284795f2d8921661adeae3250b6e4de941bcf2df8f939544c1d -->
