### PR TITLE
No longer require building number for Chile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- No longer require building number for Chile [#585](https://github.com/Shopify/worldwide/pull/585)
+
 ---
 
 ## [1.26.2] - 2026-08-05

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (1.26.2)
+    worldwide (1.26.3)
       activesupport (>= 7.0)
       i18n (>= 1.15)
       phonelib (~> 0.8)

--- a/data/regions/CL.yml
+++ b/data/regions/CL.yml
@@ -10,7 +10,6 @@ group: South American Countries
 group_name: South America
 zip_example: '8340457'
 phone_number_prefix: 56
-building_number_required: true
 week_start_day: sunday
 format:
   edit: "{country}_{firstName}{lastName}_{company}_{address1}_{address2}_{zip}{city}_{province}_{phone}"

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "1.26.2"
+  VERSION = "1.26.3"
 end


### PR DESCRIPTION
### What are you trying to accomplish?
Many Chilean addresses lack a house number. The `building_number_required` country config leads to warnings and nudges encouraging users to provide one.

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
