### PR TITLE
Release NL/BE/DE parsing fix: gem 1.26.2 + npm changeset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Security in case of vulnerabilities.
 
 ## [Unreleased]
-- Fix `address1_regex` for NL/BE/DE so house numbers with uppercase unit letters (`Voltastraat 2 A`), hyphenated ranges (`Philippusweg 3-5`), and NL streets starting with an ordinal (`1e Helmersstraat 5`) split correctly instead of dumping the whole value into `streetName`. [#565](https://github.com/Shopify/worldwide/pull/565)
+
+---
+
+## [1.26.2] - 2026-08-05
+- Fix `address1_regex` for NL/BE/DE so house numbers with uppercase unit letters (`Voltastraat 2 A`), hyphenated ranges (`Philippusweg 3-5`), roman-numeral suffixes (`Kerkstraat 12-II`), and NL streets starting with an ordinal (`1e Helmersstraat 5`) split correctly instead of dumping the whole value into `streetName`. [#565](https://github.com/Shopify/worldwide/pull/565)
 
 ---
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (1.26.1)
+    worldwide (1.26.2)
       activesupport (>= 7.0)
       i18n (>= 1.15)
       phonelib (~> 0.8)

--- a/lang/typescript/.changeset/nl-be-de-house-number-parsing.md
+++ b/lang/typescript/.changeset/nl-be-de-house-number-parsing.md
@@ -1,0 +1,5 @@
+---
+"@shopify/worldwide": patch
+---
+
+Fix `splitAddress1` for NL/BE/DE so house numbers with uppercase unit letters (`Voltastraat 2 A`), hyphenated ranges (`Philippusweg 3-5`), roman-numeral suffixes (`Kerkstraat 12-II`), and NL streets starting with an ordinal (`1e Helmersstraat 5`) split correctly instead of dumping the whole value into `streetName`.

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "1.26.1"
+  VERSION = "1.26.2"
 end


### PR DESCRIPTION
Cuts a release for the NL/BE/DE house-number parsing fix merged in #565, for **both** artifacts the worldwide repo publishes.

## Ruby gem `worldwide` (1.26.1 → 1.26.2)
- `lib/worldwide/version.rb` + `Gemfile.lock`
- `CHANGELOG.md`: `[Unreleased]` → dated `[1.26.2]`
- Consumed by Ruby (atlas). ⚠️ **i18n floor**: worldwide ≥1.25.6 requires `i18n >= 1.15`; the atlas gem bump must move `Gemfile:9` (`i18n ~> 1.14.0`) in the **same commit**.

## npm `@shopify/worldwide` (0.7.7 → 0.7.8)
- Added a **changeset** (`.changeset/nl-be-de-house-number-parsing.md`). On merge, `changesets/action` opens a "Version NPM Package" PR that bumps `package.json` + regenerates the npm CHANGELOG; merging that publishes 0.7.8.
- **This is the artifact that actually fixes the merchant.** The checkout-web bug (`normalizePrefilledAddress1ForConcatenatedMode` → `splitAddress1`) runs on the npm package, which has **no i18n / Ruby coupling**.

## After merge
1. Gem: tag `v1.26.2` + publish → bump in atlas (atomic with i18n)
2. npm: merge the auto-opened Version PR → publishes 0.7.8 → **bump `@shopify/worldwide` in shop/world checkout-web** (this closes the merchant issue, no i18n involved)
