### PR TITLE
Prepare patch release 1.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Security in case of vulnerabilities.
 
 ## [Unreleased]
-- Add IE Eircode routing key `H16` (Cootehill) to `zips_crossing_provinces` so it is valid for both Cavan and Monaghan
 
 ---
+
+## [1.26.1] - 2026-07-29
+- Add IE Eircode routing key `H16` (Cootehill) to `zips_crossing_provinces` so it is valid for both Cavan and Monaghan. [#562](https://github.com/Shopify/worldwide/pull/562)
 
 ## [1.26.0] - 2026-07-22
 - Add `Worldwide::BusinessNames.abbreviated` for script-aware abbreviation of a single business name string. [#538](https://github.com/Shopify/worldwide/pull/538) [#553](https://github.com/Shopify/worldwide/pull/553)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (1.26.0)
+    worldwide (1.26.1)
       activesupport (>= 7.0)
       i18n (>= 1.15)
       phonelib (~> 0.8)

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "1.26.0"
+  VERSION = "1.26.1"
 end


### PR DESCRIPTION
Patch release so the IE `zips_crossing_provinces` fix in #562 — the only change since `v1.26.0` — gets published.

- Bump `Worldwide::VERSION` and the lockfile version to 1.26.1
- Move the `[Unreleased]` entry into a dated 1.26.1 section

Publishing and tag creation are left to ShipIt after merge.

### Testing

- `bundle exec rake`: 1444 tests, 0 failures; RuboCop 107 files, 0 offenses
- `bundle exec gem build worldwide.gemspec` → 1.26.1

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
