### PR TITLE
Align CLDR storage selection with i18n

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- Select CLDR storage based on i18n's config behavior instead of Ruby's Fiber API.
 - No longer require building number for Chile [#585](https://github.com/Shopify/worldwide/pull/585)
 
 ---

--- a/lib/worldwide/cldr.rb
+++ b/lib/worldwide/cldr.rb
@@ -11,11 +11,7 @@ module Worldwide
       cldr_config.exception_handler = Worldwide::Config.exception_handler
     end
 
-    # i18n 1.15 keeps the active config and fallbacks in Fiber storage on Ruby
-    # 3.2+ and in thread-local storage otherwise. We must write the same slots
-    # i18n reads back, so a Thread.current[:i18n_config] write is not silently
-    # ignored on Ruby 3.2+. These strategies mirror i18n's own storage; the one
-    # matching the runtime is selected once into STORAGE.
+    # Match i18n's config storage behavior, not Ruby's Fiber API.
     module FiberStorage
       class << self
         def config
@@ -57,7 +53,7 @@ module Worldwide
       end
     end
 
-    STORAGE = Fiber.respond_to?(:[]) ? FiberStorage : ThreadStorage
+    STORAGE = I18n::Config.method_defined?(:owned_by?) ? FiberStorage : ThreadStorage
 
     class << self
       def fallbacks

--- a/test/worldwide/cldr_test.rb
+++ b/test/worldwide/cldr_test.rb
@@ -4,6 +4,12 @@ require "test_helper"
 
 module Worldwide
   class CldrTest < ActiveSupport::TestCase
+    test "selects storage based on i18n config behavior" do
+      expected_storage = I18n::Config.method_defined?(:owned_by?) ? Cldr::FiberStorage : Cldr::ThreadStorage
+
+      assert_same expected_storage, Cldr::STORAGE
+    end
+
     test "applies the CLDR config and fallbacks while translating" do
       # Regression guard: on i18n 1.15 the config and fallbacks live in fiber
       # storage, so a Thread.current[:i18n_config] write is silently ignored and


### PR DESCRIPTION
### What are you trying to accomplish?

`Worldwide::Cldr` should select the same config storage that the installed `i18n` version uses. Selecting from Ruby's Fiber API couples two independent behaviors and can drift when either dependency changes.

The equivalent `ShopifyI18n::Cldr` wrapper [recently moved to behavior-based selection](https://github.com/Shopify/shopify-i18n/pull/2302) for the same reason. This change brings Worldwide's duplicated storage handling into alignment with that fix.

### What approach did you choose and why?

Select storage from `I18n::Config#owned_by?`, the capability that identifies i18n's Fiber-aware config implementation. This matches i18n's behavior directly instead of inferring it from Ruby.

### What should reviewers focus on?

Worldwide currently requires `i18n >= 1.15`, so both predicates select the same storage in the supported dependency matrix. This change removes the brittle inference rather than changing current output.

### The impact of these changes

No public API or formatting behavior changes.

### Testing

- `bundle exec ruby -Itest test/worldwide/cldr_test.rb` — 5 tests, 8 assertions
- `bundle exec rake test` — 1,445 tests, 1,977,384 assertions
- `bundle exec rubocop lib/worldwide/cldr.rb test/worldwide/cldr_test.rb` — no offenses

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
