### PR TITLE
Release Worldwide 1.26.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-- Select CLDR storage based on i18n's config behavior instead of Ruby's Fiber API.
-- No longer require building number for Chile [#585](https://github.com/Shopify/worldwide/pull/585)
+---
+
+## [1.26.3] - 2026-09-01
+- Select CLDR storage based on i18n's config behavior instead of Ruby's Fiber API. [#586](https://github.com/Shopify/worldwide/pull/586)
+- No longer require building number for Chile. [#585](https://github.com/Shopify/worldwide/pull/585)
 
 ---
 


### PR DESCRIPTION
### What are you trying to accomplish?

Release Worldwide 1.26.3 with the Chile building-number update from #585 and the CLDR storage alignment from #586.

### What approach did you choose and why?

Move both unreleased entries into a dated 1.26.3 changelog section. #585 already updated `Worldwide::VERSION` and `Gemfile.lock` to 1.26.3, so this PR completes the release preparation without changing them again.

### What should reviewers focus on?

Confirm that the 1.26.3 section contains every Ruby gem change since 1.26.2.

### The impact of these changes

After merge, deploying the RubyGems Shipit stack will publish Worldwide 1.26.3.

### Testing

- `bundle exec rake` — 1,445 tests, 1,977,384 assertions; 107 RuboCop files clean
- `bundle exec gem build worldwide.gemspec --output /tmp/worldwide-1.26.3.gem` — built successfully

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
