### PR TITLE
Add the 81 Türkiye province zones, staged behind ignore_provinces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+- Add the 81 province (il) zones for Türkiye (`TR-01`..`TR-81`), staged behind `ignore_provinces` and `hide_provinces_from_addresses`. Each zone carries its plaka number as a `zip_prefix`, so a province can be inferred from the postal code. Address forms and validation are unchanged until the flags are removed.
+
 ---
 
 ## [1.26.3] - 2026-09-01

--- a/data/regions/TR.yml
+++ b/data/regions/TR.yml
@@ -6,6 +6,8 @@ currency: TRY
 unit_system: metric
 tax_name: KDV
 tax_inclusive: true
+ignore_provinces: true
+hide_provinces_from_addresses: true
 group: European Countries
 group_name: Europe
 zip_example: '01960'
@@ -34,7 +36,497 @@ languages:
 example_address:
   address1: Küçük Ayasofya Mahallesi
   address2: Camii Sokagi No:20 ⁠Küçük Ayasofya
-  city: Fatih/İstanbul
+  city: Fatih
   zip: '34122'
+  province_code: TR-34
   phone: "+90 212 491 16 63"
 timezone: Europe/Istanbul
+zones:
+- name: Adana
+  code: TR-01
+  iso_code: TR-01
+  tax: 0.0
+  zip_prefixes:
+  - '01'
+- name: Adıyaman
+  code: TR-02
+  iso_code: TR-02
+  tax: 0.0
+  zip_prefixes:
+  - '02'
+- name: Afyonkarahisar
+  code: TR-03
+  iso_code: TR-03
+  tax: 0.0
+  zip_prefixes:
+  - '03'
+- name: Ağrı
+  code: TR-04
+  iso_code: TR-04
+  tax: 0.0
+  zip_prefixes:
+  - '04'
+- name: Aksaray
+  code: TR-68
+  iso_code: TR-68
+  tax: 0.0
+  zip_prefixes:
+  - '68'
+- name: Amasya
+  code: TR-05
+  iso_code: TR-05
+  tax: 0.0
+  zip_prefixes:
+  - '05'
+- name: Ankara
+  code: TR-06
+  iso_code: TR-06
+  tax: 0.0
+  zip_prefixes:
+  - '06'
+- name: Antalya
+  code: TR-07
+  iso_code: TR-07
+  tax: 0.0
+  zip_prefixes:
+  - '07'
+- name: Ardahan
+  code: TR-75
+  iso_code: TR-75
+  tax: 0.0
+  zip_prefixes:
+  - '75'
+- name: Artvin
+  code: TR-08
+  iso_code: TR-08
+  tax: 0.0
+  zip_prefixes:
+  - '08'
+- name: Aydın
+  code: TR-09
+  iso_code: TR-09
+  tax: 0.0
+  zip_prefixes:
+  - '09'
+- name: Balıkesir
+  code: TR-10
+  iso_code: TR-10
+  tax: 0.0
+  zip_prefixes:
+  - '10'
+- name: Bartın
+  code: TR-74
+  iso_code: TR-74
+  tax: 0.0
+  zip_prefixes:
+  - '74'
+- name: Batman
+  code: TR-72
+  iso_code: TR-72
+  tax: 0.0
+  zip_prefixes:
+  - '72'
+- name: Bayburt
+  code: TR-69
+  iso_code: TR-69
+  tax: 0.0
+  zip_prefixes:
+  - '69'
+- name: Bilecik
+  code: TR-11
+  iso_code: TR-11
+  tax: 0.0
+  zip_prefixes:
+  - '11'
+- name: Bingöl
+  code: TR-12
+  iso_code: TR-12
+  tax: 0.0
+  zip_prefixes:
+  - '12'
+- name: Bitlis
+  code: TR-13
+  iso_code: TR-13
+  tax: 0.0
+  zip_prefixes:
+  - '13'
+- name: Bolu
+  code: TR-14
+  iso_code: TR-14
+  tax: 0.0
+  zip_prefixes:
+  - '14'
+- name: Burdur
+  code: TR-15
+  iso_code: TR-15
+  tax: 0.0
+  zip_prefixes:
+  - '15'
+- name: Bursa
+  code: TR-16
+  iso_code: TR-16
+  tax: 0.0
+  zip_prefixes:
+  - '16'
+- name: Çanakkale
+  code: TR-17
+  iso_code: TR-17
+  tax: 0.0
+  zip_prefixes:
+  - '17'
+- name: Çankırı
+  code: TR-18
+  iso_code: TR-18
+  tax: 0.0
+  zip_prefixes:
+  - '18'
+- name: Çorum
+  code: TR-19
+  iso_code: TR-19
+  tax: 0.0
+  zip_prefixes:
+  - '19'
+- name: Denizli
+  code: TR-20
+  iso_code: TR-20
+  tax: 0.0
+  zip_prefixes:
+  - '20'
+- name: Diyarbakır
+  code: TR-21
+  iso_code: TR-21
+  tax: 0.0
+  zip_prefixes:
+  - '21'
+- name: Düzce
+  code: TR-81
+  iso_code: TR-81
+  tax: 0.0
+  zip_prefixes:
+  - '81'
+- name: Edirne
+  code: TR-22
+  iso_code: TR-22
+  tax: 0.0
+  zip_prefixes:
+  - '22'
+- name: Elazığ
+  code: TR-23
+  iso_code: TR-23
+  tax: 0.0
+  zip_prefixes:
+  - '23'
+- name: Erzincan
+  code: TR-24
+  iso_code: TR-24
+  tax: 0.0
+  zip_prefixes:
+  - '24'
+- name: Erzurum
+  code: TR-25
+  iso_code: TR-25
+  tax: 0.0
+  zip_prefixes:
+  - '25'
+- name: Eskişehir
+  code: TR-26
+  iso_code: TR-26
+  tax: 0.0
+  zip_prefixes:
+  - '26'
+- name: Gaziantep
+  code: TR-27
+  iso_code: TR-27
+  tax: 0.0
+  zip_prefixes:
+  - '27'
+- name: Giresun
+  code: TR-28
+  iso_code: TR-28
+  tax: 0.0
+  zip_prefixes:
+  - '28'
+- name: Gümüşhane
+  code: TR-29
+  iso_code: TR-29
+  tax: 0.0
+  zip_prefixes:
+  - '29'
+- name: Hakkâri
+  code: TR-30
+  iso_code: TR-30
+  tax: 0.0
+  zip_prefixes:
+  - '30'
+- name: Hatay
+  code: TR-31
+  iso_code: TR-31
+  tax: 0.0
+  zip_prefixes:
+  - '31'
+- name: Iğdır
+  code: TR-76
+  iso_code: TR-76
+  tax: 0.0
+  zip_prefixes:
+  - '76'
+- name: Isparta
+  code: TR-32
+  iso_code: TR-32
+  tax: 0.0
+  zip_prefixes:
+  - '32'
+- name: Istanbul
+  code: TR-34
+  iso_code: TR-34
+  tax: 0.0
+  zip_prefixes:
+  - '34'
+- name: Izmir
+  code: TR-35
+  iso_code: TR-35
+  tax: 0.0
+  zip_prefixes:
+  - '35'
+- name: Kahramanmaraş
+  code: TR-46
+  iso_code: TR-46
+  tax: 0.0
+  zip_prefixes:
+  - '46'
+- name: Karabük
+  code: TR-78
+  iso_code: TR-78
+  tax: 0.0
+  zip_prefixes:
+  - '78'
+- name: Karaman
+  code: TR-70
+  iso_code: TR-70
+  tax: 0.0
+  zip_prefixes:
+  - '70'
+- name: Kars
+  code: TR-36
+  iso_code: TR-36
+  tax: 0.0
+  zip_prefixes:
+  - '36'
+- name: Kastamonu
+  code: TR-37
+  iso_code: TR-37
+  tax: 0.0
+  zip_prefixes:
+  - '37'
+- name: Kayseri
+  code: TR-38
+  iso_code: TR-38
+  tax: 0.0
+  zip_prefixes:
+  - '38'
+- name: Kilis
+  code: TR-79
+  iso_code: TR-79
+  tax: 0.0
+  zip_prefixes:
+  - '79'
+- name: Kırıkkale
+  code: TR-71
+  iso_code: TR-71
+  tax: 0.0
+  zip_prefixes:
+  - '71'
+- name: Kırklareli
+  code: TR-39
+  iso_code: TR-39
+  tax: 0.0
+  zip_prefixes:
+  - '39'
+- name: Kırşehir
+  code: TR-40
+  iso_code: TR-40
+  tax: 0.0
+  zip_prefixes:
+  - '40'
+- name: Kocaeli
+  code: TR-41
+  iso_code: TR-41
+  tax: 0.0
+  zip_prefixes:
+  - '41'
+- name: Konya
+  code: TR-42
+  iso_code: TR-42
+  tax: 0.0
+  zip_prefixes:
+  - '42'
+- name: Kütahya
+  code: TR-43
+  iso_code: TR-43
+  tax: 0.0
+  zip_prefixes:
+  - '43'
+- name: Malatya
+  code: TR-44
+  iso_code: TR-44
+  tax: 0.0
+  zip_prefixes:
+  - '44'
+- name: Manisa
+  code: TR-45
+  iso_code: TR-45
+  tax: 0.0
+  zip_prefixes:
+  - '45'
+- name: Mardin
+  code: TR-47
+  iso_code: TR-47
+  tax: 0.0
+  zip_prefixes:
+  - '47'
+- name: Mersin
+  code: TR-33
+  iso_code: TR-33
+  tax: 0.0
+  zip_prefixes:
+  - '33'
+  # Northern Cyprus is addressed via Türkiye as "Mersin 10" and uses the 99xxx postal code range
+  - '99'
+- name: Muğla
+  code: TR-48
+  iso_code: TR-48
+  tax: 0.0
+  zip_prefixes:
+  - '48'
+- name: Muş
+  code: TR-49
+  iso_code: TR-49
+  tax: 0.0
+  zip_prefixes:
+  - '49'
+- name: Nevşehir
+  code: TR-50
+  iso_code: TR-50
+  tax: 0.0
+  zip_prefixes:
+  - '50'
+- name: Niğde
+  code: TR-51
+  iso_code: TR-51
+  tax: 0.0
+  zip_prefixes:
+  - '51'
+- name: Ordu
+  code: TR-52
+  iso_code: TR-52
+  tax: 0.0
+  zip_prefixes:
+  - '52'
+- name: Osmaniye
+  code: TR-80
+  iso_code: TR-80
+  tax: 0.0
+  zip_prefixes:
+  - '80'
+- name: Rize
+  code: TR-53
+  iso_code: TR-53
+  tax: 0.0
+  zip_prefixes:
+  - '53'
+- name: Sakarya
+  code: TR-54
+  iso_code: TR-54
+  tax: 0.0
+  zip_prefixes:
+  - '54'
+- name: Samsun
+  code: TR-55
+  iso_code: TR-55
+  tax: 0.0
+  zip_prefixes:
+  - '55'
+- name: Şanlıurfa
+  code: TR-63
+  iso_code: TR-63
+  tax: 0.0
+  zip_prefixes:
+  - '63'
+- name: Siirt
+  code: TR-56
+  iso_code: TR-56
+  tax: 0.0
+  zip_prefixes:
+  - '56'
+- name: Sinop
+  code: TR-57
+  iso_code: TR-57
+  tax: 0.0
+  zip_prefixes:
+  - '57'
+- name: Şırnak
+  code: TR-73
+  iso_code: TR-73
+  tax: 0.0
+  zip_prefixes:
+  - '73'
+- name: Sivas
+  code: TR-58
+  iso_code: TR-58
+  tax: 0.0
+  zip_prefixes:
+  - '58'
+- name: Tekirdağ
+  code: TR-59
+  iso_code: TR-59
+  tax: 0.0
+  zip_prefixes:
+  - '59'
+- name: Tokat
+  code: TR-60
+  iso_code: TR-60
+  tax: 0.0
+  zip_prefixes:
+  - '60'
+- name: Trabzon
+  code: TR-61
+  iso_code: TR-61
+  tax: 0.0
+  zip_prefixes:
+  - '61'
+- name: Tunceli
+  code: TR-62
+  iso_code: TR-62
+  tax: 0.0
+  zip_prefixes:
+  - '62'
+- name: Uşak
+  code: TR-64
+  iso_code: TR-64
+  tax: 0.0
+  zip_prefixes:
+  - '64'
+- name: Van
+  code: TR-65
+  iso_code: TR-65
+  tax: 0.0
+  zip_prefixes:
+  - '65'
+- name: Yalova
+  code: TR-77
+  iso_code: TR-77
+  tax: 0.0
+  zip_prefixes:
+  - '77'
+- name: Yozgat
+  code: TR-66
+  iso_code: TR-66
+  tax: 0.0
+  zip_prefixes:
+  - '66'
+- name: Zonguldak
+  code: TR-67
+  iso_code: TR-67
+  tax: 0.0
+  zip_prefixes:
+  - '67'


### PR DESCRIPTION
## What

81 province (il) zones for Türkiye in `data/regions/TR.yml`, staged: `ignore_provinces: true`, `hide_provinces_from_addresses: true`, no `{province}` in the formats. Step 1 of shop/issues-addresses#1131.

## Data decisions, each from precedent

- **Codes**: `code` = `iso_code` = `TR-01`..`TR-81`, the ISO 3166-2:TR subdivision codes (plaka numbers). Validate against the official list: https://www.iso.org/obp/ui/#iso:code:3166:TR. Every zone set added since 2020 uses prefixed ISO codes (PH-ABR, KW-AH, CR-A, SV-AH, UY-AR, VE-Z); JP-01 is the numeric precedent. Bare codes (CA, US, GB) are all legacy.
- **Names**: CLDR English subdivision names (`tr01`..`tr81`), the KW convention. Translations already ship in `data/cldr/locales/*/subdivisions.yml`, no translation work.
- **Order**: alphabetical by `ActiveSupport::Inflector.transliterate(name.downcase)`, per the consistency test. Not plaka order: Aksaray (68) sorts after Ağrı (04).
- **zip_prefixes**: each zone's plaka number. The first two digits of a Turkish postal code are the province number, so provinces are inferable from postal codes (55.2% of stored TR addresses, measured on the issue). Prefix `99` belongs to Mersin (TR-33): Northern Cyprus is addressed via Türkiye as "Mersin 10" with the 99xxx range, and `Zip.find_country(country_code: :CY, zip: "99628")` must keep returning TR.
- **example_address**: gains `province_code: TR-34` (zip 34122 is İstanbul), required by the consistency tests once zones exist. The city drops the province suffix (`Fatih/İstanbul` → `Fatih`): with zones defined, the il belongs in the province field, not the city.

## Tax: `tax: 0.0` per zone, no `tax_name`

The `tax:` key is mandatory: `region_yml_consistency_test.rb` ("all countries and provinces have tax information") asserts every province's `tax_rate` is a Float in 0..1, and the loader passes the YAML value through with no zone-level default (`regions_loader.rb`, `tax_rate: zone["tax"]`), so omitting the key fails the suite.

The value 0.0 is verified: KDV is levied nationally under Law 3065, with rates (20%/10%/1%) set by national legislation and Presidential decision. No province-level VAT or regional surtax exists across the 81 il ([Grant Thornton indirect tax guide, Türkiye](https://www.grantthornton.global/en/insights/indirect-tax-guide/indirect-tax---turkey/), [Kreston VAT guide, Türkiye](https://www.kreston.com/vat-guide/turkey/)). The national rate stays at the country level (`tax: 0.18` in this file); zones contribute nothing on top, the same shape as PH, KW, CR, SV, UY, VE.

`tax_name` is omitted: the consistency test only requires a tax name when the zone rate is non-zero.

## What does not change

The staged flag pair plus no `{province}` in the formats is a legal state for `region_data_consistency_test`. `has_provinces?` stays false, address forms and `AddressValidator` behavior are untouched until go-live removes the flags.

## Verification

- Full suite: 1445 tests, 0 failures.
- `region(code: "TR").zone(zip: "34122")` → TR-34, `zone(zip: "01960")` → TR-01, `zone(zip: "99628")` → TR-33.
- `zone(code: "TR-04")` and `zone(code: "04")` both resolve (lookup registers both forms).

## Sequencing

After this releases: country_db zone stubs (with Shopify/country_db#2061 already merged there), then core → pay → billing → Atlas last, so the shipping picker cannot show regions the backend rejects.

