### PR TITLE
Add IE routing key H16 to zips_crossing_provinces (Cavan + Monaghan)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Security in case of vulnerabilities.
 
 ## [Unreleased]
+- Add IE Eircode routing key `H16` (Cootehill) to `zips_crossing_provinces` so it is valid for both Cavan and Monaghan
 
 ---
 

--- a/data/regions/IE.yml
+++ b/data/regions/IE.yml
@@ -622,6 +622,9 @@ zips_crossing_provinces:
   H12:
   - CN
   - LM
+  H16:
+  - CN
+  - MN
   H53:
   - G
   - RN

--- a/test/worldwide/region_validation_test.rb
+++ b/test/worldwide/region_validation_test.rb
@@ -116,6 +116,31 @@ module Worldwide
       end
     end
 
+    test "validity of zips whose prefix crosses a province boundary" do
+      [
+        # 42223 (Fort Campbell) straddles the KY/TN border
+        [:US, [:KY, :TN], "42223"],
+        # Eircode routing key H16 (Cootehill) serves addresses in both Cavan and Monaghan
+        [:IE, [:CN, :MN], "H16 A440"],
+        # Eircode routing key A81 (Carrickmacross) serves addresses in both Monaghan and Cavan
+        [:IE, [:MN, :CN], "A81 AB12"],
+      ].each do |country_code, province_codes, zip|
+        assert_equal(
+          true,
+          Worldwide.region(code: country_code).valid_zip?(zip),
+          "Expected zip #{zip.inspect} to be valid for country #{country_code}",
+        )
+
+        province_codes.each do |province_code|
+          assert_equal(
+            true,
+            Worldwide.region(code: country_code).zone(code: province_code).valid_zip?(zip),
+            "Expected cross-border zip #{zip.inspect} to be valid for province #{country_code}-#{province_code}",
+          )
+        end
+      end
+    end
+
     test "#valid_zip? with valid partial postal codes" do
       [
         [:CA, "T1Y"],


### PR DESCRIPTION
### What are you trying to accomplish?

Irish Eircodes with the `H16` routing key are rejected for addresses in Co. Monaghan.

Eircode routing keys are An Post sortation areas and deliberately **do not** follow county boundaries — Eircode's own documentation states a routing key is not linked to a county and may cross county borders. `H16` (Cootehill) is registered under Co. Cavan in `zip_prefixes`, which is correct for most of the area, but it also serves addresses in Co. Monaghan. Because `H16` was missing from `zips_crossing_provinces`, `valid_zip?("H16 …")` returns `false` for `IE-MN`.

This was reported via a case where a buyer's `H16` Eircode was replaced with an `H18` one (the routing key for Monaghan town) so that it would pass validation — the new code looks plausible but routes to the wrong place.

### What approach did you choose and why?

One data entry, following the pattern established when IE prefixes were added (#440, #454): the county the prefix resolves to (its `zip_prefixes` owner) is listed first, then the other counties it serves.

```yaml
H16:
- CN
- MN
```

Evidence that `H16` crosses into Co. Monaghan:

- Eircode Finder resolves `H16 A440` to a Co. Monaghan address.
- Independently, Cavan and Monaghan ETB publishes "Tanagh Outdoor Education Centre, via Cootehill, Dartrey, **Co. Monaghan** — **H16** HC83".

I also added a regression test for cross-province postal codes. The existing consistency tests only assert the *shape* of `zips_crossing_provinces` (first-listed province, neighbour relationships) — nothing asserted that a crossing prefix actually validates for the secondary province, which is the behaviour that broke here. The new test covers `H16` plus the pre-existing `A81` (IE MN/CN) and `42223` (US KY/TN).

### What should reviewers focus on?

- Ordering: `CN` must stay first, because `H16` lives in Cavan's `zip_prefixes` and `region_data_consistency_test.rb` asserts the first-listed province is the one the prefix resolves to.
- Out of scope: a broader audit of every existing IE `zips_crossing_provinces` entry. That needs a second authoritative data source and shouldn't block this fix.

### The impact of these changes

`H16 …` Eircodes are now valid for both `IE-CN` and `IE-MN`. Nothing becomes invalid — `zips_crossing_provinces` only widens acceptance, and `H16` still resolves to Cavan for province inference. No behaviour change outside IE.

### Testing

- The new test fails without the data change and passes with it: `Expected cross-border zip "H16 A440" to be valid for province IE-MN. Expected: true Actual: false`
- `bin/test`: `1444 tests, 1977379 assertions, 0 failures, 0 errors, 0 skips`
- `bundle exec rubocop`: `107 files inspected, no offenses detected`

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
