### PR TITLE
Prepare release 1.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-### Added
+---
+
+## [1.27.0] - 2026-09-11
 - Add the 81 province (il) zones for Türkiye (`TR-01`..`TR-81`), staged behind `ignore_provinces` and `hide_provinces_from_addresses`. Each zone carries its plaka number as a `zip_prefix`, so a province can be inferred from the postal code. Address forms and validation are unchanged until the flags are removed.
 
 ---

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    worldwide (1.26.3)
+    worldwide (1.27.0)
       activesupport (>= 7.0)
       i18n (>= 1.15)
       phonelib (~> 0.8)
@@ -137,6 +137,7 @@ PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
   arm64-darwin-24
+  arm64-darwin-25
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/worldwide/version.rb
+++ b/lib/worldwide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Worldwide
-  VERSION = "1.26.3"
+  VERSION = "1.27.0"
 end


### PR DESCRIPTION
Bumps version to 1.27.0 (minor bump for the addition of 81 Türkiye province zones).

- Updates `lib/worldwide/version.rb`
- Formats `CHANGELOG.md` for the new version
- Regenerates `Gemfile.lock`

Part of https://github.com/shop/issues-addresses/issues/1131