### PR TITLE
Parse Brazilian comma-delimited address complements

### DIFF
--- a/data/regions/BR.yml
+++ b/data/regions/BR.yml
@@ -31,6 +31,7 @@ format_extended:
 address1_regex:
   - "^(?<streetName>.+?),\\s*(?<streetNumber>(?:\\d+[a-zà-öø-ÿ]?|\\d+(?:[-/]\\d+[a-zà-öø-ÿ]?)+|\\d+(?:\\s+\\d+)+|s\\/?n|sem n[úu]mero))$"
   - "^(?<streetName>.+?),\\s*(?<streetNumber>(?:\\d+[a-zà-öø-ÿ]?|\\d+(?:[-/]\\d+[a-zà-öø-ÿ]?)+|\\d+(?:\\s+\\d+)+|s\\/?n|sem n[úu]mero))\\s*,\\s*(?<line2>.+)$"
+  - "^(?<streetName>.+?),\\s*(?<streetNumber>(?:\\d+[a-zà-öø-ÿ]?|\\d+(?:[-/]\\d+[a-zà-öø-ÿ]?)+|\\d+(?:\\s+\\d+)+|s\\/?n|sem n[úu]mero))\\s+(?<line2>condom[ií]nio(?:\\s+.+)?)$"
   - "^(?<streetName>(?:[^\\d,\\s]+\\s)*[^\\d,\\s]+)\\s+(?<streetNumber>\\d+(?: ?[a-z])?)\\s+(?<line2>(?:apt(?:o|\\.)?|apartamento|bloco|casa|sala|fundos|loja)\\b.+)$"
   - "^(?<streetName>(?:[^\\d,\\s]+\\s)*[^\\d,\\s]+)(?:,? ?)(?<streetNumber>\\d+(?: ?[a-z])?)\\s*,\\s*(?<line2>.+)$"
   - "^(?<streetName>(?:[^\\d,\\s]+\\s)*[^\\d,\\s]+)(?:,? ?)(?<streetNumber>\\d+(?: ?[a-z])?)$"

--- a/data/regions/BR.yml
+++ b/data/regions/BR.yml
@@ -31,7 +31,7 @@ format_extended:
 address1_regex:
   - "^(?<streetName>.+?),\\s*(?<streetNumber>(?:\\d+[a-zà-öø-ÿ]?|\\d+(?:[-/]\\d+[a-zà-öø-ÿ]?)+|\\d+(?:\\s+\\d+)+|s\\/?n|sem n[úu]mero))$"
   - "^(?<streetName>.+?),\\s*(?<streetNumber>(?:\\d+[a-zà-öø-ÿ]?|\\d+(?:[-/]\\d+[a-zà-öø-ÿ]?)+|\\d+(?:\\s+\\d+)+|s\\/?n|sem n[úu]mero))\\s*,\\s*(?<line2>.+)$"
-  - "^(?<streetName>.+?),\\s*(?<streetNumber>(?:\\d+[a-zà-öø-ÿ]?|\\d+(?:[-/]\\d+[a-zà-öø-ÿ]?)+|\\d+(?:\\s+\\d+)+|s\\/?n|sem n[úu]mero))\\s+(?<line2>condom[ií]nio(?:\\s+.+)?)$"
+  - "^(?<streetName>.+?),\\s*(?<streetNumber>(?:\\d+[a-zà-öø-ÿ]?|\\d+(?:[-/]\\d+[a-zà-öø-ÿ]?)+|\\d+(?:\\s+\\d+)+|s\\/?n|sem n[úu]mero))\\s+(?<line2>(?:apt(?:o|\\.)?|apartamento|bloco|casa|sala|fundos|loja|condom[ií]nio)\\b.+)$"
   - "^(?<streetName>(?:[^\\d,\\s]+\\s)*[^\\d,\\s]+)\\s+(?<streetNumber>\\d+(?: ?[a-z])?)\\s+(?<line2>(?:apt(?:o|\\.)?|apartamento|bloco|casa|sala|fundos|loja)\\b.+)$"
   - "^(?<streetName>(?:[^\\d,\\s]+\\s)*[^\\d,\\s]+)(?:,? ?)(?<streetNumber>\\d+(?: ?[a-z])?)\\s*,\\s*(?<line2>.+)$"
   - "^(?<streetName>(?:[^\\d,\\s]+\\s)*[^\\d,\\s]+)(?:,? ?)(?<streetNumber>\\d+(?: ?[a-z])?)$"

--- a/lang/typescript/.changeset/parse-brazil-condominium-addresses.md
+++ b/lang/typescript/.changeset/parse-brazil-condominium-addresses.md
@@ -2,4 +2,4 @@
 '@shopify/worldwide': patch
 ---
 
-Parse Brazilian addresses with a comma-delimited building number followed by a condominium name.
+Parse Brazilian addresses with a comma-delimited building number followed by a recognized complement.

--- a/lang/typescript/.changeset/parse-brazil-condominium-addresses.md
+++ b/lang/typescript/.changeset/parse-brazil-condominium-addresses.md
@@ -1,0 +1,5 @@
+---
+'@shopify/worldwide': patch
+---
+
+Parse Brazilian addresses with a comma-delimited building number followed by a condominium name.

--- a/lang/typescript/src/extended-address/splitAddress1.test.ts
+++ b/lang/typescript/src/extended-address/splitAddress1.test.ts
@@ -495,6 +495,22 @@ describe('splitAddress1', () => {
         line2: 'Apto 4 - Bloco B',
       },
     },
+    {
+      address: 'Avenida Felipe Wandscheer, 7335 Condominio Reserva IguaÇu',
+      expected: {
+        streetName: 'Avenida Felipe Wandscheer',
+        streetNumber: '7335',
+        line2: 'Condominio Reserva IguaÇu',
+      },
+    },
+    {
+      address: 'Rua 25 de Março, 100 Condomínio Edifício X',
+      expected: {
+        streetName: 'Rua 25 de Março',
+        streetNumber: '100',
+        line2: 'Condomínio Edifício X',
+      },
+    },
   ])(
     'extracts the optional line2 component from 3-component BR addresses',
     ({address, expected}) => {
@@ -502,7 +518,12 @@ describe('splitAddress1', () => {
     },
   );
 
-  test.each(['Avenida Normando Tedesco, 1400 - Centro', 'Rua 25 de Março 100'])(
+  test.each([
+    'Avenida Normando Tedesco, 1400 - Centro',
+    'Avenida Felipe Wandscheer, 7335 Centro',
+    'Rua 25 de Março 100',
+    'Rua 4 Condominio X',
+  ])(
     'returns address1 as street name when BR address is ambiguous for regex fallback',
     (address) => {
       expect(splitAddress1('BR', address, true)).toEqual({

--- a/lang/typescript/src/extended-address/splitAddress1.test.ts
+++ b/lang/typescript/src/extended-address/splitAddress1.test.ts
@@ -511,6 +511,22 @@ describe('splitAddress1', () => {
         line2: 'Condomínio Edifício X',
       },
     },
+    {
+      address: 'Praça Ramos de Azevedo, 123 Apto 45',
+      expected: {
+        streetName: 'Praça Ramos de Azevedo',
+        streetNumber: '123',
+        line2: 'Apto 45',
+      },
+    },
+    {
+      address: 'Rua Santo Antônio, 722 Casa 2',
+      expected: {
+        streetName: 'Rua Santo Antônio',
+        streetNumber: '722',
+        line2: 'Casa 2',
+      },
+    },
   ])(
     'extracts the optional line2 component from 3-component BR addresses',
     ({address, expected}) => {
@@ -523,6 +539,9 @@ describe('splitAddress1', () => {
     'Avenida Felipe Wandscheer, 7335 Centro',
     'Rua 25 de Março 100',
     'Rua 4 Condominio X',
+    'Rua das Flores, 100 Condominio',
+    'Rua das Flores, 100 Condominios Verdes',
+    'Rua das Flores, 100 Apto',
   ])(
     'returns address1 as street name when BR address is ambiguous for regex fallback',
     (address) => {


### PR DESCRIPTION
### What are you trying to accomplish?

Brazilian raw address lines can place a recognized complement directly after a comma-delimited building number, for example:

- `Avenida Felipe Wandscheer, 7335 Condominio Reserva IguaÇu`
- `Praça Ramos de Azevedo, 123 Apto 45`

The current ordered BR fallback patterns do not recognize this shape, so `splitAddress1` leaves the entire value in `streetName` instead of extracting the building number and complement.

### What approach did you choose and why?

Add one high-confidence BR fallback pattern after the existing comma-delimited patterns. It requires:

- a comma before the building number
- a valid existing BR building-number shape
- one of the complement keywords already trusted by the no-comma fallback, or `Condominio` / `Condomínio`
- content following the complement keyword

This follows the conservative ordered-pattern approach from #520 without treating arbitrary text after a number as `line2`.

### What should reviewers focus on?

The boundary of the trusted complement vocabulary. Inputs such as `Avenida Felipe Wandscheer, 7335 Centro`, bare complement keywords, plural `Condominios`, and comma-less numeric street shapes continue to fall back to the full `streetName`.

### The impact of these changes

`splitAddress1("BR", address, true)` now extracts `streetName`, `streetNumber`, and `line2` from comma-delimited numbers followed by `Apto`, `Apartamento`, `Bloco`, `Casa`, `Sala`, `Fundos`, `Loja`, or `Condominio` / `Condomínio` complements.

A patch changeset is included for the TypeScript package.